### PR TITLE
use expand.grid(KEEP.OUT.ATTRS = FALSE)

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -222,7 +222,7 @@ my_str_split <- function(string,pattern,n=3,fixed=FALSE,collapse=pattern) {
 ##' @md
 ##' @export
 expand.idata <- function(...) {
-  ans <- expand.grid(...,stringsAsFactors=FALSE)
+  ans <- expand.grid(...,stringsAsFactors=FALSE, KEEP.OUT.ATTRS = FALSE)
   ans$ID <- seq_len(nrow(ans))
   dplyr::select(ans, "ID", everything())
 }


### PR DESCRIPTION
dplyr 1.0.6, which we are about to release does a better job of keeping attributes around for bare data frames. Unfortunately, this means that the `out.attrs` generated by `expand.grid()` are no longer automatically dropped by some functions. 

This pull request just makes sure the attributes are not added to the result of `expand.grid()` since as far as I can see, these are not used anyway.

Alternatively I would recommend to use the 3rd edition of [testthat](https://testthat.r-lib.org/articles/third-edition.html) where you can `expect_equal(ignore_attr=TRUE)` thanks to `waldo`. 