### PR TITLE
Fix for parsing error in nmxml.R

### DIFF
--- a/R/nmxml.R
+++ b/R/nmxml.R
@@ -78,9 +78,11 @@ nmxml <- function(run=numeric(0), project=character(0),
   }
   
   tree <- xml2::as_list(xml2::read_xml(target))
-  tree <- ifelse(is.null(tree[["output"]]),
-                 tree$nonmem$problem$estimation,
-                 tree$output$nonmem$problem$estimation)
+  if(is.null(tree[["output"]])){
+    tree <- tree$nonmem$problem$estimation
+  } else {
+    tree <- tree$output$nonmem$problem$estimation
+  }
   
   th <- list()
   om <- matrix(0,0,0)

--- a/R/nmxml.R
+++ b/R/nmxml.R
@@ -78,7 +78,9 @@ nmxml <- function(run=numeric(0), project=character(0),
   }
   
   tree <- xml2::as_list(xml2::read_xml(target))
-  tree <- tree$output$nonmem$problem$estimation
+  tree <- ifelse(is.null(tree[["output"]]),
+                 tree$nonmem$problem$estimation,
+                 tree$output$nonmem$problem$estimation)
   
   th <- list()
   om <- matrix(0,0,0)


### PR DESCRIPTION
Reviewing the source of the nmxml error, found that the tree structure was different than expected. Added an if/else statement to account for this variable structure (i.e. "output" element omitted from tree list, but all remaining elements present). Unsure why the structure was different, so this workaround may need to be implemented in a more general fashion in the future to account for additional variability.