### PR TITLE
Adding log_sum_exp in dosing

### DIFF
--- a/inst/include/odeproblem.h
+++ b/inst/include/odeproblem.h
@@ -113,6 +113,7 @@ public:
   void y_init(int pos, double value);
   void y_init(Rcpp::NumericVector init);
   void y_add(const unsigned int pos, const double& value);
+  void y_log_sum_exp(const unsigned int pos, const double& value);
   
   void table_call();
   void table_init_call();

--- a/src/datarecord.cpp
+++ b/src/datarecord.cpp
@@ -156,6 +156,9 @@ void datarecord::implement(odeproblem* prob) {
     if(!prob->is_on(eq_n)) prob->on(eq_n);
     prob->y_add(eq_n, Amt * Fn);
     break;
+  case 11: // Dosing event record with log_sum_exp
+    if(!prob->is_on(eq_n)) prob->on(eq_n);
+    prob->y_log_sum_exp(eq_n, Amt);
   case 5:  // Turn infusion on event record
     if(!prob->is_on(eq_n)) prob->on(eq_n);
     if(Fn == 0) break;

--- a/src/odeproblem.cpp
+++ b/src/odeproblem.cpp
@@ -157,6 +157,10 @@ void odeproblem::y_add(const unsigned int pos, const double& value) {
   Y[pos] = Y[pos] + value; 
 }
 
+void odeproblem::y_log_sum_exp(const unsigned int pos, const double& value) {
+  Y[pos] = std::max(Y[pos], value) + log(exp(Y[pos] - std::max(Y[pos], value)) + exp(value  - std::max(Y[pos], value) ) );
+}
+
 /** Derivative function that gets called by the solver. 
  * 
  * @param neq number of equations


### PR DESCRIPTION
This branch allows to use the log form of ODE and dosing using evid=11which under-the-hood uses log_sum_exp to add the dose in a numerically stable way.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
Carlos, Traynor Univ. of Warwick


By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)