### PR TITLE
ci: add drone

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -45,3 +45,4 @@ Makefile
 docs
 ^DOCS$
 ^_pkgdown\.yml$
+^\.drone\.yml$

--- a/.drone.yml
+++ b/.drone.yml
@@ -18,6 +18,8 @@ steps:
   environment:
     R_LIBS_USER: "/opt/rpkgs/3.6/2020-03-07"
   commands:
+  # uses .libPaths("~/Rlibs") that causes failure so lets symlink it
+  - ln -s /opt/rpkgs/3.6/2020-03-07 ~/Rlibs
   - R_LIBS=/opt/rpkgs/3.6/2020-03-07 make check
 
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,56 @@
+kind: pipeline
+type: docker
+name: mrgsolve
+
+steps:
+- name: Pull mpn container from ECR
+  image: omerxx/drone-ecr-auth
+  volumes:
+  - name: docker.sock
+    path: /var/run/docker.sock
+  commands:
+  - $(aws ecr get-login --no-include-email --region us-east-1)
+  - docker pull 906087756158.dkr.ecr.us-east-1.amazonaws.com/mpn:2020-03-07
+
+- name: R36
+  image: "906087756158.dkr.ecr.us-east-1.amazonaws.com/mpn:2020-03-07"
+  pull: never
+  environment:
+    R_LIBS_USER: "/opt/rpkgs/3.6/2020-03-07"
+  commands:
+  - /opt/R/3.6.2/bin/R -e "devtools::install_deps(upgrade = 'never')"
+  - /opt/R/3.6.2/bin/R -e "devtools::test()"
+  - /opt/R/3.6.2/bin/R -e "devtools::check()"
+
+
+- name: R35
+  image: "906087756158.dkr.ecr.us-east-1.amazonaws.com/mpn:2020-03-07"
+  pull: never
+  environment:
+    R_LIBS_USER: "/opt/rpkgs/3.5/2020-03-07"
+  commands:
+  - /opt/R/3.5.3/bin/R -e "devtools::install_deps(upgrade = 'never')"
+  - /opt/R/3.5.3/bin/R -e "devtools::test()"
+  - /opt/R/3.5.3/bin/R -e "devtools::check()"
+
+- name: release
+  when:
+    event:
+    - tag
+    status:
+    - success
+  image: "906087756158.dkr.ecr.us-east-1.amazonaws.com/mpn:2020-03-07"
+  pull: never
+  environment:
+    R_LIBS_USER: "/opt/rpkgs/3.6/2020-03-07"
+  commands:
+  - git config --global user.email "drone@metrumrg.com"
+  - git config --global user.name "Drony"
+  - git fetch --tags
+  - R -e "pkgpub::create_tagged_repo()"
+  - aws s3 sync /tmp/${DRONE_TAG} s3://mpn.metworx.dev/releases/${DRONE_REPO_NAME}/${DRONE_TAG}
+
+volumes:
+- name: docker.sock
+  host:
+    path: /var/run/docker.sock

--- a/.drone.yml
+++ b/.drone.yml
@@ -18,20 +18,10 @@ steps:
   environment:
     R_LIBS_USER: "/opt/rpkgs/3.6/2020-03-07"
   commands:
-  - /opt/R/3.6.2/bin/R -e "devtools::install_deps(upgrade = 'never')"
-  - /opt/R/3.6.2/bin/R -e "devtools::test()"
-  - /opt/R/3.6.2/bin/R -e "devtools::check()"
+  - make check
 
 
-- name: R35
-  image: "906087756158.dkr.ecr.us-east-1.amazonaws.com/mpn:2020-03-07"
-  pull: never
-  environment:
-    R_LIBS_USER: "/opt/rpkgs/3.5/2020-03-07"
-  commands:
-  - /opt/R/3.5.3/bin/R -e "devtools::install_deps(upgrade = 'never')"
-  - /opt/R/3.5.3/bin/R -e "devtools::test()"
-  - /opt/R/3.5.3/bin/R -e "devtools::check()"
+
 
 - name: release
   when:

--- a/.drone.yml
+++ b/.drone.yml
@@ -18,7 +18,7 @@ steps:
   environment:
     R_LIBS_USER: "/opt/rpkgs/3.6/2020-03-07"
   commands:
