### PR TITLE
reset solver when copying parameters

### DIFF
--- a/src/dataobject.cpp
+++ b/src/dataobject.cpp
@@ -202,6 +202,7 @@ void dataobject::copy_next_parameters(int id_n, bool from_data, int this_row,
   if(done_copying) return;
   if(from_data) {
     copy_parameters(this_row, prob);
+    prob->lsoda_init();
     if(this_row >= Endrow.at(id_n)) {
       done_copying = true;  
       return;
@@ -212,6 +213,7 @@ void dataobject::copy_next_parameters(int id_n, bool from_data, int this_row,
   if((next_copy_row != last_copy_row) && (next_copy_row <= Endrow.at(id_n))) {
     copy_parameters(next_copy_row, prob); 
     last_copy_row = next_copy_row;
+    prob->lsoda_init();
   }
 }
 

--- a/src/dataobject.cpp
+++ b/src/dataobject.cpp
@@ -54,7 +54,7 @@ dataobject::dataobject(Rcpp::NumericMatrix _data,
   
   col.resize(8,0);
   
-  any_copy = parnames.size() > 0;
+  any_copy = par_from.size() > 0;
   done_copying = false;
   last_copy_row = -1;
   next_copy_row = 0;
@@ -88,7 +88,7 @@ dataobject::dataobject(Rcpp::NumericMatrix _data,
   
   col.resize(8,0);
   
-  any_copy = parnames.size() > 0;
+  any_copy = par_from.size() > 0;
   done_copying = false;
   last_copy_row = -1;
   next_copy_row = 0;
@@ -186,10 +186,10 @@ void dataobject::idata_row() {
 
 void dataobject::copy_parameters(int this_row, odeproblem* prob) {
   size_t n = par_from.size();
-  for(size_t i=0; i < n; ++i) {
+  for(size_t i = 0; i < n; ++i) {
     prob->param(par_to[i],Data(this_row,par_from[i]));
   }
-  prob->lsoda_init();
+  if(n > 0) prob->lsoda_init();
 }
 
 void dataobject::next_id(int id_n) {

--- a/src/dataobject.cpp
+++ b/src/dataobject.cpp
@@ -189,7 +189,7 @@ void dataobject::copy_parameters(int this_row, odeproblem* prob) {
   for(size_t i = 0; i < n; ++i) {
     prob->param(par_to[i],Data(this_row,par_from[i]));
   }
-  if(n > 0) prob->lsoda_init();
+  prob->lsoda_init();
 }
 
 void dataobject::next_id(int id_n) {

--- a/src/dataobject.cpp
+++ b/src/dataobject.cpp
@@ -186,10 +186,13 @@ void dataobject::idata_row() {
 
 void dataobject::copy_parameters(int this_row, odeproblem* prob) {
   size_t n = par_from.size();
+  bool call_lsoda_init = false;
   for(size_t i = 0; i < n; ++i) {
+    call_lsoda_init = call_lsoda_init || 
+      (prob->Param[par_to[i]] != Data(this_row,par_from[i]));
     prob->param(par_to[i],Data(this_row,par_from[i]));
   }
-  prob->lsoda_init();
+  if(call_lsoda_init) prob->lsoda_init();
 }
 
 void dataobject::next_id(int id_n) {

--- a/src/dataobject.cpp
+++ b/src/dataobject.cpp
@@ -189,6 +189,7 @@ void dataobject::copy_parameters(int this_row, odeproblem* prob) {
   for(size_t i=0; i < n; ++i) {
     prob->param(par_to[i],Data(this_row,par_from[i]));
   }
+  prob->lsoda_init();
 }
 
 void dataobject::next_id(int id_n) {
@@ -202,7 +203,6 @@ void dataobject::copy_next_parameters(int id_n, bool from_data, int this_row,
   if(done_copying) return;
   if(from_data) {
     copy_parameters(this_row, prob);
-    prob->lsoda_init();
     if(this_row >= Endrow.at(id_n)) {
       done_copying = true;  
       return;
@@ -213,7 +213,6 @@ void dataobject::copy_next_parameters(int id_n, bool from_data, int this_row,
   if((next_copy_row != last_copy_row) && (next_copy_row <= Endrow.at(id_n))) {
     copy_parameters(next_copy_row, prob); 
     last_copy_row = next_copy_row;
-    prob->lsoda_init();
   }
 }
 

--- a/src/devtran.cpp
+++ b/src/devtran.cpp
@@ -386,11 +386,13 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
       idat.copy_inits(this_idata_row,&prob);
     }
     
-    if(a[i][0]->from_data()) {
-      dat.copy_parameters(a[i][0]->pos(),&prob);
-    } else {
-      if(filbak) {
-        dat.copy_parameters(dat.start(i),&prob);
+    if(dat.any_copy) {
+      if(a[i][0]->from_data()) {
+        dat.copy_parameters(a[i][0]->pos(),&prob);
+      } else {
+        if(filbak) {
+          dat.copy_parameters(dat.start(i),&prob);
+        }
       }
     }
     
@@ -440,7 +442,7 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
           &prob
         );
       }
-
+      
       tto = this_rec->time();
       
       double dt  = (tto-tfrom)/(tfrom == 0.0 ? 1.0 : tfrom);

--- a/src/devtran.cpp
+++ b/src/devtran.cpp
@@ -432,7 +432,7 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
       }
       
       if(dat.any_copy && nocb) {
-        // this will call lsoda_init if parameters are copied
+        // will call lsoda_init if parameters are copied
         dat.copy_next_parameters(
           i, 
           this_rec->from_data(), 
@@ -552,8 +552,8 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
       
       if(!nocb && dat.any_copy) {
         if(this_rec->from_data()) {
+          // will call lsoda_init
           dat.copy_parameters(this_rec->pos(),&prob);
-          prob.lsoda_init();
         }
       }
       

--- a/src/devtran.cpp
+++ b/src/devtran.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2013 - 2019  Metrum Research Group
+// Copyright (C) 2013 - 2020  Metrum Research Group
 //
 // This file is part of mrgsolve.
 //
@@ -431,15 +431,16 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
         continue;
       }
       
-      if(nocb && dat.any_copy) {
+      if(dat.any_copy && nocb) {
+        // this will call lsoda_init if parameters are copied
         dat.copy_next_parameters(
           i, 
           this_rec->from_data(), 
           this_rec->pos(), 
           &prob
-        );  
+        );
       }
-      
+
       tto = this_rec->time();
       
       double dt  = (tto-tfrom)/(tfrom == 0.0 ? 1.0 : tfrom);
@@ -497,9 +498,9 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
             newev->phantom_rec();
             newev->time(this_rec->time() + prob.alag(this_cmtn));
             newev->ss(0);
-            reclist::iterator it = a[i].begin()+j;
-            advance(it,1);
-            a[i].insert(it,newev);
+            reclist::iterator alagit = a[i].begin()+j;
+            advance(alagit,1);
+            a[i].insert(alagit,newev);
             newev->schedule(a[i], maxtime, put_ev_first, NN, Fn);
             this_rec->unarm();
             sort_recs = true;
@@ -552,6 +553,7 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
       if(!nocb && dat.any_copy) {
         if(this_rec->from_data()) {
           dat.copy_parameters(this_rec->pos(),&prob);
+          prob.lsoda_init();
         }
       }
       


### PR DESCRIPTION
Issue #745

- reset solver any time parameters are copied from the data
- see the issue; there were solver overshoot issues when time varying covariates changed parameter values; this is fixed by re-initializing solver whenever we copy parameters

 