### PR TITLE
use modelparse_rmd when appropriate in blocks #608

### DIFF
--- a/R/class_mrgmod.R
+++ b/R/class_mrgmod.R
@@ -673,8 +673,12 @@ summary.mrgmod <- function(object,...) {
 
 blocks_ <- function(file,what) {
   if(length(what)==0) what <- c("PARAM","MAIN", "ODE","DES", "TABLE")
-  if(!file_exists(file)) stop("Can't find model file", call.=FALSE)
-  bl <- modelparse(readLines(file, warn=FALSE))
+  if(!file_exists(file)) wstop("can't find model file.")
+  if(grepl("\\.Rmd$", file)) {
+      bl <- modelparse_rmd(readLines(file, warn=FALSE))
+  } else {
+    bl <- modelparse(readLines(file, warn=FALSE))    
+  }
   if(!any(what == "all")) bl <- bl[names(bl) %in% what]
   if(length(bl)==0) {
     message("No blocks found.")

--- a/inst/validation/test-validation.R
+++ b/inst/validation/test-validation.R
@@ -77,3 +77,11 @@ test_that("Add N_CMT as plugin issue-606", {
   expect_true(all(out$N_A==1))
 })
 
+test_that("call blocks on model from Rmd issue-608", {
+  mod <- modlib("popex.Rmd",compile=FALSE)
+  expect_output(
+    blocks(mod), 
+    regexp = "popex\\.Rmd"
+  )
+})
+


### PR DESCRIPTION
See #608 and #588 (original report from @billdenney 