### PR TITLE
Fix/ss bolus lag #596

### DIFF
--- a/inst/validation/test-validation.R
+++ b/inst/validation/test-validation.R
@@ -21,3 +21,22 @@ BAR : baz = zot
 })
 
 
+
+code <- '
+$PARAM CL = 1, V =20, KA = 1.488,LAG = 1
+$CMT DEPOT CENT AUC
+$MAIN ALAG_DEPOT = LAG;
+$ODE
+dxdt_DEPOT = -KA*DEPOT;
+dxdt_CENT =   KA*DEPOT - (CL/V)*CENT;
+dxdt_AUC = CENT/V;
+'
+
+test_that("ss bolus with lag and AUC issue-596", {
+  first <- ev(amt = 100, ii = 24, ss=1, cmt =1) 
+  mod <- mcode_cache("issue_596",code) %>% param(LAG = 13)
+  out <- expect_warning(mrgsim_df(mod,first))
+  expect_true(all(out[["CENT"]] >=0))
+})
+
+

--- a/src/datarecord.cpp
+++ b/src/datarecord.cpp
@@ -260,12 +260,9 @@ void datarecord::steady_bolus(odeproblem* prob, LSODA& solver) {
       last[j] = prob->y(j);
     } 
     if(ngood == prob->neq()) {
-      tfrom = double(i-1)*Ii;
-      tto  = double(i)*Ii;
       made_it = true;
       break;
     }
-    tfrom = tto;
   }
   
   if((!made_it) && warn) {
@@ -290,7 +287,12 @@ void datarecord::steady_bolus(odeproblem* prob, LSODA& solver) {
     prob->lsoda_init();
     evon->implement(prob); 
     if(lagt <= Ii) {
-      prob->advance(tfrom, (tto - lagt), solver);
+      tfrom = tto;
+      tto = tfrom + Ii - lagt;
+      if(tto <= tfrom) {
+        throw Rcpp::exception("tto <= tfrom in seady_bolus with lag time.",false);  
+      }
+      prob->advance(tfrom, tto, solver);
     }
   }
   


### PR DESCRIPTION
Makes sure that `tfrom` and `tto` are correct when adjusting for lag time during steady state advance for bolus dosing.
