### PR TITLE
check input names for mutually exclusive pairs #513

### DIFF
--- a/R/class_ev.R
+++ b/R/class_ev.R
@@ -32,8 +32,9 @@ is.ev <- function(x) {
 ##' @rdname ev_dplyr
 ##' @export
 mutate.ev <- function(.data, ...) {
+  input_cols <- names(match.call(expand.dots=TRUE))
   .data@data <- as.data.frame(mutate(.data@data, ...))
-  .data@data <- finalize_ev(.data@data)
+  .data@data <- finalize_ev(.data@data,input_cols)
   .data
 }
 
@@ -151,15 +152,31 @@ As_data_set <- function(x) {
   return(x)
 }
 
-finalize_ev_data <- function(data) {
+finalize_ev_data <- function(data,input_cols=NULL) {
+  if(is.character(input_cols)) {
+    if(any(c("tinf", "total", "until") %in% input_cols)) {
+      if(all(c("rate", "tinf") %in% input_cols)) {
+        wstop("input can include either rate or input, not both")
+      }
+      if(all(c("total", "addl") %in% input_cols)) {
+        wstop("input can include either total or addl, not both")
+      }
+      if(all(c("until", "addl") %in% input_cols)) {
+        wstop("input can include either until or addl, not both")
+      }
+    }
+  }
   if("tinf" %in% names(data)) {
+    if("rate" %in% input_cols) {
+      wstop("cannot set rate when tinf already exists")  
+    }
     tinf <- data[["tinf"]]
     if(any(tinf < 0)) {
-      stop("tinf must be greater than or equal to zero", call.=FALSE)
+      wstop("tinf must be greater than or equal to zero")
     }
+    data[["rate"]] <- 0    
     if(any(tinf > 0)) {
       i <- tinf > 0
-      data[["rate"]] <- 0
       data[["rate"]][i] <- data[["amt"]][i]/tinf[i]
     }
   }
@@ -171,12 +188,12 @@ finalize_ev_data <- function(data) {
         data[["addl"]] <- total - 1
       }
     } else {
-      stop("total required to be greater than zero", call.=FALSE)
+      wstop("total required to be greater than zero")
     }
   }
   if("until" %in% names(data)) {
     if(!("ii" %in% names(data))) {
-      stop("ii is required when until is specified", call.=FALSE)
+      wstop("ii is required when until is specified")
     }
     until <- data[["until"]]
     data[["until"]] <- NULL
@@ -191,11 +208,11 @@ finalize_ev_data <- function(data) {
   data
 }
 
-finalize_ev <- function(x) {
+finalize_ev <- function(x,...) {
   if(is.data.frame(x)) {
-    x <- finalize_ev_data(x)
+    x <- finalize_ev_data(x,...)
   } else if(is.ev(x)) {
-    x@data <- finalize_ev_data(x@data)
+    x@data <- finalize_ev_data(x@data,...)
   } else {
     wstop("object must be a data frame or class ev")  
   }

--- a/R/events.R
+++ b/R/events.R
@@ -107,11 +107,11 @@ setMethod("ev", "missing", function(time=0, amt=0, evid=1, cmt=1, ID=numeric(0),
   }
   
   if(any(evid==0)) {
-    stop("evid cannot be 0 (observation)")
+    wstop("evid cannot be 0 (observation)")
   }
   
   if(missing(amt)) {
-    stop("argument \"amt\" is missing, with no default.", call.=FALSE)  
+    wstop("argument \"amt\" is missing, with no default.")  
   }
   
   l <- list(time=time, cmt=cmt, amt=amt, evid=evid)
@@ -128,7 +128,7 @@ setMethod("ev", "missing", function(time=0, amt=0, evid=1, cmt=1, ID=numeric(0),
   
   data <- as.data.frame(as_tibble(l))
 
-  data <- finalize_ev(data)
+  data <- finalize_ev(data, names(l))
 
   if(length(ID) > 0) {
     
@@ -213,6 +213,8 @@ setMethod("as.ev", "data.frame", function(x,keep_id=TRUE,clean = FALSE,...) {
     names(x)[where] <- tolower(names(x)[where])
   }
   
+  input_cols <- names(x)
+  
   if(!has_name("cmt",x)) {
     x[["cmt"]] <- 1 
   }
@@ -239,7 +241,7 @@ setMethod("as.ev", "data.frame", function(x,keep_id=TRUE,clean = FALSE,...) {
     x <- x[,keep]
   }
   
-  x <- finalize_ev(x)
+  x <- finalize_ev(x,input_cols)
   
   new("ev", data=x)
 })
@@ -276,21 +278,21 @@ collect_ev <- function(...) {
   
   if(length(na.check) > 0) {
     if(any(is.na(unlist(x[,na.check])))) {
-      warning("missing values in some columns.",call.=FALSE)
+      warning("missing values in some columns",call.=FALSE)
     }
   }
   x <- dplyr::select(x,c(match(tran,names(x)),seq_along(names(x))))
   
   if(!any(c("time", "TIME") %in% names(x))) {
-    stop("No time or TIME column in the data set", call. = FALSE) 
+    wstop("no time or TIME column in the data set") 
   }
   
   if(!any(c("cmt", "CMT") %in% names(x))) {
-    stop("No cmt or CMT column in the data set", call. = FALSE) 
+    wstop("no cmt or CMT column in the data set") 
   }
   
   if(!has_ID(x)) {
-    stop("No ID column in the data set", call. = FALSE)
+    wstop("no ID column in the data set")
   }
   return(x)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -220,7 +220,7 @@ expand.ev <- function(...) {
   if(!has_name("cmt", ans)) ans[["cmt"]] <- 1
   if(!has_name("time", ans)) ans[["time"]] <- 0
   if(!has_name("amt", ans)) ans[["amt"]] <- 0
-  finalize_ev(ans)
+  finalize_ev(ans,input_cols = names(ans))
 }
 
 #' @export

--- a/inst/maintenance/unit/tests.md
+++ b/inst/maintenance/unit/tests.md
@@ -87,9 +87,9 @@
 |test-ev.R                 |test-ev                              |as.ev                                                                     |  6|      0|FALSE   |FALSE |       0|      6|
 |test-ev.R                 |test-ev                              |ev_repeat                                                                 |  1|      0|FALSE   |FALSE |       0|      1|
 |test-ev.R                 |test-ev                              |create ev with evaluation issue-512                                       |  4|      0|FALSE   |FALSE |       0|      4|
-|test-ev.R                 |test-ev                              |tinf issue-513                                                            |  4|      0|FALSE   |FALSE |       0|      4|
-|test-ev.R                 |test-ev                              |total  issue-513                                                          |  4|      0|FALSE   |FALSE |       0|      4|
-|test-ev.R                 |test-ev                              |until  issue-513                                                          |  3|      0|FALSE   |FALSE |       0|      3|
+|test-ev.R                 |test-ev                              |tinf issue-513                                                            |  6|      0|FALSE   |FALSE |       0|      6|
+|test-ev.R                 |test-ev                              |total  issue-513                                                          |  5|      0|FALSE   |FALSE |       0|      5|
+|test-ev.R                 |test-ev                              |until  issue-513                                                          |  4|      0|FALSE   |FALSE |       0|      4|
 |test-evid4.R              |test-evid4                           |evid4 bolus dosing is the same as evid1                                   |  1|      0|FALSE   |FALSE |       0|      1|
 |test-evid4.R              |test-evid4                           |evid4 infusion dosing is the same as evid1                                |  1|      0|FALSE   |FALSE |       0|      1|
 |test-fixed-cmtn.R         |test-fixed-cmtn                      |FIXED items are excluded from param                                       |  2|      0|FALSE   |FALSE |       0|      2|

--- a/tests/testthat/test-ev.R
+++ b/tests/testthat/test-ev.R
@@ -194,11 +194,13 @@ test_that("tinf issue-513", {
   e <- ev(amt = 100, tinf = 10)
   expect_identical(e$rate, 10)
   e <- ev(amt = 100, tinf = 0)
-  expect_identical(e$rate, NULL)
+  expect_identical(e$rate, 0)
   expect_error(ev(amt = 100, tinf = -1))
   e <- ev(amt = 100)
   e <- mutate(e, tinf = 20)
   expect_identical(e$rate,5)
+  expect_error(ev(amt=100,tinf=2,rate=5), "input can include either")
+  expect_error(mutate(e, rate = 5), "cannot set rate when tinf")
 })
 
 test_that("total  issue-513", {
@@ -210,6 +212,7 @@ test_that("total  issue-513", {
   e <- ev(amt = 100, ii = 12)
   e <- mutate(e, total = 20)
   expect_identical(e$addl,19)
+  expect_error(ev(amt=100,addl=5,total=4), "input can include either")
 })
 
 test_that("until  issue-513", {
@@ -219,4 +222,5 @@ test_that("until  issue-513", {
   e <- ev(amt = 100)
   e <- mutate(e, ii = 24, until = 168)
   expect_identical(e$addl,6)
+  expect_error(ev(amt=100,addl=5,until=100), "input can include either")
 })


### PR DESCRIPTION
Continues #513 

- Check input names and error when input is ambiguous (e.g. addl and total are both supplied)