### PR TITLE
Fix printing of long model filenames

### DIFF
--- a/R/print.R
+++ b/R/print.R
@@ -117,7 +117,7 @@ print.mrgmod <- function(x,verbose=FALSE,...) {
   
   src <- paste0("source: ", basename(cfile(x)))
   nsrc <- nchar(src)
-  nside <- (52-nsrc)/2 - 2
+  nside <- max((52-nsrc)/2 - 2, 0)
   side <- paste0(rep("-", nside),collapse="")
 
   header <- paste0("\n\n",side, "  ", src, "  ", side, "\n\n")


### PR DESCRIPTION
I feel like I need to maintain my reputation for "why would anyone do something like that".

I created a long filename for my model, and that caused an issue with printing.

Steps to reproduce:
* Create a model named something very long (I used "why_would_anyone_make_a_filename_this_long.Rmd")
    * That wasn't the real filename ;)
* Compile it `model <- mread(model="why_would_anyone_make_a_filename_this_long.Rmd")`
* Try to print it: `model`
* Get an error: `Error in rep("-", nside) : invalid 'times' argument`