### PR TITLE
fix omega collate issue

### DIFF
--- a/R/class_matlist.R
+++ b/R/class_matlist.R
@@ -47,7 +47,7 @@ valid.matlist <- function(object) {
   }
   
   if(!x4) {
-    y <- which(sapply(object@data, det) < 0)
+    y <- which(!sapply(object@data, det) > 0)
     message("Problem with this matrix:")
     print(object@data[y])
     out <- c(out, "Invalid matrix: determinant is less than 0.")

--- a/R/matlist.R
+++ b/R/matlist.R
@@ -259,8 +259,10 @@ setMethod("as.list", "matlist", function(x, ...) x@data)
 #' @rdname matlist
 #' @export
 setMethod("as.matrix", "matlist", function(x, ...) {
-  if(length(x@data)==0) return(matrix(nrow=0,ncol=0))
-  SUPERMATRIX(x@data, ..., keep_names = FALSE)
+  if(length(x@data)==0) {
+    return(matrix(nrow = 0, ncol = 0))
+  }
+  SUPERMATRIX(x@data, ...)
 })
 
 #' @rdname matlist

--- a/R/matlist.R
+++ b/R/matlist.R
@@ -200,7 +200,6 @@ setMethod("smat", "mrgsims", function(.x,make=FALSE,...) {
   as.matrix(mod(.x)@sigma)
 })
 
-
 #' Zero out random effects in a model object
 #' 
 #' Sets all elements of the OMEGA or SIGMA matrix to zero
@@ -261,7 +260,7 @@ setMethod("as.list", "matlist", function(x, ...) x@data)
 #' @export
 setMethod("as.matrix", "matlist", function(x, ...) {
   if(length(x@data)==0) return(matrix(nrow=0,ncol=0))
-  SUPERMATRIX(x@data, ...)
+  SUPERMATRIX(x@data, ..., keep_names = FALSE)
 })
 
 #' @rdname matlist
@@ -335,13 +334,14 @@ cumoffset <- function(x) {
 ##' @rdname matlist_ops
 ##' @export
 setMethod("c", "matlist", function(x,...,recursive=FALSE) {
-  what <- c(list(x),list(...))
-  stopifnot(all(sapply(what,is.matlist)))
+  what <- c(list(x), list(...))
+  stopifnot(all(sapply(what, is.matlist)))
+  what <- what[sapply(what, slot, name = "n") > 0]
   if(length(what)==1) return(x)
-  d <- lapply(what,as.matrix)
-  d <- setNames(d,sapply(what,names))
+  d <- lapply(what, as.matrix)
+  d <- setNames(d, sapply(what, names))
   l <- sapply(unname(what), labels)
-  create_matlist(d,labels=l, class=class(x)[1])
+  create_matlist(d, labels = l, class = class(x)[1])
 })
 
 collapse_matrix <- function(x,class) {

--- a/R/matrix.R
+++ b/R/matrix.R
@@ -1,5 +1,4 @@
-# Copyright (C) 2013 - 2019  Metrum Research Group, LLC
-#
+# Copyright (C) 2013 - 2021  Metrum Research Group
 # This file is part of mrgsolve.
 #
 # mrgsolve is free software: you can redistribute it and/or modify it
@@ -17,6 +16,8 @@
 
 
 SUPERMATRIX <- function(x,keep_names=FALSE) {
+  stopifnot(is.list(x))
+  stopifnot(all(sapply(x, is.matrix)))
   x <- .Call(`_mrgsolve_SUPERMATRIX`,x,keep_names,PACKAGE="mrgsolve")
   if(nrow(x) > 0 & !keep_names) {
     dimnames(x) <- list(paste0(seq_len(nrow(x)), ": "), NULL)

--- a/R/matrix.R
+++ b/R/matrix.R
@@ -14,10 +14,10 @@
 # You should have received a copy of the GNU General Public License
 # along with mrgsolve.  If not, see <http://www.gnu.org/licenses/>.
 
-SUPERMATRIX <- function(x,keep_names=FALSE) {
+SUPERMATRIX <- function(x, keep_names = FALSE) {
   stopifnot(is.list(x))
   stopifnot(all(sapply(x, is.matrix)))
-  x <- .Call(`_mrgsolve_SUPERMATRIX`,x,keep_names,PACKAGE="mrgsolve")
+  x <- .Call(`_mrgsolve_SUPERMATRIX`, x, keep_names, PACKAGE = "mrgsolve")
   if(nrow(x) > 0 & !keep_names) {
     dimnames(x) <- list(paste0(seq_len(nrow(x)), ": "), NULL)
   }

--- a/R/matrix.R
+++ b/R/matrix.R
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with mrgsolve.  If not, see <http://www.gnu.org/licenses/>.
 
-
 SUPERMATRIX <- function(x,keep_names=FALSE) {
   stopifnot(is.list(x))
   stopifnot(all(sapply(x, is.matrix)))

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -7,6 +7,11 @@
 
 using namespace Rcpp;
 
+#ifdef RCPP_USE_GLOBAL_ROSTREAM
+Rcpp::Rostream<true>&  Rcpp::Rcout = Rcpp::Rcpp_cout_get();
+Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
+#endif
+
 // DEVTRAN
 Rcpp::List DEVTRAN(const Rcpp::List parin, const Rcpp::NumericVector& inpar, const Rcpp::CharacterVector& parnames, const Rcpp::NumericVector& init, Rcpp::CharacterVector& cmtnames, const Rcpp::IntegerVector& capture, const Rcpp::List& funs, const Rcpp::NumericMatrix& data, const Rcpp::NumericMatrix& idata, Rcpp::NumericMatrix& OMEGA, Rcpp::NumericMatrix& SIGMA, Rcpp::Environment envir);
 RcppExport SEXP _mrgsolve_DEVTRAN(SEXP parinSEXP, SEXP inparSEXP, SEXP parnamesSEXP, SEXP initSEXP, SEXP cmtnamesSEXP, SEXP captureSEXP, SEXP funsSEXP, SEXP dataSEXP, SEXP idataSEXP, SEXP OMEGASEXP, SEXP SIGMASEXP, SEXP envirSEXP) {

--- a/src/mrgsolve.cpp
+++ b/src/mrgsolve.cpp
@@ -150,6 +150,10 @@ void dcorr(Rcpp::NumericMatrix& x) {
 //[[Rcpp::export]]
 Rcpp::NumericMatrix SUPERMATRIX(const Rcpp::List& a, bool keep_names) {
   
+  if(a.size()==1) {
+    return a[0];  
+  }
+  
   int j,k;
   Rcpp::NumericMatrix mat;
   

--- a/tests/testthat/test-matlist.R
+++ b/tests/testthat/test-matlist.R
@@ -49,10 +49,10 @@ test_that("Indexing SIGMA matrix elements", {
   expect_equivalent(as.matrix(smat(mod))[3,3],0.3)
 })
 
-o1 <- 
-  omat(diag(c(1.1, 2.2, 3.3)), 
-       diag(c(4.4, 5.5, 6.6)), 
-       matrix(seq(91,99),nrow=3, byrow=TRUE))
+a <- diag(c(1.1, 2.2, 3.3))
+b <- diag(c(4.4, 5.5, 6.6))
+c <- matrix(seq(91,99),nrow = 3, byrow = TRUE)
+o1 <- omat(a,b,c)
 
 mat <- as.matrix(o1)
 

--- a/tests/testthat/test-matrix.R
+++ b/tests/testthat/test-matrix.R
@@ -43,7 +43,7 @@ test_that("SUPERMATRIX", {
     ml$a <- NULL
     ans <- mrgsolve:::SUPERMATRIX(ml[2])
     expect_identical(unname(ml[[2]]),unname(ans))
-    ans <- mrgsolve:::SUPERMATRIX(ml[1], keep_names=TRUE)
+    ans <- mrgsolve:::SUPERMATRIX(ml[1], keep_names = TRUE)
     expect_identical(ans, ml[[1]])
     ans1 <- mrgsolve:::SUPERMATRIX(list())
     expect_identical(ans1, matrix(0, nrow = 0, ncol = 0))

--- a/tests/testthat/test-matrix.R
+++ b/tests/testthat/test-matrix.R
@@ -45,4 +45,8 @@ test_that("SUPERMATRIX", {
     expect_identical(unname(ml[[2]]),unname(ans))
     ans <- mrgsolve:::SUPERMATRIX(ml[1], keep_names=TRUE)
     expect_identical(ans, ml[[1]])
+    ans1 <- mrgsolve:::SUPERMATRIX(list())
+    expect_identical(ans1, matrix(0, nrow = 0, ncol = 0))
+    ans2 <- mrgsolve:::SUPERMATRIX(omat()@data)
+    expect_identical(ans1, ans2)
 })

--- a/tests/testthat/test-matrix.R
+++ b/tests/testthat/test-matrix.R
@@ -31,7 +31,18 @@ test_that("Testing modMATRIX", {
     expect_equal(modMATRIX("0 0 0", use=FALSE), matrix(0,nrow=3,ncol=3))
 })
 
-
-
-
-
+test_that("SUPERMATRIX", {
+    ml <- list(matrix(1, 2, 2), matrix(3, 4, 4))
+    dimnames(ml[[1]]) <- list(c("a", "b"), c("A", "B"))
+    ans <- mrgsolve:::SUPERMATRIX(ml)
+    expect_is(ans, "matrix")
+    expect_equal(dim(ans), c(6, 6))
+    ml$a <- "a"
+    expect_error(mrgsolve:::SUPERMATRIX(ml), msg = "is not TRUE")
+    expect_error(mrgsolve:::SUPERMATRIX(ml[[1]]), msg = "is not TRUE")
+    ml$a <- NULL
+    ans <- mrgsolve:::SUPERMATRIX(ml[2])
+    expect_identical(unname(ml[[2]]),unname(ans))
+    ans <- mrgsolve:::SUPERMATRIX(ml[1], keep_names=TRUE)
+    expect_identical(ans, ml[[1]])
+})


### PR DESCRIPTION
# Summary

- When we use `$NMXML` to read in results, drop `OMEGA` results and ask for a different `$OMEGA` matrix in the model file, mrgsolve breaks when creating the `matlist` object.
- Modify `SUPERMATRIX` to just return the first matrix in the list when there is just one matrix.
- Add tests for `SUPERMATRIX`; these weren't already in the test suite and would have helped 
- Check types before calling `SUPERMATRIX`

# What this does

```r
> x <- list(diag(c(1,2,3)), diag(c(4,5,6,7)))
> mrgsolve:::SUPERMATRIX(x)
    [,1] [,2] [,3] [,4] [,5] [,6] [,7]
1:     1    0    0    0    0    0    0
2:     0    2    0    0    0    0    0
3:     0    0    3    0    0    0    0
4:     0    0    0    4    0    0    0
5:     0    0    0    0    5    0    0
6:     0    0    0    0    0    6    0
7:     0    0    0    0    0    0    7
```

See #863