### PR TITLE
Adding ss=2 functionality

### DIFF
--- a/R/chain.R
+++ b/R/chain.R
@@ -223,10 +223,13 @@ obsaug <- function(x,value=TRUE,...) {
 ##'   data_set(data) %>%
 ##'   mrgsim %>% 
 ##'   plot(RESP~time|GRP)
-design <- function(x, deslist=list(), descol = attr(deslist,"descol"), ...) {
+design <- function(x, deslist=list(), descol = character(0), ...) {
   
-  if(is.null(descol)) {
-    stop("please provide a value for descol",call.=FALSE)
+  if(missing(descol)) {
+    descol <- attr(deslist,"descol") 
+    if(is.null(descol)) {
+      stop("please provide a value for descol",call.=FALSE)
+    }
   }
   
   descol <- as.character(substitute(descol))

--- a/man/design.Rd
+++ b/man/design.Rd
@@ -4,7 +4,7 @@
 \alias{design}
 \title{Set observation designs for the simulation.}
 \usage{
-design(x, deslist = list(), descol = attr(deslist, "descol"), ...)
+design(x, deslist = list(), descol = character(0), ...)
 }
 \arguments{
 \item{x}{model object}

--- a/src/dataobject.cpp
+++ b/src/dataobject.cpp
@@ -228,7 +228,7 @@ void dataobject::get_records(recstack& a, int NID, int neq,
     for(j = this->start(h); j <= this->end(h); ++j) {
       
       if(Data(j,col[_COL_time_]) < lastime) {
-        Rcpp::stop("Problem with time: data set is not sorted by time or time is negative.");
+        Rcpp::stop("data set is not sorted by time or time is negative.");
       }
       
       lastime = Data(j,col[_COL_time_]);

--- a/src/datarecord.cpp
+++ b/src/datarecord.cpp
@@ -148,7 +148,7 @@ void datarecord::implement(odeproblem *prob) {
   int eq_n = std::abs(Cmt)-1;
   
   // Check for steady state records:
-  if(Ss==1) {
+  if(Ss > 0) {
     if(Fn==0) Rcpp::stop("Cannot use ss flag when F(n) is zero.");
     if(Rate == 0) this->steady_bolus(prob);
     if(Rate >  0) this->steady_infusion(prob);
@@ -218,6 +218,15 @@ void datarecord::implement(odeproblem *prob) {
 
 void datarecord::steady_bolus(odeproblem *prob) {
   
+  dvec state_incoming;
+  
+  if(Ss == 2) {
+    state_incoming.resize(prob->neq());
+    for(int i = 0; i < state_incoming.size(); i++) {
+       state_incoming[i] = prob->y(i);
+    }
+  }
+  
   prob->rate_reset();
   
   double tfrom = 0.0;
@@ -253,7 +262,7 @@ void datarecord::steady_bolus(odeproblem *prob) {
     
     this_sum = std::accumulate(res.begin(), res.end(), 0.0);
     
-    if(i>10) {
+    if(i > 10) {
       diff = std::abs(this_sum - last_sum);
       if((diff < CRIT_DIFF_SS)){
         break;
@@ -263,7 +272,15 @@ void datarecord::steady_bolus(odeproblem *prob) {
     tfrom = tto;
     last_sum = this_sum;
   }
+  
+  if(Ss == 2) {
+    for(int i=0; i < state_incoming.size(); i++) {
+      prob->y(i,prob->y(i) + state_incoming[i]); 
+    }
+  }
+  
   prob->itask(1);
+
 }
 
 
@@ -368,7 +385,7 @@ void datarecord::schedule(std::vector<rec_ptr>& thisi, double maxtime,
                                                    Rate,-300, Id);
     thisi.push_back(evoff);
     
-    if(Ss) {
+    if(Ss > 0) {
       
       double duration = this->dur(Fn);
       


### PR DESCRIPTION
Addresses #221 started by @mhismail.

I'm going to let this sit for a while until we get some comment or correction for what I did.

Test case: 10 mg po QAM, 20 mg po QPM 

Basically:
1. The dose record at time 0 just advances to 10 mg Q24h steady state
1. Then the system advances to 12 hour dose record with `ss=2`
1. The compartment amounts are cached, the system advances to 20 mg Q24h steady state, and the cached compartment amounts are added to that new steady state value prior to continuing
1. After that ... continue

I was originally wondering if there were some conditions to enforce for this but now it seems no.  Waiting for some comment on that issue as well.

