### PR TITLE
Fix/tad evid4

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,9 @@
 
 - Remove `qsim` and all associated functions
 - Export new function / workflow as `qsim` as a simpler, quicker simulation
-routine #490
+  routine #490
+- tad calculation (when called through `mrgsim()` and variants) recognizes
+  evid 4 in addition to evid 1 #502
 
 # mrgsolve 0.9.2
 - Fix bug where system advanced to next time after advancing to steady state

--- a/src/devtran.cpp
+++ b/src/devtran.cpp
@@ -184,7 +184,7 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
     tofd.reserve(a.size());
     for(recstack::const_iterator it = a.begin(); it !=a.end(); ++it) {
       for(reclist::const_iterator itt = it->begin(); itt != it->end(); ++itt) {
-        if((*itt)->evid()==1) {
+        if(((*itt)->evid()==1) || ((*itt)->evid()==4)) {
           tofd.push_back((*itt)->time());
           break;
         }
@@ -542,7 +542,7 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
         }
         
         if(tad) {
-          if((this_rec->evid()==1)) {
+          if((this_rec->evid()==1) || (this_rec->evid()==4)) {
             if(this_rec->armed()) {
               told = tto - prob->alag(this_cmtn);  
             }

--- a/tests/testthat/test-tad.R
+++ b/tests/testthat/test-tad.R
@@ -48,3 +48,11 @@ test_that("tad", {
   expect_equal(out$tad,c(-3,-2,-1,0,1,2,0,1,2,0,1,2))
 })
 
+test_that("tad recognizes evid 1 and 4", {
+  d1 <- ev(amt = 100, time = 12, evid = 4, addl=2, ii = 4)
+  d2 <- ev(amt = 100, time = 12, addl = 2, ii = 4)
+  out1 <- mrgsim(mod,d1,tad=TRUE)
+  out2 <- mrgsim(mod,d2,tad=TRUE)
+  expect_identical(out1,out2)
+})
+

--- a/tests/testthat/test-tad.R
+++ b/tests/testthat/test-tad.R
@@ -48,7 +48,7 @@ test_that("tad", {
   expect_equal(out$tad,c(-3,-2,-1,0,1,2,0,1,2,0,1,2))
 })
 
-test_that("tad recognizes evid 1 and 4", {
+test_that("tad recognizes evid 1 and 4 issue-502", {
   d1 <- ev(amt = 100, time = 12, evid = 4, addl=2, ii = 4)
   d2 <- ev(amt = 100, time = 12, addl = 2, ii = 4)
   out1 <- mrgsim(mod,d1,tad=TRUE)


### PR DESCRIPTION
- Look for both evid 1 and 4 when looking for first dose
- Reset time of dose when evid is 1 or 4
- Add test to make sure tad is calculated the same with evid 1 or 4