### PR TITLE
 get more selective about messaging when drop chr column #709

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,6 @@
+^run-*\.R$
+^test-*\.R$
+^test\.R$
 Doxygen
 doxyfile
 man/figures/README-.*\.png$

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+run-*.R
+./test-*.R
 Doxygen
 DOCS
 mrgsolve.Rcheck

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: mrgsolve
 Title: Simulate from ODE-Based Models
-Version: 0.10.4.9001
+Version: 0.10.4.9002
 Authors@R: 
     c(person(given = "Kyle T",
              family = "Baron",

--- a/Makefile
+++ b/Makefile
@@ -126,8 +126,12 @@ check-winhub:
 doxygen: 
 	doxygen doxyfile
 
-bump_dev:
+bump-dev:
 	Rscript -e 'usethis::use_version("dev")'
+
+tag-version:
+	git tag $(VERSION)
+	git push origin $(VERSION)
 
 testing:
 	cp ${TARBALL} ${MRGSOLVE_TEST_LOC}

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# mrgsolve (development version)
+- `valid_data_set` and `valid_idata_set` only warn when non-numeric columns are
+dropped when the columns correspond to parameters or NMTRAN data items
+
 # mrgsolve 0.10.3
 
 - The simulation time grid was adjusted so that rendering the grid could result

--- a/R/mrgsolve.R
+++ b/R/mrgsolve.R
@@ -538,12 +538,12 @@ do_mrgsim <- function(x,
   
   ## data
   if(!is.valid_data_set(data)) {
-    data <- valid_data_set(data,x,verbose)
+    data <- valid_data_set(data,x,verbose = verbose)
   } 
   
   ## "idata"
   if(!is.valid_idata_set(idata)) {
-    idata <- valid_idata_set(idata,x,verbose=verbose)
+    idata <- valid_idata_set(idata,x,verbose = verbose)
   }
   
   tcol <- timename(data)
@@ -576,8 +576,8 @@ do_mrgsim <- function(x,
     carry_out <- setdiff(carry_out,carry.tran)
     
     # What to carry out from data and idata
-    carry.data  <- intersect(carry_out, colnames(data))
-    carry.idata <- intersect(carry_out, colnames(idata))
+    carry.data  <- intersect(carry_out, dimnames(data)[[2]])
+    carry.idata <- intersect(carry_out, dimnames(idata)[[2]])
     
     # Carry from data_set if name is in idata_set too
     carry.idata <- setdiff(carry.idata, carry.data)

--- a/tests/testthat/test-carry_out.R
+++ b/tests/testthat/test-carry_out.R
@@ -95,7 +95,7 @@ test_that("recover input data-set items", {
   expect_is(out$A,"numeric")
   expect_is(out$b,"character")
   expect_true(all(out$a==out$A))
-  expect_message(mrgsim(mod,dose,recover="A=a"),"Dropping non-numeric columns")
+  expect_silent(mrgsim(mod,dose,recover="A=a"))
   expect_error(mrgsim(mod,recover="a",carry_out="a"))
 })
  

--- a/tests/testthat/test-mrgindata.R
+++ b/tests/testthat/test-mrgindata.R
@@ -30,11 +30,23 @@ mod <- mrgsolve::house() %>% update(end=end, delta=delta)
 data(extran3)
 
 test_that("valid_data_set warns for character columns", {
-  dat <- expand.ev(amt=100,ID=1:4, CL = "A")
-  expect_message(valid_data_set(dat,m=mod), regexp="dropped non-numeric:")
-  dat <- expand.ev(amt=100,ID=1:4,X="A")
-  expect_silent(valid_data_set(dat,m=mod))
+  chr_param <- expand.ev(amt=100,ID=1:4, CL = "A")
+  expect_message(valid_data_set(chr_param,m=mod), regexp="dropped non-numeric:")
+  chr_X <- expand.ev(amt=100,ID=1:4,X="A")
+  expect_silent(valid_data_set(chr_X,m=mod))
+  chr_rate <- expand.ev(amt=100,rate="A")
+  expect_message(valid_data_set(chr_rate,m=mod), "dropped non-numeric:")
+  chr_cmt <- expand.ev(amt=100,cmt="GUT")
+  expect_silent(valid_data_set(chr_cmt,m=mod))
 })
+
+test_that("valid_idata_set warns for character columns", {
+  chr_param <- expand.idata(FOO = 1, CL = "A")
+  expect_message(valid_idata_set(chr_param,m=mod), regexp="dropped non-numeric:")
+  chr_X <- expand.idata(FOO = 1, X = "A")
+  expect_silent(valid_idata_set(chr_X,m=mod))
+})
+
 
 test_that("valid_data_set subs character cmt", {
   dat <- expand.ev(amt=100,ID=1:4,cmt="RESP")

--- a/tests/testthat/test-mrgindata.R
+++ b/tests/testthat/test-mrgindata.R
@@ -30,16 +30,17 @@ mod <- mrgsolve::house() %>% update(end=end, delta=delta)
 data(extran3)
 
 test_that("valid_data_set warns for character columns", {
+  dat <- expand.ev(amt=100,ID=1:4, CL = "A")
+  expect_message(valid_data_set(dat,m=mod), regexp="dropped non-numeric:")
   dat <- expand.ev(amt=100,ID=1:4,X="A")
-  expect_message(valid_data_set(dat,m=mod), regexp="^Dropping")
-  
+  expect_silent(valid_data_set(dat,m=mod))
 })
 
 test_that("valid_data_set subs character cmt", {
   dat <- expand.ev(amt=100,ID=1:4,cmt="RESP")
   x <- valid_data_set(dat,mod)
   expect_true(all(x[,"cmt"] ==3))
-
+  
   dat$cmt <- "GUT"
   x <- valid_data_set(dat,mod)
   expect_true(all(x[,"cmt"] ==1))
@@ -47,8 +48,8 @@ test_that("valid_data_set subs character cmt", {
 })
 
 test_that("Run with no input", {
-    expect_equal(length(stime(mod)),n)
-    expect_equal(nrow(mrgsim(mod)),n)
+  expect_equal(length(stime(mod)),n)
+  expect_equal(nrow(mrgsim(mod)),n)
 })
 
 test_that("Run with no input - and nid", {
@@ -103,8 +104,8 @@ test_that("Run ev event - and nid", {
 
 
 test_that("Run with data set - data.frame", {
-    out <- mod %>% data_set(extran3) %>% mrgsim
-    expect_equal(nrow(out),nrow(extran3))
+  out <- mod %>% data_set(extran3) %>% mrgsim
+  expect_equal(nrow(out),nrow(extran3))
 })
 
 test_that("Run with data set - tibble", {


### PR DESCRIPTION
- for data and idata, only warn when dropped column is a parameter or a NMTRAN item (except for CMT/cmt)
- numerics_only will continue to warn for anything by default; but valid_data_set and valid_idata_set will always call with quiet flag