### PR TITLE
feature: adds ID number to ss fail message

### DIFF
--- a/src/datarecord.cpp
+++ b/src/datarecord.cpp
@@ -277,8 +277,8 @@ void datarecord::steady_bolus(odeproblem* prob, LSODA& solver) {
   if((!made_it) && warn) {
     Rcpp::warning(
       tfm::format(
-        "[steady_bolus] failed to reach steady state with settings\n  ss_n: %d, rtol: %d, atol: %d", 
-        N_SS, solver.Rtol, solver.Atol
+        "[steady_bolus] ID %d failed to reach steady state\n  ss_n: %d, rtol: %d, atol: %d", 
+        this->id(), N_SS, solver.Rtol, solver.Atol
       ).c_str()
     );
   }
@@ -408,8 +408,8 @@ void datarecord::steady_infusion(odeproblem* prob, reclist& thisi, LSODA& solver
   if((!made_it) && warn) {
     Rcpp::warning(
       tfm::format(
-        "[steady_infusion] failed to reach steady state with settings\n  ss_n: %d, rtol: %d, atol: %d", 
-        N_SS, solver.Rtol, solver.Atol
+        "[steady_infusion] ID %d failed to reach steady state\n  ss_n: %d, rtol: %d, atol: %d", 
+        this->id(), N_SS, solver.Rtol, solver.Atol
       ).c_str()
     );
   }
@@ -536,8 +536,8 @@ void datarecord::steady_zero(odeproblem* prob, LSODA& solver) {
   if((!made_it) && warn) {
     Rcpp::warning(
       tfm::format(
-        "[steady_zero] failed to reach steady state with settings\n  ss_n: %d, rtol: %d, atol: %d", 
-        N_SS, solver.Rtol, solver.Atol
+        "[steady_zero] ID %d failed to reach steady state\n  ss_n: %d, rtol: %d, atol: %d", 
+        this->id(),N_SS, solver.Rtol, solver.Atol
       ).c_str()
     );
   }

--- a/tests/testthat/test-ss.R
+++ b/tests/testthat/test-ss.R
@@ -26,11 +26,11 @@ context("test-ss")
 
 test_that("ss_n and ss_fixed issue-533", {
   mod <- mrgsolve:::house(end = 72,delta=4) %>% param(VC = 50)
-  dose <- ev(amt = 100, ii = 24, ss=1, cmt=2, addl=2)
+  dose <- ev(amt = 100, ii = 24, ss=1, cmt=2, addl=2, ID=31)
   out <- mrgsim_e(mod,dose,recsort=3)
   expect_is(out,"mrgsims")
-  expect_warning(out2 <-mrgsim_e(mod,dose, ss_n = 3,recsort=3), 
-                 "failed to reach steady state")
+  expect_warning(out2 <- mrgsim_e(mod,dose, ss_n = 3,recsort=3), 
+                 "ID 31 failed to reach steady state")
   expect_true(all(out2$CP != out$CP))
   expect_silent(out3 <- mrgsim_e(mod,dose, ss_n = 3, ss_fixed=TRUE, recsort=3))
   expect_true(all(out3$CP != out$CP))


### PR DESCRIPTION
I just thought of this;  not required to function, but I'm sure people will ask for it and it will be useful when simulating a population. 

Ok to dismiss if you'd rather just bring it in at the next release. 