### PR TITLE
ci: update to also publish to static latest_tag

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -37,6 +37,7 @@ steps:
   - git fetch --tags
   - R -e "pkgpub::create_tagged_repo()"
   - aws s3 sync /tmp/${DRONE_TAG} s3://mpn.metworx.dev/releases/${DRONE_REPO_NAME}/${DRONE_TAG}
+  - aws s3 sync /tmp/${DRONE_TAG} s3://mpn.metworx.dev/releases/${DRONE_REPO_NAME}/latest_tag
 
 volumes:
 - name: docker.sock

--- a/.drone.yml
+++ b/.drone.yml
@@ -10,13 +10,13 @@ steps:
     path: /var/run/docker.sock
   commands:
   - $(aws ecr get-login --no-include-email --region us-east-1)
-  - docker pull 906087756158.dkr.ecr.us-east-1.amazonaws.com/mpn:2020-03-07
+  - docker pull 906087756158.dkr.ecr.us-east-1.amazonaws.com/mpn:2020-03-24
 
 - name: R36
-  image: "906087756158.dkr.ecr.us-east-1.amazonaws.com/mpn:2020-03-07"
+  image: "906087756158.dkr.ecr.us-east-1.amazonaws.com/mpn:2020-03-24"
   pull: never
   environment:
-    R_LIBS_USER: "/opt/rpkgs/3.6/2020-03-07"
+    R_LIBS_USER: "/opt/rpkgs/3.6/2020-03-24"
     _MRGSOLVE_SKIP_MODLIB_BUILD_: false
   commands:
   - make drone
@@ -27,10 +27,10 @@ steps:
     - tag
     status:
     - success
-  image: "906087756158.dkr.ecr.us-east-1.amazonaws.com/mpn:2020-03-07"
+  image: "906087756158.dkr.ecr.us-east-1.amazonaws.com/mpn:2020-03-24"
   pull: never
   environment:
-    R_LIBS_USER: "/opt/rpkgs/3.6/2020-03-07"
+    R_LIBS_USER: "/opt/rpkgs/3.6/2020-03-24"
   commands:
   - git config --global user.email "drone@metrumrg.com"
   - git config --global user.name "Drony"


### PR DESCRIPTION
This will also publish to a fixed endpoint `latest_tag` that will allow people that just want to get the latest tagged version, regardless of what that is, and pull it easily. New tags should override that endpoint so it should be used with caution but is easy when the answer is just 'give me whatever is newest'.

