### PR TITLE
Refactor simeta and simeps to accept n argument

### DIFF
--- a/inst/base/mrgsolv.h
+++ b/inst/base/mrgsolv.h
@@ -25,7 +25,7 @@
 #include <vector>
 #include <iostream>
 
-typedef void (*refun)(void*, unsigned int n);
+typedef void (*refun)(void*, int n);
 
 namespace mrgsolve {
 /**

--- a/inst/base/mrgsolv.h
+++ b/inst/base/mrgsolv.h
@@ -25,7 +25,7 @@
 #include <vector>
 #include <iostream>
 
-typedef void (*refun)(void*);
+typedef void (*refun)(void*, unsigned int n);
 
 namespace mrgsolve {
 /**
@@ -39,8 +39,8 @@ struct resim {
   //! resim constructor
   resim(refun x, void* y) : fun(x), prob(y){}
   resim(){}
-  void operator()() {
-    return fun(prob);
+  void operator()(int n = 0) {
+    return fun(prob, n);
   }
   
 protected: 

--- a/inst/maintenance/unit/test-plugin.R
+++ b/inst/maintenance/unit/test-plugin.R
@@ -56,7 +56,6 @@ $OMEGA 1 1 3
 
 $MAIN
 
-
 if(NEWIND <= 1) {
 
   double a = ETA(1);
@@ -69,6 +68,7 @@ if(NEWIND <= 1) {
     b = ETA(2);
     i++;
   }
+  
 }
 
 double c = ETA(3);

--- a/inst/maintenance/unit/test-simeta.R
+++ b/inst/maintenance/unit/test-simeta.R
@@ -1,0 +1,142 @@
+# Copyright (C) 2013 - 2021  Metrum Research Group
+#
+# This file is part of mrgsolve.
+#
+# mrgsolve is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# mrgsolve is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with mrgsolve.  If not, see <http://www.gnu.org/licenses/>.
+
+library(testthat)
+library(mrgsolve)
+library(dplyr)
+Sys.setenv(R_TESTS="")
+options("mrgsolve_mread_quiet"=TRUE)
+
+context("test-simeta.R")
+
+code <- '
+$PARAM n = 0, m = 0, mode = 1
+
+$OMEGA 2 2 2
+$SIGMA 2 2
+
+$MAIN
+
+if(mode==1) { 
+  simeta();
+  capture a = ETA(1); 
+  capture b = ETA(2); 
+  capture c = ETA(3);
+}
+
+if(mode==2) {
+  simeta(n); 
+  a = ETA(1); 
+  b = ETA(2); 
+  c = ETA(3);
+}
+
+if(mode==3) {
+  simeta(n); 
+  simeta(m);
+  a = ETA(1); 
+  b = ETA(2); 
+  c = ETA(3);
+}
+
+$ERROR
+if(mode==4) {
+  simeps(); 
+  a = EPS(1); 
+  b = EPS(2);
+}
+
+if(mode==5) {
+  simeps(n);
+  a = EPS(1);
+  b = EPS(2);
+  c = 9;
+}
+
+'
+mod <- mcode("simeta-n", code, end = 6, delta = 2)
+
+test_that("resimulate all eta", {
+  
+  # simeta with no argument
+  set.seed(1234)
+  all <- mrgsim_df(mod) 
+  all$ID <- NULL
+  expect_false(any(duplicated(unlist(all))))
+  
+  # Setting n = 0 is the same as no argument
+  set.seed(1234)
+  all2 <- mrgsim_df(mod, param = list(n = 0, mode = 2))
+  all2$ID <- NULL
+  expect_identical(all, all2)
+  
+})
+
+test_that("resimulate specific eta", {
+  
+  set.seed(5678)
+  # simeta with n = 1 (simeta(3))
+  n1 <-  mrgsim_df(mod, param = list(n = 1, mode = 2)) 
+  expect_true(all(n1$b==n1$b[1]))
+  expect_true(all(n1$c==n1$c[1]))
+  expect_false(any(duplicated(n1$a)))
+  
+  # simeta with n = 2 (simeta(2))
+  n2 <-  mrgsim(mod, param = list(n = 2, mode = 2))
+  expect_true(all(n2$a==n2$a[1]))
+  expect_true(all(n2$c==n2$c[1]))
+  expect_false(any(duplicated(n2$b)))
+  
+  # simeta with n = 3 (simeta(3))
+  n3 <-  mrgsim(mod, param = list(n = 3, mode = 2))
+  expect_true(all(n3$a==n3$a[1]))
+  expect_true(all(n3$b==n3$b[1]))
+  expect_false(any(duplicated(n3$c)))
+  
+  # simeta  with simeta(1) and simeta(3)
+  n13 <- mrgsim(mod, param = list(n = 1, m = 3,  mode = 3))
+  expect_true(all(n13$b==n13$b[1]))
+  expect_false(any(duplicated(n13$a)))
+  expect_false(any(duplicated(n13$c)))
+  
+})
+
+test_that("resimulate all or specific eps", {
+  data <- data.frame(amt = 0, evid = 0, time = c(0,0,0), cmt = 0, ID = 1)
+  set.seed(87654)
+  all <- mrgsim_df(mod, data = data, param = list(mode = 4))
+  all$ID <- NULL
+  all$c <- NULL
+  all$time <- NULL
+  expect_false(any(duplicated(unlist(all))))
+  
+  # simeps with n = 2 (simeps(2))
+  n <-  mrgsim(mod, data = data, param = list(n = 2, mode = 5))
+  expect_true(all(n$a==n$a[1]))
+  expect_false(any(duplicated(n$b)))
+})
+
+test_that("invalid value for n when calling simeta or simeps", {
+  expect_error(
+    mrgsim(mod, param = list(mode = 2, n = 100)), 
+    "simeta index out of bounds"
+  )
+  expect_error(
+    mrgsim(mod, param = list(mode = 5, n = 100)), 
+    "simeps index out of bounds"
+  )
+})

--- a/src/odeproblem.cpp
+++ b/src/odeproblem.cpp
@@ -30,10 +30,10 @@
 static Rcpp::NumericMatrix OMEGADEF(1,1);
 static arma::mat OMGADEF(1,1,arma::fill::zeros);
 
-void dosimeta(void* prob_, unsigned int n) {
+void dosimeta(void* prob_, int n) {
   odeproblem* prob = reinterpret_cast<odeproblem*>(prob_);
   arma::mat eta = prob->mv_omega(1);
-  if(n > eta.n_cols) {
+  if(n > int(eta.n_cols)) {
     throw Rcpp::exception("simeta index out of bounds", false);
   }
   if(n > 0) {
@@ -45,10 +45,10 @@ void dosimeta(void* prob_, unsigned int n) {
   }
 }
 
-void dosimeps(void* prob_, unsigned int n) {
+void dosimeps(void* prob_, int n) {
   odeproblem* prob = reinterpret_cast<odeproblem*>(prob_);
   arma::mat eps = prob->mv_sigma(1);
-  if(n > eps.n_cols) {
+  if(n > int(eps.n_cols)) {
     throw Rcpp::exception("simeps index out of bounds", false);
   }
   if(n > 0) {

--- a/src/odeproblem.cpp
+++ b/src/odeproblem.cpp
@@ -30,17 +30,31 @@
 static Rcpp::NumericMatrix OMEGADEF(1,1);
 static arma::mat OMGADEF(1,1,arma::fill::zeros);
 
-void dosimeta(void* prob_) {
+void dosimeta(void* prob_, unsigned int n) {
   odeproblem* prob = reinterpret_cast<odeproblem*>(prob_);
   arma::mat eta = prob->mv_omega(1);
+  if(n > eta.n_cols) {
+    throw Rcpp::exception("simeta index out of bounds", false);
+  }
+  if(n > 0) {
+    prob->eta(n-1,eta(0,n-1));
+    return;
+  }
   for(unsigned int i=0; i < eta.n_cols; ++i) {
     prob->eta(i,eta(0,i)); 
   }
 }
 
-void dosimeps(void* prob_) {
+void dosimeps(void* prob_, unsigned int n) {
   odeproblem* prob = reinterpret_cast<odeproblem*>(prob_);
   arma::mat eps = prob->mv_sigma(1);
+  if(n > eps.n_cols) {
+    throw Rcpp::exception("simeps index out of bounds", false);
+  }
+  if(n > 0) {
+    prob->eps(n-1,eps(0,n-1));
+    return;
+  }
   for(unsigned int i=0; i < eps.n_cols; ++i) {
     prob->eps(i,eps(0,i)); 
   }


### PR DESCRIPTION
# Summary
Add optional integer to `simeta()` and `simeps()` 
- exception when `n` is larger than the number of eta/eps
- when `n` is positive, we resimulate everything, but only copy `eta(n)` into the vector
- when `n` is zero (default) then we resimulate everything and copy everything so that the existing behavior is retained
- I wouldn't mind requiring `n` and **only** supporting the simulation of one eta; but going with this for now to just make it possible

# Questions for reviewers
I've never used default argument before, but seems to work?  

# Waiting on
- [ ] Tests
- [ ] Review

Looking to merge this into another feature. 