-  - make check
+  - R_LIBS=/opt/rpkgs/3.6/2020-03-07 make check
 
 
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -18,13 +18,8 @@ steps:
   environment:
     R_LIBS_USER: "/opt/rpkgs/3.6/2020-03-07"
   commands:
-  # uses .libPaths("~/Rlibs") that causes failure so lets symlink it
-  - ln -s /opt/rpkgs/3.6/2020-03-07 ~/Rlibs
-  - R_LIBS=/opt/rpkgs/3.6/2020-03-07 make check
-
-
-
-
+  - make drone
+  
 - name: release
   when:
     event:

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ CHKDIR=Rchecks
 drone:
 	R CMD build --md5 $(PKGDIR) --no-manual
 	R CMD check --as-cran --no-manual ${TARBALL}
-	Rscript -e 'testthat::test_dir("inst/maintenance/unit",stop_on_failure = )'
+	Rscript -e 'testthat::test_dir("inst/maintenance/unit",stop_on_failure = TRUE)'
 
 spelling:
 	Rscript -e 'spelling::spell_check_package(".")'

--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,10 @@ travis:
 	R CMD check --as-cran --no-manual ${TARBALL} -o ${CHKDIR}
 	make test2
 
+drone:
+	make build
+	R CMD check --as-cran --no-manual ${TARBALL} -o ${CHKDIR}
+
 rhub:
 	Rscript -e 'rhub::check_for_cran(env_vars = c(`_R_CHECK_FORCE_SUGGESTS_` = "false"))'
 	

--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ travis:
 
 drone:
 	make build
-	R CMD check --as-cran --no-manual ${TARBALL} -o ${CHKDIR}
+	R CMD check --as-cran --no-manual ${TARBALL}
 
 rhub:
 	Rscript -e 'rhub::check_for_cran(env_vars = c(`_R_CHECK_FORCE_SUGGESTS_` = "false"))'

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,11 @@ CHKDIR=Rchecks
 ## Set libPaths:
 ## export R_LIBS=${LIBDIR}
 
+drone:
+	R CMD build --md5 $(PKGDIR) --no-manual
+	R CMD check --as-cran --no-manual ${TARBALL}
+	Rscript -e 'testthat::test_dir("inst/maintenance/unit",stop_on_failure = )'
+
 spelling:
 	Rscript -e 'spelling::spell_check_package(".")'
 
@@ -27,9 +32,6 @@ house:
 no-test:
 	make build
 	R CMD check ${TARBALL} --no-tests
-
-gut_check:
-	Rscript "inst/maintenance/gut_check.R"
 
 everything:
 	make all
@@ -51,12 +53,6 @@ cran:
 	make doc
 	make build
 	R CMD CHECK --as-cran ${TARBALL} -o ${CHKDIR}
-
-travis_build:
-	make housemodel
-	make doc
-	make build
-	make install
 
 readme:
 	Rscript -e 'library(rmarkdown); render("README.Rmd")'
@@ -120,16 +116,12 @@ travis:
 	R CMD check --as-cran --no-manual ${TARBALL} -o ${CHKDIR}
 	make test2
 
-drone:
-	R CMD build --md5 $(PKGDIR) --no-manual
-	R CMD check --as-cran --no-manual ${TARBALL}
-	Rscript -e 'testthat::test_dir("inst/maintenance/unit")'
-
 rhub:
 	Rscript -e 'rhub::check_for_cran(env_vars = c(`_R_CHECK_FORCE_SUGGESTS_` = "false"))'
 	
 check-fedora:
 	Rscript -e 'rhub::check_on_fedora(env_vars = c(`_R_CHECK_FORCE_SUGGESTS_` = "false"))'
+
 check-devel: 
 	Rscript -e 'rhub::check_with_rdevel()'
 

--- a/Makefile
+++ b/Makefile
@@ -121,8 +121,9 @@ travis:
 	make test2
 
 drone:
-	make build
+	R CMD build --md5 $(PKGDIR) --no-manual
 	R CMD check --as-cran --no-manual ${TARBALL}
+	Rscript -e 'testthat::test_dir("inst/maintenance/unit")'
 
 rhub:
 	Rscript -e 'rhub::check_for_cran(env_vars = c(`_R_CHECK_FORCE_SUGGESTS_` = "false"))'


### PR DESCRIPTION
This adds a basic CI config - I think we'll need to adjust slightly - but actually we could probably just call some of your make scripts instead of directly check/test