### PR TITLE
capture pp def; re-factor mread capture error messages

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -183,21 +183,21 @@ as.cvec <- function(x) {
 }
 
 # collapse a character vector back to length n (undo strsplit)
-collapsen <- function(string,pattern,n=3) {
+collapsen <- function(string,collapse,n=3) {
     if(length(string) <= n) return(string)
-    if(n==1) return(paste0(string, collapse = pattern))
+    if(n==1) return(paste0(string, collapse = collapse))
     ans <- string[seq(1,(n-1))]
     if(n >= 2) {
-      remainder <- paste0(string[seq(n,length(string))],collapse=pattern)
+      remainder <- paste0(string[seq(n,length(string))],collapse=collapse)
       ans <- c(ans, remainder)  
     }
     ans
 }
 
 # replica str_split; to be replace if / when we take up stringr
-my_str_split <- function(string,pattern,n=3,fixed=FALSE) {
+my_str_split <- function(string,pattern,n=3,fixed=FALSE,collapse=pattern) {
   m <- strsplit(string, pattern, fixed = fixed)
-  lapply(m,collapsen,pattern=pattern,n=n)
+  lapply(m,collapsen,collapse=collapse,n=n)
 }
 
 ##' Create template data sets for simulation

--- a/inst/maintenance/unit/test-capture.R
+++ b/inst/maintenance/unit/test-capture.R
@@ -63,8 +63,17 @@ test_that("capture via mread", {
   mod <- mcode("capture-mread", code, capture = "Q,a=b,OGA2") 
   out <- outvars(mod)
   expect_equal(out$capture, c("CL", "VP", "Q", "a", "OGA2"))
-  expect_error(mread("pk1",modlib(),capture = "mrgsolve"))
+  expect_error(
+    mread("pk1",modlib(),capture = "mrgsolve"),
+    msg = "all requested `capture` variables must exist in the model"
+  )
   mod <- mcode("capture-mread", code, capture="(everything)", compile=FALSE)
   res <- c("CL","VP", "Q", "V3", "KA", "OGA2", "ETA_1", "ETA_2", "b")
   expect_equal(outvars(mod)$capture, res)
 })
+
+test_that("capture pp directive via mread", {
+  mod <- modlib("irm3", capture = "STIM", compile = FALSE)  
+  expect_equal(outvars(mod)$capture, c("CP", "STIM"))
+})
+

--- a/man/mread.Rd
+++ b/man/mread.Rd
@@ -34,6 +34,7 @@ mread_cache(
   soloc = getOption("mrgsolve.soloc", tempdir()),
   quiet = FALSE,
   preclean = FALSE,
+  capture = NULL,
   ...
 )
 


### PR DESCRIPTION
Issues #774 and #775 

# Summary

- refactor to provide better error message when requesting capture items via `mread()`
- when using `mread_cache`, force a re-build when `capture` items are passed
  - there may be some way to cache this as well but for now you are forced to rebuild from scratch
- scrape pre-processor definitions from `$GLOBAL` and let the user `capture` those as well via `mread()`
- there is also a minor re-factor of `my_str_split` which splits a string up to `n` chunks