### PR TITLE
Modify behavior around advance to steady state

### DIFF
--- a/R/mrgsolve.R
+++ b/R/mrgsolve.R
@@ -454,15 +454,15 @@ mrgsim_nid <- function(x, nid, events = ev(), ...) {
 ##' the PK system; a warning will be issued if steady state is not achieved 
 ##' within \code{ss_n} iterations when \code{ss_fixed} is \code{TRUE}
 ##' @param ss_fixed if \code{FALSE} (the default), then a warning will be issued
-##' if the system does not advance to steady state within \code{ss_n} iterations
+##' if the system does not reach steady state within \code{ss_n} iterations
 ##' given the model tolerances \code{rtol} and \code{atol}; if \code{TRUE}, 
-##' then a fixed number of iterations are 
-##' performed (determined by \code{ss_n}) for determining steady state without
-##' regard to model tolerances; to silence warnings related to steady state, 
-##' set \code{ss_fixed} to \code{TRUE} and set \code{ss_n} as the number of 
-##' iterations to advance the system for steady state determination. If 
-##' \code{ss_n} is \code{FALSE} a warning will be issued 
-##' 
+##' the number of iterations for determining steady state are capped at 
+##' \code{ss_n} and no warning will be issued if steady state 
+##' has not been reached within \code{ss_n} dosing iterations.
+##' To silence warnings related to steady state, 
+##' set \code{ss_fixed} to \code{TRUE} and set \code{ss_n} as the maximum number 
+##' of iterations to try when advancing the system for steady state 
+##' determination.
 ##' 
 ##' @rdname mrgsim
 ##' @export

--- a/man/mrgsim.Rd
+++ b/man/mrgsim.Rd
@@ -101,14 +101,15 @@ the PK system; a warning will be issued if steady state is not achieved
 within \code{ss_n} iterations when \code{ss_fixed} is \code{TRUE}}
 
 \item{ss_fixed}{if \code{FALSE} (the default), then a warning will be issued
-if the system does not advance to steady state within \code{ss_n} iterations
+if the system does not reach steady state within \code{ss_n} iterations
 given the model tolerances \code{rtol} and \code{atol}; if \code{TRUE}, 
-then a fixed number of iterations are 
-performed (determined by \code{ss_n}) for determining steady state without
-regard to model tolerances; to silence warnings related to steady state, 
-set \code{ss_fixed} to \code{TRUE} and set \code{ss_n} as the number of 
-iterations to advance the system for steady state determination. If 
-\code{ss_n} is \code{FALSE} a warning will be issued}
+the number of iterations for determining steady state are capped at 
+\code{ss_n} and no warning will be issued if steady state 
+has not been reached within \code{ss_n} dosing iterations.
+To silence warnings related to steady state, 
+set \code{ss_fixed} to \code{TRUE} and set \code{ss_n} as the maximum number 
+of iterations to try when advancing the system for steady state 
+determination.}
 }
 \value{
 An object of class \code{\link{mrgsims}}

--- a/src/datarecord.cpp
+++ b/src/datarecord.cpp
@@ -232,7 +232,6 @@ void datarecord::steady_bolus(odeproblem* prob, LSODA& solver) {
   prob->rate_reset();
   bool warn = !prob->ss_fixed;
   int N_SS = prob->ss_n;  
-  int min_check = std::min(10, N_SS);
   double tfrom = 0.0;
   double tto = 0.0;
   
@@ -255,20 +254,16 @@ void datarecord::steady_bolus(odeproblem* prob, LSODA& solver) {
     
     int ngood = 0;
     for(int j=0; j < prob->neq(); ++j) {
-      if(i >= min_check) {
-        diff = fabs(prob->y(j) - last[j]);
-        err = solver.Rtol * fabs(prob->y(j)) + solver.Atol;
-        if(diff < err ) ++ngood;
-      }
+      diff = fabs(prob->y(j) - last[j]);
+      err = solver.Rtol * fabs(prob->y(j)) + solver.Atol;
+      if(diff < err ) ++ngood;
       last[j] = prob->y(j);
     } 
-    if(i > min_check) {
-      if(ngood == prob->neq()) {
-        tfrom = double(i-1)*Ii;
-        tto  = double(i)*Ii;
-        made_it = true;
-        break;
-      }
+    if(ngood == prob->neq()) {
+      tfrom = double(i-1)*Ii;
+      tto  = double(i)*Ii;
+      made_it = true;
+      break;
     }
     tfrom = tto;
   }
@@ -340,7 +335,6 @@ void datarecord::steady_infusion(odeproblem* prob, reclist& thisi, LSODA& solver
   int j;
   bool warn = !prob->ss_fixed;
   int N_SS = prob->ss_n;  
-  int min_check = std::min(10, N_SS);
   std::vector<double> last(prob->neq(),-1e9);
   
   reclist offs;
@@ -388,20 +382,16 @@ void datarecord::steady_infusion(odeproblem* prob, reclist& thisi, LSODA& solver
     
     int ngood = 0;
     for(j=0; j < prob->neq(); ++j) {
-      if(i >= min_check) {
-        diff = fabs(prob->y(j) - last[j]);
-        err = solver.Rtol * fabs(prob->y(j)) + solver.Atol;
-        if(diff < err ) ++ngood;
-      }
+      diff = fabs(prob->y(j) - last[j]);
+      err = solver.Rtol * fabs(prob->y(j)) + solver.Atol;
+      if(diff < err ) ++ngood;
       last[j] = prob->y(j);
     } 
-    if(i > min_check) {
-      if(ngood == prob->neq()) {
-        tfrom = nexti;
-        nexti  = double(i+1)*Ii;
-        made_it = true;
-        break;
-      }
+    if(ngood == prob->neq()) {
+      tfrom = nexti;
+      nexti  = double(i+1)*Ii;
+      made_it = true;
+      break;
     }
   }
   if((!made_it) && warn) {
@@ -489,7 +479,6 @@ void datarecord::steady_zero(odeproblem* prob, LSODA& solver) {
   double a1 = 0, a2 = 0, t1 = 0, t2 = 0;
   bool warn = !prob->ss_fixed;
   int N_SS = prob->ss_n;  
-  int min_check = std::min(10, N_SS);
   std::vector<double> last(prob->neq(),-1e9);
   bool made_it = false;
   
@@ -506,30 +495,26 @@ void datarecord::steady_zero(odeproblem* prob, LSODA& solver) {
     tfrom = tto;
     int ngood = 0;
     for(int j=0; j < prob->neq(); ++j) {
-      if(i >= min_check) {
-        diff = fabs(prob->y(j) - last[j]);
-        err = solver.Rtol*fabs(prob->y(j)) + solver.Atol;
-        if(diff < err) ++ngood;
-      }
+      diff = fabs(prob->y(j) - last[j]);
+      err = solver.Rtol*fabs(prob->y(j)) + solver.Atol;
+      if(diff < err) ++ngood;
       last[j] = prob->y(j);
     }
-    if(i > min_check) {
-      if(ngood == prob->neq()) {
-        made_it = true;
-        break;
-      }
-      duration = 15;
-      if(i==12) {
-        a1 = prob->y(Cmt);
-        t1 = tto;
-        duration = 20;
-      }
-      if(i==25) {
-        a2 = prob->y(Cmt);
-        t2 = tto;
-        double k_ = Rate/(a1+a2) + (a1-a2)/((a1+a2)*(t2-t1));
-        duration = std::max(duration,0.693/k_); // 2*thalf Chiou
-      }
+    if(ngood == prob->neq()) {
+      made_it = true;
+      break;
+    }
+    if(i==10) duration = 15;
+    if(i==15) {
+      a1 = prob->y(Cmt);
+      t1 = tto;
+      duration = 20;
+    }
+    if(i==25) {
+      a2 = prob->y(Cmt);
+      t2 = tto;
+      double k_ = Rate/(a1+a2) + (a1-a2)/((a1+a2)*(t2-t1));
+      duration = std::max(duration,0.693/k_); // 2*thalf Chiou
     }
   }
   if((!made_it) && warn) {

--- a/src/datarecord.cpp
+++ b/src/datarecord.cpp
@@ -276,8 +276,8 @@ void datarecord::steady_bolus(odeproblem* prob, LSODA& solver) {
   if((!made_it) && warn) {
     Rcpp::warning(
       tfm::format(
-        "[steady_bolus] failed to reach steady state with settings\n  ss_n: %d, rtol: %d, atol: %d", 
-        N_SS, solver.Rtol, solver.Atol
+        "[steady_bolus] ID %d failed to reach steady state\n  ss_n: %d, rtol: %d, atol: %d", 
+        this->id(),N_SS, solver.Rtol, solver.Atol
       ).c_str()
     );
   }
@@ -407,8 +407,8 @@ void datarecord::steady_infusion(odeproblem* prob, reclist& thisi, LSODA& solver
   if((!made_it) && warn) {
     Rcpp::warning(
       tfm::format(
-        "[steady_infusion] failed to reach steady state with settings\n  ss_n: %d, rtol: %d, atol: %d", 
-        N_SS, solver.Rtol, solver.Atol
+        "[steady_infusion] ID %d failed to reach steady state\n  ss_n: %d, rtol: %d, atol: %d", 
+        this->id(),N_SS, solver.Rtol, solver.Atol
       ).c_str()
     );
   }
@@ -535,8 +535,8 @@ void datarecord::steady_zero(odeproblem* prob, LSODA& solver) {
   if((!made_it) && warn) {
     Rcpp::warning(
       tfm::format(
-        "[steady_zero] failed to reach steady state with settings\n  ss_n: %d, rtol: %d, atol: %d", 
-        N_SS, solver.Rtol, solver.Atol
+        "[steady_zero] ID %d failed to reach steady state\n  ss_n: %d, rtol: %d, atol: %d", 
+        this->id(),N_SS, solver.Rtol, solver.Atol
       ).c_str()
     );
   }

--- a/src/datarecord.cpp
+++ b/src/datarecord.cpp
@@ -232,7 +232,7 @@ void datarecord::steady_bolus(odeproblem* prob, LSODA& solver) {
   prob->rate_reset();
   bool warn = !prob->ss_fixed;
   int N_SS = prob->ss_n;  
-
+  int min_check = (N_SS < 10) ? N_SS : 10;
   double tfrom = 0.0;
   double tto = 0.0;
   

--- a/src/datarecord.cpp
+++ b/src/datarecord.cpp
@@ -232,7 +232,7 @@ void datarecord::steady_bolus(odeproblem* prob, LSODA& solver) {
   prob->rate_reset();
   bool warn = !prob->ss_fixed;
   int N_SS = prob->ss_n;  
-  int min_check = (N_SS < 10) ? N_SS : 10;
+  int min_check = std::min(10, N_SS);
   double tfrom = 0.0;
   double tto = 0.0;
   
@@ -340,7 +340,7 @@ void datarecord::steady_infusion(odeproblem* prob, reclist& thisi, LSODA& solver
   int j;
   bool warn = !prob->ss_fixed;
   int N_SS = prob->ss_n;  
-  int min_check = (N_SS < 10) ? N_SS : 10;
+  int min_check = std::min(10, N_SS);
   std::vector<double> last(prob->neq(),-1e9);
   
   reclist offs;
@@ -489,7 +489,7 @@ void datarecord::steady_zero(odeproblem* prob, LSODA& solver) {
   double a1 = 0, a2 = 0, t1 = 0, t2 = 0;
   bool warn = !prob->ss_fixed;
   int N_SS = prob->ss_n;  
-  int min_check = (N_SS < 10) ? N_SS : 10;
+  int min_check = std::min(10, N_SS);
   std::vector<double> last(prob->neq(),-1e9);
   bool made_it = false;
   

--- a/src/datarecord.cpp
+++ b/src/datarecord.cpp
@@ -232,7 +232,6 @@ void datarecord::steady_bolus(odeproblem* prob, LSODA& solver) {
   prob->rate_reset();
   bool warn = !prob->ss_fixed;
   int N_SS = prob->ss_n;  
-  int min_check = (N_SS < 10 || prob->ss_fixed) ? N_SS : 10;
 
   double tfrom = 0.0;
   double tto = 0.0;
@@ -341,7 +340,7 @@ void datarecord::steady_infusion(odeproblem* prob, reclist& thisi, LSODA& solver
   int j;
   bool warn = !prob->ss_fixed;
   int N_SS = prob->ss_n;  
-  int min_check = (N_SS < 10 || prob->ss_fixed) ? N_SS : 10;
+  int min_check = (N_SS < 10) ? N_SS : 10;
   std::vector<double> last(prob->neq(),-1e9);
   
   reclist offs;
@@ -490,7 +489,7 @@ void datarecord::steady_zero(odeproblem* prob, LSODA& solver) {
   double a1 = 0, a2 = 0, t1 = 0, t2 = 0;
   bool warn = !prob->ss_fixed;
   int N_SS = prob->ss_n;  
-  int min_check = (N_SS < 10 || prob->ss_fixed) ? N_SS : 10;
+  int min_check = (N_SS < 10) ? N_SS : 10;
   std::vector<double> last(prob->neq(),-1e9);
   bool made_it = false;
   

--- a/tests/testthat/test-ss.R
+++ b/tests/testthat/test-ss.R
@@ -26,12 +26,18 @@ context("test-ss")
 
 test_that("ss_n and ss_fixed issue-533", {
   mod <- mrgsolve:::house(end = 72,delta=4) %>% param(VC = 50)
-  dose <- ev(amt = 100, ii = 24, ss=1, cmt=2, addl=2)
+  dose <- ev(amt = 100, ii = 24, ss=1, cmt=2, addl=2, ID=123)
   out <- mrgsim_e(mod,dose,recsort=3)
   expect_is(out,"mrgsims")
-  expect_warning(out2 <-mrgsim_e(mod,dose, ss_n = 3,recsort=3), 
-                 "failed to reach steady state")
+  expect_warning(out2 <- mrgsim_e(mod,dose, ss_n = 3,recsort=3), 
+                 "\\[steady_bolus\\] ID 123 failed to reach steady state")
   expect_true(all(out2$CP != out$CP))
   expect_silent(out3 <- mrgsim_e(mod,dose, ss_n = 3, ss_fixed=TRUE, recsort=3))
   expect_true(all(out3$CP != out$CP))
+  e <- ev(amt = 100, ii = 12, ss=1, cmt=2, rate = 5, ID = 321)
+  expect_warning(mrgsim_e(mod,e, ss_n=3),
+                 "\\[steady_infusion\\] ID 321 failed to reach steady state")
+  e <- ev(amt = 0, ii = 12, ss = 1, rate = 5, ID = 246)
+  expect_warning(mrgsim_e(mod,e, ss_n=3), 
+                 "\\[steady_zero\\] ID 246 failed to reach steady state")
 })


### PR DESCRIPTION
@dpastoor - wondering too if the argument name should get changed?  I had "fixed" in mind but now it's more of `ss_cap = TRUE`?

See #571 which modifies #533 - ok to stop early if ss is reached based on rtol/atol

See #573  - adds ID number to warning if steady state isn't reached


