### PR TITLE
add function to collapse matrices; matrix values into details data frame

### DIFF
--- a/rdev/R/matlist.R
+++ b/rdev/R/matlist.R
@@ -324,3 +324,25 @@ setMethod("c", "matlist", function(x,...,recursive=FALSE) {
 })
 
 
+collapse_matrix <- function(x,class) {
+  l <- list(unlist(labels(x)))
+  m <- list(as.matrix(x))
+  create_matlist(m,l,class=class)
+}
+
+collapse_sigma <- function(x) {
+  x@sigma <- collapse_matrix(smat(x),class="sigmalist")
+  x
+}
+collapse_omega <- function(x) {
+  x@omega <- collapse_matrix(omat(x),class="omegalist")
+  x
+}
+
+
+
+
+
+
+
+

--- a/rdev/R/mread.R
+++ b/rdev/R/mread.R
@@ -174,7 +174,7 @@ mread <- function(model=character(0),project=getwd(),code=NULL,udll=TRUE,
   annot <- dplyr::bind_rows(nonull.list(mread.env$annot))
   omega <- omat(do.call("c", nonull.list(mread.env$omega)))
   sigma <- smat(do.call("c", nonull.list(mread.env$sigma)))
-  
+
   
   ## Collect potential multiples
   subr  <- collect_subr(spec)

--- a/rdev/inst/Rmd/mrgsolve_render_template.Rmd
+++ b/rdev/inst/Rmd/mrgsolve_render_template.Rmd
@@ -48,7 +48,7 @@ if(nrow(d) > 0) {
                      value=diag(as.matrix(sg)))
   
   dfp <- 
-    as.data.frame(t(as.data.frame(param(mod)))) %>% 
+    as.data.frame(t(as.data.frame(allparam(mod)))) %>% 
     setNames(.,"value") %>%
     mutate(name=rownames(.))
   

--- a/rdev/inst/Rmd/mrgsolve_render_template.Rmd
+++ b/rdev/inst/Rmd/mrgsolve_render_template.Rmd
@@ -37,17 +37,26 @@ rmbl <- function(x) x[x!=""]
 # Details
 ```{r}
 d <- mrgsolve:::details(mod)
-  if(nrow(d) > 0) {
+if(nrow(d) > 0) {
+  
+  om <- omat(mod)
+  dfom <- data.frame(name=unlist(labels(om)),
+                     value=diag(as.matrix(om)))
+
+  sg <- smat(mod)
+  dfsg <- data.frame(name=unlist(labels(sg)),
+                     value=diag(as.matrix(sg)))
+  
   dfp <- 
     as.data.frame(t(as.data.frame(param(mod)))) %>% 
     setNames(.,"value") %>%
     mutate(name=rownames(.))
-
+  
   dfi <- as.data.frame(t(as.data.frame(init(mod)))) %>%
     setNames(.,"value") %>%
     mutate(name=rownames(.))
   
-  dfj <- bind_rows(dfp,dfi)
+  dfj <- bind_rows(dfp,dfi,dfom,dfsg)
   
   d <- left_join(d,dfj,by="name")
   
@@ -59,14 +68,14 @@ d <- mrgsolve:::details(mod)
 
 ```
 
-## Parameter values
+## Parameter and fixed values
 ```{r}
-(param(mod))
+allparam(mod)
 ```
 
 ## Compartments and initial values
 ```{r}
-(init(mod))
+init(mod)
 ```
 
 # Model code


### PR DESCRIPTION
- `collapse_matrix` takes a `matlist` object and collapses it down to another `matlist` object but with only one position; this can make updates later on easier depending on where new matrices are coming from; so a list of `2x2` and `3x3` gets turned into a single `5x5` matrix list.

- Updated the render `.Rmd` template to show `$OMEGA` and `$SIGMA` values in the details data frame; also, showing both parameters and fixed values