### PR TITLE
Respect empty time grid except when it would result in not output rows

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# mrgsolve 0.10.1.9000
+
+- The simulation time grid was adjusted so that rendering the grid coudl result
+  in no times (length 0 vector of times); this is a breaking change from 
+  previous behavior where the time grid resolved to 0 when there were no 
+  observations to be found.  While this is a breaking change, the old behavior
+  was almost always wrong when the desired output was a series of
+  non-observation records #640
+
 # mrgsolve 0.10.1
 
 - Add `select_sims` method for selecting columns in `mrgsims` object #585

--- a/R/class_tgrid.R
+++ b/R/class_tgrid.R
@@ -163,12 +163,16 @@ setMethod("stime", "tgrids", function(x,...) {
 })
 
 render_time <- function(x) {
-  add <- times <- numeric(0)
-  #if(!is.mt(x@add)){add <- x@add}
-  if(x@end >= 0){times <-seq(x@start,x@end,x@delta)}
-  times <- invisible(as.numeric(unique(c(times,x@add))))
-  if(is.mt(times)) {return(0)}
-  sort(times[times>=0])
+  if(x@end < x@start) {
+    times <- sort(x@add)
+    if(length(times)==0) times <- 0
+    return(times)
+  }
+  times <- seq(x@start,x@end,x@delta) 
+  if(length(x@add) > 0) {
+    times <- sort(as.numeric(unique(c(times,x@add))))
+  }
+  times[times>=0]
 }
 
 ##' @rdname tgrid

--- a/R/class_tgrid.R
+++ b/R/class_tgrid.R
@@ -164,9 +164,7 @@ setMethod("stime", "tgrids", function(x,...) {
 
 render_time <- function(x) {
   if(x@end < x@start) {
-    times <- sort(x@add)
-    if(length(times)==0) times <- 0
-    return(times)
+    return(sort(x@add))
   }
   times <- seq(x@start,x@end,x@delta) 
   if(length(x@add) > 0) {

--- a/inst/maintenance/unit/test-modlib.R
+++ b/inst/maintenance/unit/test-modlib.R
@@ -25,7 +25,6 @@ options("mrgsolve_mread_quiet"=TRUE)
 context("test-modlib models")
 
 test_that("Lagged bolus", {
-  
   test_lib <- function(x) {
     mod <- mread(x,modlib())
     out <- mrgsim(mod)

--- a/inst/maintenance/unit/test-nocb.R
+++ b/inst/maintenance/unit/test-nocb.R
@@ -43,13 +43,13 @@ mod <- mcode("mypk",code)
 
 test_that("simulation with nocb", {
   out <- mod %>% mrgsim(data = e, nocb = TRUE, end = -1)
-  expect_true(out$foo[4] < 1)
-  expect_true(out$foo[3] == 100)
+  expect_true(out$foo[3] < 1)
+  expect_true(out$foo[2] == 100)
 })
 
 test_that("simulation with locf", {
   out <- mod %>% mrgsim(data = e, nocb = FALSE, end = -1)
-  expect_true(out$foo[4] == 100)
-  expect_true(out$foo[5] < 50)
+  expect_true(out$foo[3] == 100)
+  expect_true(out$foo[4] < 50)
 })
 

--- a/src/devtran.cpp
+++ b/src/devtran.cpp
@@ -193,6 +193,9 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
     Rcpp::NumericMatrix tgrid = 
       Rcpp::as<Rcpp::NumericMatrix>(parin["tgridmatrix"]);
     
+    if((tgrid.nrow() == 0) && (obscount==0) && (evcount==0)) {
+      tgrid = Rcpp::NumericMatrix(1,1);  
+    }
     
     bool multiple_tgrid = tgrid.ncol() > 1;
     
@@ -268,7 +271,6 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
   int precol = 2 + int(tad);
   const unsigned int n_out_col  = precol + n_tran_carry
     + n_data_carry + n_idata_carry + nreq + n_capture;
-  if(NN==0) CRUMP("There are zero rows in output.");
   Rcpp::NumericMatrix ans(NN,n_out_col);
   const unsigned int tran_carry_start = precol;
   const unsigned int data_carry_start = tran_carry_start + n_tran_carry;

--- a/src/devtran.cpp
+++ b/src/devtran.cpp
@@ -134,7 +134,7 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
   unsigned int obscount = 0;
   unsigned int evcount = 0;
   dat.get_records(a, NID, neq, obscount, evcount, obsonly, debug);
-
+  
   // Requested compartments
   Rcpp::IntegerVector request = parin["request"];
   const unsigned int nreq = request.size();
@@ -192,6 +192,7 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
     
     Rcpp::NumericMatrix tgrid = 
       Rcpp::as<Rcpp::NumericMatrix>(parin["tgridmatrix"]);
+    
     
     bool multiple_tgrid = tgrid.ncol() > 1;
     
@@ -267,6 +268,7 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
   int precol = 2 + int(tad);
   const unsigned int n_out_col  = precol + n_tran_carry
     + n_data_carry + n_idata_carry + nreq + n_capture;
+  if(NN==0) CRUMP("There are zero rows in output.");
   Rcpp::NumericMatrix ans(NN,n_out_col);
   const unsigned int tran_carry_start = precol;
   const unsigned int data_carry_start = tran_carry_start + n_tran_carry;
@@ -391,7 +393,7 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
     
     prob.set_d(a[i][0]);
     prob.init_call(tfrom);
-
+    
     for(size_t j=0; j < a[i].size(); ++j) {
       
       if(crow == NN) continue;

--- a/tests/testthat/test-tgrid.R
+++ b/tests/testthat/test-tgrid.R
@@ -1,4 +1,4 @@
-# Copyright (C) 2013 - 2019  Metrum Research Group
+# Copyright (C) 2013 - 2020  Metrum Research Group
 #
 # This file is part of mrgsolve.
 #
@@ -24,6 +24,8 @@ options("mrgsolve_mread_quiet"=TRUE)
 
 context("test-tgrid")
 
+mod <- house()
+
 test_that("tgrid", {
   x <- tgrid(0,24,1)
   expect_is(x,"tgrid")
@@ -33,5 +35,20 @@ test_that("tgrid", {
   expect_length(stime(x),50)
   x <- c(1,2,3,4,5)
   expect_identical(stime(x),x)
+})
+
+test_that("stime can render length 0", {
+  expect_length(stime(numeric(0)), 0)
+  mod <- update(mod, end = -1, add = numeric(0))
+  expect_length(stime(mod),0)
+})
+
+test_that("no extra time 0 record when no observations", {
+  data <- ev(amt = 0, ii = 24, addl = 5) %>% realize_addl()
+  out <- mrgsim(house(),data=data, end = -1)
+  expect_identical(data$time,out$time)
+  data <- filter(data, time !=0)
+  out <- mrgsim(mod, data=data, end = -1)
+  expect_identical(data$time,out$time)
 })
 


### PR DESCRIPTION
See #648 

This is technically a breaking change.  But I am expecting it to be low impact.  Making the issue medium-risk just because it could technically change things. 

Some old tests were updated precisely because this behavior changed.  

1. refactor `render_time` for efficiency and to allow return of `numeric(0)` if there really aren't times in the grid
1. when there will be absolutely zero records in the output, throw in a time=0 record as a place holder; there is intentionally no warning with this
