### PR TITLE
Inventory refactor and testing

### DIFF
--- a/R/inven.R
+++ b/R/inven.R
@@ -45,9 +45,9 @@ inventory <- function(x,obj,...) {
   dots <- lazyeval::lazy_dots(...)
   need <- select_vars_(names(param(x)),dots)
   if(length(need)==0) need <- names(param(x))
-  ans <- inven(x,obj,need,crump=FALSE) 
-  if(ans) message("Found all required parameters.")
-  return(invisible(ans))
+  inven(x,obj,need,crump=FALSE) 
+  message("Found all required parameters.")
+  return(x)
 }
 
 inven_stop <- function(x,obj,need) {

--- a/R/inven.R
+++ b/R/inven.R
@@ -60,6 +60,6 @@ inven_report <- function(obj,need) {
   miss <- setdiff(need,names(obj))
   warning("The object is missing these parameters:\n", 
        paste(paste0(" - ",miss,collapse="\n")))
-  return(invisible(FALSE))
+  return(miss)
 }
 

--- a/R/inven.R
+++ b/R/inven.R
@@ -5,13 +5,12 @@
 ##' @param need required parameters
 ##' @param crump logical; if \code{TRUE} an error is generated when any parameter
 ##' in \code{need} is not found in the object
-##' @param ... passed along
 ##' 
 ##' @export
 ##' 
 ##' 
 ##' 
-inven <- function(x,obj,need=NULL,crump=TRUE,...) {
+inven <- function(x,obj,need=NULL,crump=TRUE) {
   # if(substr(need,1,1)=="@") {
   #   if(need=="@all") {
   #     need <- names(param(x))

--- a/R/inven.R
+++ b/R/inven.R
@@ -44,7 +44,9 @@ inven <- function(x,obj,need="@all",crump=TRUE,...) {
 inventory <- function(x,obj,...) {
   dots <- lazyeval::lazy_dots(...)
   need <- select_vars_(names(param(x)),dots)
-  if(length(need)==0) need <- names(param(x))
+  if(!length(need)) {
+    return(x)
+  }
   inven(x,obj,need,crump=FALSE) 
   message("Found all required parameters.")
   return(x)

--- a/R/inven.R
+++ b/R/inven.R
@@ -7,9 +7,6 @@
 ##' in \code{need} is not found in the object
 ##' 
 ##' @export
-##' 
-##' 
-##' 
 inven <- function(x,obj,need=NULL,crump=TRUE) {
   # if(substr(need,1,1)=="@") {
   #   if(need=="@all") {

--- a/R/inven.R
+++ b/R/inven.R
@@ -11,7 +11,7 @@
 ##' 
 ##' 
 ##' 
-inven <- function(x,obj,need="@all",crump=TRUE,...) {
+inven <- function(x,obj,need=NULL,crump=TRUE,...) {
   # if(substr(need,1,1)=="@") {
   #   if(need=="@all") {
   #     need <- names(param(x))

--- a/R/inven.R
+++ b/R/inven.R
@@ -20,7 +20,7 @@ inven <- function(x,obj,need=NULL,crump=TRUE) {
   # }
 
   if(is.null(need)) {
-    return(inven_report(x,obj,names(param(x))))
+    return(inven_report(obj,names(param(x))))
   }
   
   need <- cvec_cs(need)
@@ -30,8 +30,8 @@ inven <- function(x,obj,need=NULL,crump=TRUE) {
   }
   
   if(!all(need %in% names(obj))) {
-    if(crump) inven_stop(x,obj,need)
-    return(inven_report(x,obj,need))
+    if(crump) inven_stop(obj,need)
+    return(inven_report(obj,need))
   }
   
   return(invisible(TRUE))
@@ -50,13 +50,13 @@ inventory <- function(x,obj,...) {
   return(x)
 }
 
-inven_stop <- function(x,obj,need) {
+inven_stop <- function(obj,need) {
   miss <- setdiff(need,names(obj))
   stop("The object is missing required parameters:\n", 
        paste(paste0("- ",miss,collapse="\n")),call.=FALSE)
 }
 
-inven_report <- function(x,obj,need) {
+inven_report <- function(obj,need) {
   miss <- setdiff(need,names(obj))
   warning("The object is missing these parameters:\n", 
        paste(paste0(" - ",miss,collapse="\n")))

--- a/R/inven.R
+++ b/R/inven.R
@@ -49,8 +49,8 @@ inven <- function(x,obj,need=NULL,crump=TRUE) {
 #' @return original mrgmod
 #' @export
 inventory <- function(x,obj,..., .strict = TRUE) {
-  dots <- lazyeval::lazy_dots(...)
-  need <- select_vars_(names(param(x)),dots)
+  
+  need <- select_vars(names(param(x)), ...)
   
   if(!length(need)) {
     return(x)

--- a/R/inven.R
+++ b/R/inven.R
@@ -58,8 +58,10 @@ inven_stop <- function(obj,need) {
 
 inven_report <- function(obj,need) {
   miss <- setdiff(need,names(obj))
-  warning("The object is missing these parameters:\n", 
+  if (length(miss)) {
+    warning("The object is missing these parameters:\n", 
        paste(paste0(" - ",miss,collapse="\n")))
+  }
   return(miss)
 }
 

--- a/R/inven.R
+++ b/R/inven.R
@@ -58,7 +58,7 @@ inven_stop <- function(x,obj,need) {
 
 inven_report <- function(x,obj,need) {
   miss <- setdiff(need,names(obj))
-  message("The object is missing these parameters:\n", 
+  warning("The object is missing these parameters:\n", 
        paste(paste0(" - ",miss,collapse="\n")))
   return(invisible(FALSE))
 }

--- a/R/inven.R
+++ b/R/inven.R
@@ -21,7 +21,6 @@ inven <- function(x,obj,need=NULL,crump=TRUE,...) {
   # }
 
   if(is.null(need)) {
-    if(crump) inven_stop(x,obj,names(param(x)))
     return(inven_report(x,obj,names(param(x))))
   }
   

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -17,6 +17,7 @@
 
 Sys.setenv("R_TESTS" = "")
 library(testthat)
+library(magrittr)
 library(mrgsolve)
 
 test_check("mrgsolve", reporter="summary")

--- a/tests/testthat/test-inventory.R
+++ b/tests/testthat/test-inventory.R
@@ -1,0 +1,8 @@
+context("inventory")
+
+test_that("inven_report displays warns and missing items", {
+  obj <- data.frame(KA = 1, CL = 1, V = 1, OCC = 1, F = 1)
+  expect_equal(inven_report(obj, c("KA", "CL")), vector(mode = "character"))
+  expect_equal(inven_report(obj, c("KA", "OCC2")), c("OCC2"))
+  expect_warning(inven_report(obj, c("KA", "OCC2")), "The object is missing these parameters:\\n - OCC2")
+})

--- a/tests/testthat/test-inventory.R
+++ b/tests/testthat/test-inventory.R
@@ -2,7 +2,50 @@ context("inventory")
 
 test_that("inven_report displays warns and missing items", {
   obj <- data.frame(KA = 1, CL = 1, V = 1, OCC = 1, F = 1)
+  inven_report <- mrgsolve:::inven_report
   expect_equal(inven_report(obj, c("KA", "CL")), vector(mode = "character"))
   expect_equal(inven_report(obj, c("KA", "OCC2")), c("OCC2"))
   expect_warning(inven_report(obj, c("KA", "OCC2")), "The object is missing these parameters:\\n - OCC2")
+})
+
+mod <- mcode("test", "$PARAM KA = 1, CL = 1, V = 1, OCC1 = 1, OCC2 = 1, F = 1")
+all_obj <- data.frame(KA = 1, CL = 1, V = 1, OCC1 = 1, OCC2 = 1, F = 1)
+missing_obj <- data.frame(KA = 1, CL = 1, V = 1, OCC1 = 1, F = 1)
+  
+test_that("inventory works", {
+  # no requirements gives back model 
+  expect_s4_class(inventory(mod, all_obj), "mrgmod")
+ 
+  # everything says it found all and returns original model 
+  expect_message(inventory(mod, all_obj, dplyr::everything()), "Found all required parameters")
+  expect_s4_class(inventory(mod, all_obj, dplyr::everything()), "mrgmod")
+  
+})
+
+test_that("inventory errors when missing required params", {
+  expect_error(inventory(mod, missing_obj, dplyr::everything()), 
+               "The object is missing required parameters:\\n- OCC2")
+  expect_error(inventory(mod, missing_obj, contains("OCC")), 
+               "The object is missing required parameters:\\n- OCC2")
+  expect_error(inventory(mod, missing_obj, V:F), 
+               "The object is missing required parameters:\\n- OCC2")
+  expect_error(inventory(mod, missing_obj, OCC2), 
+               "The object is missing required parameters:\\n- OCC2")
+})
+
+test_that("inventory warns when missing required params but not checking strictly", {
+  expect_warning(inventory(mod, missing_obj, 
+                            dplyr::everything(), 
+                            .strict = FALSE), 
+                 "The object is missing these parameters:\\n - OCC2")
+  expect_s4_class(inventory(mod, missing_obj, 
+                            dplyr::everything(), 
+                            .strict = FALSE), "mrgmod")
+  expect_warning(inventory(mod, missing_obj, 
+                            OCC2, 
+                            .strict = FALSE), 
+                 "The object is missing these parameters:\\n - OCC2")
+  expect_s4_class(inventory(mod, missing_obj, 
+                            OCC2, 
+                            .strict = FALSE), "mrgmod")
 })


### PR DESCRIPTION
Hi Kyle,

I've dug through the inventory implementation and refactored a number of things to make it a bit more extensible and simplify the logic.

First, I refactored inven to be more consistent in what it returns, namely either it stops (when crumping) or it returns a vector of names for what is missing. This way, it can also be used to do things like tune other defaults or do other programmatic introspection downstream, rather than just giving a T/F plus a human consumable message. This also involved refactoring the underlying inven_report

Second, I refactored inventory to expose crump, however called it `.strict`. This is required by name, and gives the option for people to control the degree that they'd like to have the inventory warn them.

Third, I am returning the original model now, given inventory passes. This will allow inventory to be used in pipelines

```r
mod %>% 
    inventory(idata, everything()) %>% 
    idata_set(idata) %>% 
    mrgsim()
```

Finally, I added a number of tests. It is by no mean comprehensive at this point, but it gives some assurances that the various selection criteria are working as expected.  

I think there still needs to be a vignette/blog post expanding on this, but that may or may not need to be in scope for this PR.