### PR TITLE
Convert to data frame with Rcpp

### DIFF
--- a/R/mrgsim_q.R
+++ b/R/mrgsim_q.R
@@ -157,7 +157,7 @@ mrgsim_q <- function(x,
     PACKAGE = "mrgsolve"
   )[["data"]]
   
-  names(out) <- c("ID", tcol,x@cmtL,x@capL)
+  names(out) <- c("ID", tcol, x@cmtL, x@capL)
   
   if(output=="df") {
     return(out)  
@@ -169,9 +169,9 @@ mrgsim_q <- function(x,
   
   new(
     "mrgsims",
-    request=x@cmtL,
-    data=as.data.frame(out),
-    outnames=x@capL,
-    mod=x
+    request = x@cmtL,
+    data = out,
+    outnames = x@capL,
+    mod = x
   )
 }

--- a/R/mrgsim_q.R
+++ b/R/mrgsim_q.R
@@ -157,13 +157,14 @@ mrgsim_q <- function(x,
     PACKAGE = "mrgsolve"
   )[["data"]]
   
-  dimnames(out) <- list(NULL, c("ID", tcol,x@cmtL,x@capL))
+  names(out) <- c("ID", tcol,x@cmtL,x@capL)
   
   if(output=="df") {
-    return(as.data.frame(out))  
-  }
-  if(output=="matrix") {
     return(out)  
+  }
+  
+  if(output=="matrix") {
+    return(as.matrix(out))  
   }
   
   new(

--- a/R/mrgsolve.R
+++ b/R/mrgsolve.R
@@ -686,38 +686,40 @@ do_mrgsim <- function(x,
     cnames <- new_names
   }
 
-  ans <- out[["data"]]
-  names(ans) <- cnames
+  names(out[["data"]]) <- cnames
   
   if(do_recover_data || do_recover_idata) {
     if(do_recover_data) {
       if(!rename.recov$identical) {
         names(join_data) <- .ren.rename(rename.recov,names(join_data))
       }
-      ans <- left_join(ans,join_data,by=".data_row.",suffix=c("", ".recov"))  
-      ans$.data_row. <- NULL
+      out[["data"]] <- left_join(out[["data"]],join_data,by=".data_row.",suffix=c("", ".recov"))  
+      out[["data"]][[".data_row."]] <- NULL
     }
     if(do_recover_idata) {
       if(!rename.recov$identical) {
         names(join_idata) <- .ren.rename(rename.recov,names(join_idata))
       }
-      ans <- left_join(ans,join_idata,by="ID",suffix=c("", ".recov"))
+      out[["data"]] <- left_join(out[["data"]],join_idata,by="ID",suffix=c("", ".recov"))
     }
   }
   
   if(!is.null(output)) {
     if(output=="df") {
-      return(ans)  
+      return(out[["data"]])  
     }
     if(output=="matrix") {
-      return(out[["data"]])  
+      if(!all(sapply(out[["data"]], is.numeric))) {
+        stop("can't return matrix because non-numeric data was found.", call.=FALSE)  
+      }
+      return(data.matrix(out[["data"]]))
     }
   }
   
   new(
     "mrgsims",
     request = x@cmtL,
-    data = ans,
+    data = out[["data"]],
     outnames = x@capL,
     mod = x
   )

--- a/R/mrgsolve.R
+++ b/R/mrgsolve.R
@@ -687,12 +687,7 @@ do_mrgsim <- function(x,
     cnames <- new_names
   }
   
-  dimnames(out[["data"]]) <- list(NULL, cnames)
-  
-  ans <- as.data.frame.matrix(
-    out[["data"]], 
-    stringsAsFactors = FALSE
-  )
+  ans <- setNames(out[["data"]], cnames)
   
   if(do_recover_data || do_recover_idata) {
     if(do_recover_data) {
@@ -730,7 +725,8 @@ do_mrgsim <- function(x,
 
 #' Basic, simple simulation from model object
 #' 
-#' This is just a lighter version of [mrgsim], with fewer options.  See `Details`.  
+#' This is just a lighter version of [mrgsim()], with fewer options.  
+#' See `Details`.  
 #' 
 #' @inheritParams mrgsim
 #' 
@@ -758,7 +754,7 @@ do_mrgsim <- function(x,
 #' 
 #' out <- qsim(mod,dose)
 #' 
-#' @seealso [mrgsim_q], [mrgsim], [mrgsim_variants]
+#' @seealso [mrgsim_q()], [mrgsim()], [mrgsim_variants]
 #' 
 #' @md
 #' 
@@ -846,17 +842,17 @@ qsim <- function(x,
   )
   
   if(tad) tcol <- c(tcol,"tad")
-  
-  dimnames(out[["data"]]) <- list(NULL, c("ID", tcol,  x@cmtL, x@capL))
+
+  names(out[["data"]]) <- c("ID", tcol,  x@cmtL, x@capL)
   
   if(output=="df") {
-    return(as.data.frame.matrix(out[["data"]]))
+    return(out[["data"]])
   }
   
   new(
     "mrgsims",
     request=x@cmtL,
-    data=as.data.frame.matrix(out[["data"]]),
+    data=out[["data"]],
     outnames=x@capL,
     mod=x
   )

--- a/R/mrgsolve.R
+++ b/R/mrgsolve.R
@@ -637,7 +637,7 @@ do_mrgsim <- function(x,
     capture.output(file=capture, append=TRUE, print(data))
     capture.output(file=capture, append=TRUE, print(carry_out))
   }
-  
+
   out <- .Call(
     `_mrgsolve_DEVTRAN`,
     parin,
@@ -654,11 +654,10 @@ do_mrgsim <- function(x,
     PACKAGE = "mrgsolve"
   )
   
-  
   # out$trannames always comes back lower case in a specific order
   # need to rename to get back to requested case
   # Then, rename again for user-supplied renaming
-  carry.tran <- .ren.rename(rename.carry.tran,out[["trannames"]])
+  carry.tran <- .ren.rename(rename.carry.tran, out[["trannames"]])
   
   if(tad) tcol <- c(tcol,"tad")
   
@@ -686,8 +685,9 @@ do_mrgsim <- function(x,
     }
     cnames <- new_names
   }
-  
-  ans <- setNames(out[["data"]], cnames)
+
+  ans <- out[["data"]]
+  names(ans) <- cnames
   
   if(do_recover_data || do_recover_idata) {
     if(do_recover_data) {

--- a/R/mrgsolve.R
+++ b/R/mrgsolve.R
@@ -717,9 +717,9 @@ do_mrgsim <- function(x,
   new(
     "mrgsims",
     request = x@cmtL,
-    data=ans,
-    outnames=x@capL,
-    mod=x
+    data = ans,
+    outnames = x@capL,
+    mod = x
   )
 }
 
@@ -851,10 +851,10 @@ qsim <- function(x,
   
   new(
     "mrgsims",
-    request=x@cmtL,
-    data=out[["data"]],
-    outnames=x@capL,
-    mod=x
+    request = x@cmtL,
+    data = out[["data"]],
+    outnames = x@capL,
+    mod = x
   )
 }
 

--- a/inst/include/mrgsolve.h
+++ b/inst/include/mrgsolve.h
@@ -61,7 +61,7 @@ Rcpp::NumericMatrix EXPAND_EVENTS(const Rcpp::IntegerVector& idcol_,
                                   const Rcpp::NumericMatrix& events,
                                   const Rcpp::NumericVector& id); 
 
-Rcpp::List mat2df(Rcpp::NumericMatrix& x);
+Rcpp::List mat2df(Rcpp::NumericMatrix const& x);
   
 // Rcpp::NumericMatrix recdata(Rcpp::NumericMatrix& dose,
 //                             Rcpp::NumericMatrix& obs,

--- a/inst/include/mrgsolve.h
+++ b/inst/include/mrgsolve.h
@@ -61,6 +61,8 @@ Rcpp::NumericMatrix EXPAND_EVENTS(const Rcpp::IntegerVector& idcol_,
                                   const Rcpp::NumericMatrix& events,
                                   const Rcpp::NumericVector& id); 
 
+Rcpp::List mat2df(Rcpp::NumericMatrix& x);
+  
 // Rcpp::NumericMatrix recdata(Rcpp::NumericMatrix& dose,
 //                             Rcpp::NumericMatrix& obs,
 //                             Rcpp::IntegerVector& cols,

--- a/man/qsim.Rd
+++ b/man/qsim.Rd
@@ -64,7 +64,8 @@ default output object; other options include \code{df} (for data.frame) or
 \code{matrix}}
 }
 \description{
-This is just a lighter version of \link{mrgsim}, with fewer options.  See \code{Details}.
+This is just a lighter version of \code{\link[=mrgsim]{mrgsim()}}, with fewer options.
+See \code{Details}.
 }
 \details{
 There is no pipeline interface for this function; all configuration options
@@ -84,5 +85,5 @@ out <- qsim(mod,dose)
 
 }
 \seealso{
-\link{mrgsim_q}, \link{mrgsim}, \link{mrgsim_variants}
+\code{\link[=mrgsim_q]{mrgsim_q()}}, \code{\link[=mrgsim]{mrgsim()}}, \link{mrgsim_variants}
 }

--- a/src/devtran.cpp
+++ b/src/devtran.cpp
@@ -640,6 +640,6 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
   if((tscale != 1) && (tscale >= 0)) {
     ans(Rcpp::_,1) = ans(Rcpp::_,1) * tscale;
   }
-  return Rcpp::List::create(Rcpp::Named("data") = ans,
+  return Rcpp::List::create(Rcpp::Named("data") = mat2df(ans),
                             Rcpp::Named("trannames") = tran_names);
 }

--- a/src/mrgsolve.cpp
+++ b/src/mrgsolve.cpp
@@ -388,7 +388,7 @@ Rcpp::List EXPAND_OBSERVATIONS(
                             Rcpp::Named("index") = index);
 }
 
-Rcpp::List mat2df(Rcpp::NumericMatrix& x) {
+Rcpp::List mat2df(Rcpp::NumericMatrix const& x) {
   Rcpp::List ret(x.ncol());
   for(int i = 0; i < x.ncol(); ++i) {
     ret[i] = x(Rcpp::_,i);

--- a/src/mrgsolve.cpp
+++ b/src/mrgsolve.cpp
@@ -388,6 +388,19 @@ Rcpp::List EXPAND_OBSERVATIONS(
                             Rcpp::Named("index") = index);
 }
 
+Rcpp::List mat2df(Rcpp::NumericMatrix& x) {
+  Rcpp::List ret(x.ncol());
+  for(int i = 0; i < x.ncol(); ++i) {
+    ret[i] = x(Rcpp::_,i);
+  }
+  Rcpp::IntegerVector rn(2);
+  rn[0] = NA_INTEGER;
+  rn[1] = x.nrow()*-1;
+  ret.attr("class")  = "data.frame";
+  ret.attr("row.names") = rn;
+  return ret;
+}
+
 #endif
 
 

--- a/tests/testthat/test-carry_out.R
+++ b/tests/testthat/test-carry_out.R
@@ -106,3 +106,12 @@ test_that("recover input idata-set items", {
   expect_is(out$b,"character")
   expect_error(mrgsim_e(mod,idata,recover="b",carry_out="b"))
 })
+
+test_that("error to request matrix and recover character data", {
+  data <- expand.ev(amt = 100, group = "A")
+  expect_is(mrgsim(mod, data, recover = "group"), "mrgsims")
+  expect_error(
+    mrgsim(mod, data, recover = "group", output = "matrix"), 
+    msg = "can't return matrix because non-numeric data was found"
+  )
+})


### PR DESCRIPTION
# Summary
This pr implements `as.data.frame.matrix` in Rcpp so that we can pass back a data frame from the simulation code. The changes in this PR are not user-facing. 

The implementation follows `base::as.data.frame.matrix()`.