### PR TITLE
refactor carry out for nocb

### DIFF
--- a/inst/include/dataobject.h
+++ b/inst/include/dataobject.h
@@ -80,7 +80,8 @@ public:
                  const Rcpp::IntegerVector& data_carry,
                  const unsigned int data_carry_start,
                  const Rcpp::IntegerVector& idata_carry,
-                 const unsigned int idata_carry_start);
+                 const unsigned int idata_carry_start, 
+                 const bool nocb);
   std::vector<unsigned int> col;
   Rcpp::CharacterVector Data_names;
   

--- a/inst/maintenance/unit/test-nocb.R
+++ b/inst/maintenance/unit/test-nocb.R
@@ -118,7 +118,7 @@ $MAIN
 double CL = CL0 / V * COV ;
 $CAPTURE DV, CL, COV2 = COV
 "
-  modelobsaug <- mread("testobsaug",code = code)
+  modelobsaug <- mcode("testobsaug", code)
   
   dat1 <- data.frame(
     ID = 1, 

--- a/inst/maintenance/unit/test-nocb.R
+++ b/inst/maintenance/unit/test-nocb.R
@@ -107,7 +107,7 @@ $PKMODEL cmt = "DEPOT CENTRAL", depot = TRUE
   expect_true(all.equal(a,b))
 })
 
-test_that("unit carry_out with obsaub", {
+test_that("loc:unit carry_out with obsaug", {
   code <- "
 $PARAM CL0 = .1, V = 10, COV = 100
 $CMT CENT

--- a/inst/maintenance/unit/test-nocb.R
+++ b/inst/maintenance/unit/test-nocb.R
@@ -139,7 +139,15 @@ $CAPTURE DV, CL, COV2 = COV
     mrgsim_df(carry_out = "COV") 
   
   expect_true(all(out$COV==out$COV2))
-
+  
+  out <- 
+    modelobsaug %>%
+    obsaug() %>% 
+    data_set(data) %>%
+    mrgsim_df(carry_out = "COV", nocb = FALSE)
+  
+  expect_true(all(out$COV==out$COV2))
+  
 })
 
 

--- a/src/dataobject.cpp
+++ b/src/dataobject.cpp
@@ -500,7 +500,8 @@ void dataobject::carry_out(const recstack& a,
                            const Rcpp::IntegerVector& data_carry,
                            const unsigned int data_carry_start,
                            const Rcpp::IntegerVector& idata_carry,
-                           const unsigned int idata_carry_start) {
+                           const unsigned int idata_carry_start, 
+                           const bool nocb) {
   
   int crow = 0;
   int j = 0;
@@ -523,7 +524,8 @@ void dataobject::carry_out(const recstack& a,
     }
     
     lastpos = -1;
-    int maxpos = Endrow.at(j);
+    const int pos_offset = nocb ? 1 : 0;
+    const int maxpos = Endrow.at(j);
     int nextpos = 0;
     
     for(reclist::const_iterator itt = it->begin(); itt != it->end(); ++itt) {
@@ -534,7 +536,7 @@ void dataobject::carry_out(const recstack& a,
           lastpos = (*itt)->pos();
           nextpos = lastpos;
         } else {
-          nextpos = std::min(lastpos + 1, maxpos);
+          nextpos = std::min(lastpos + pos_offset, maxpos);
         }
       }
       

--- a/src/dataobject.cpp
+++ b/src/dataobject.cpp
@@ -516,19 +516,26 @@ void dataobject::carry_out(const recstack& a,
   
   for(recstack::const_iterator it=a.begin(); it!=a.end(); ++it) {
     
-    j = it-a.begin();
+    j = it - a.begin();
     
     if(carry_from_idata) {
       idatarow = idat.get_idata_row(this->get_uid(j));
     }
     
     lastpos = -1;
+    int maxpos = Endrow.at(j);
+    int nextpos = 0;
     
     for(reclist::const_iterator itt = it->begin(); itt != it->end(); ++itt) {
       
       // Get the last valid data set position to carry from
       if(carry_from_data) {
-        if((*itt)->from_data()) lastpos = (*itt)->pos();
+        if((*itt)->from_data()) {
+          lastpos = (*itt)->pos();
+          nextpos = lastpos;
+        } else {
+          nextpos = std::min(lastpos + 1, maxpos);
+        }
       }
       
       if(!(*itt)->output()) continue;
@@ -539,9 +546,9 @@ void dataobject::carry_out(const recstack& a,
       }
       
       if(carry_from_data) {
-        if(lastpos >=0) {
+        if(lastpos >= 0) {
           for(k=0; k < n_data_carry; ++k) {
-            ans(crow, data_carry_start+k)  = Data(lastpos,data_carry[k]);
+            ans(crow, data_carry_start+k)  = Data(nextpos,data_carry[k]);
           }
         } else {
           for(k=0; k < n_data_carry; ++k) {

--- a/src/devtran.cpp
+++ b/src/devtran.cpp
@@ -336,8 +336,8 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
   }
   
   if(((n_idata_carry > 0) || (n_data_carry > 0)) ) {
-    dat.carry_out(a,ans,idat,data_carry,data_carry_start,
-                  idata_carry,idata_carry_start);
+    dat.carry_out(a,ans,idat,data_carry,data_carry_start,idata_carry,
+                  idata_carry_start);
   }
   
   crow = 0;

--- a/src/devtran.cpp
+++ b/src/devtran.cpp
@@ -337,7 +337,7 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
   
   if(((n_idata_carry > 0) || (n_data_carry > 0)) ) {
     dat.carry_out(a,ans,idat,data_carry,data_carry_start,idata_carry,
-                  idata_carry_start);
+                  idata_carry_start,nocb);
   }
   
   crow = 0;


### PR DESCRIPTION
See #753 

- this re-factors carry out so that it takes the actual row value when possible and the next row otherwise
- when `nocb = FALSE` we carry forward
