### PR TITLE
change the flag in CXX flag test so test behaves same for gcc

### DIFF
--- a/inst/validation/test-validation.R
+++ b/inst/validation/test-validation.R
@@ -64,10 +64,10 @@ test_that("control ss advance issue-598", {
 })
 
 test_that("PKG_CXXFLAGS is set issue-603", {
-  code <- '$ENV PKG_CXXFLAGS = "-Wbadflag"'
+  code <- '$ENV PKG_CXXFLAGS = "-Wdiv-by-zero"'
   expect_output(
     mcode("cxxflags", code, ignore.stdout = FALSE,preclean=TRUE), 
-    regexp = "Wbadflag"
+    regexp = "Wdiv-by-zero"
   )
 })
 


### PR DESCRIPTION
In test `inst/validation/test-validation.R/PKG_CXXFLAGS is set issue-603`:

- Update test so that test behavior is consistent on gcc as well as clang
- No change to package functionality or behavior; everything continues to behave properly and as expected; only tweaking test so that the test can accommodate different compilers

I will write this up as a deviation.





