### PR TITLE
CRAN release version 0.10.4

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,7 +53,8 @@ Suggests:
     xml2 (>= 1.2.0),
     rmarkdown,
     yaml,
-    knitr
+    knitr, 
+    data.table
 LinkingTo: 
     Rcpp (>= 0.12.12),
     RcppArmadillo (>= 0.7.900.2.0),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: mrgsolve
 Title: Simulate from ODE-Based Models
-Version: 0.10.3
+Version: 0.10.4
 Authors@R: 
     c(person(given = "Kyle T",
              family = "Baron",
@@ -53,8 +53,7 @@ Suggests:
     xml2 (>= 1.2.0),
     rmarkdown,
     yaml,
-    knitr, 
-    data.table
+    knitr
 LinkingTo: 
     Rcpp (>= 0.12.12),
     RcppArmadillo (>= 0.7.900.2.0),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# mrgsolve 0.10.4
+
+- This version fixes a minor documentation issue in an Rd file #699
+
 # mrgsolve 0.10.3
 
 - The simulation time grid was adjusted so that rendering the grid could result

--- a/R/mrgsims.R
+++ b/R/mrgsims.R
@@ -143,7 +143,7 @@ NULL
 
 #' @param .dots passed to various `dplyr` functions
 #' @param .data an mrgsims object; passed to various `dplyr` functions
-#' @param x passed to [dplyr::as.tbl]
+#' @param x passed to `dplyr::as.tbl`
 #' @param add passed to [dplyr::group_by] (for dplyr < `1.0.0`)
 #' @param .add passed to [dplyr::group_by] (for dplyr >= `1.0.0`)
 #' @param .keep_all passed to [dplyr::distinct]

--- a/man/mrgsims_dplyr.Rd
+++ b/man/mrgsims_dplyr.Rd
@@ -60,7 +60,7 @@ as.tbl.mrgsims(x, ...)
 
 \item{.data_}{mrgsims object}
 
-\item{x}{passed to \link[dplyr:as.tbl]{dplyr::as.tbl}}
+\item{x}{passed to \code{dplyr::as.tbl}}
 }
 \description{
 These methods modify the data in a mrgsims object and return a data frame.


### PR DESCRIPTION
-  branch with minor changes for cran
- Documentation issue: `[dplyr::as.tbl]` didn't get rendered properly in the Rd file and coming up as warning on Rdevel
- Added NEWS entry for 0.10.4