### PR TITLE
Feature/autodec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,10 @@ check-winhub:
 .PHONY: doxygen
 doxygen: 
 	doxygen doxyfile
+	
+modlib: 
+	export _MRGSOLVE_SKIP_MODLIB_BUILD_=true
+	Rscript -e 'testthat::test_dir("inst/maintenance/unit")'
 
 # possibly no longer in use
 drone:

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,10 @@ test2:
 clean:
 	rm src/*.o
 	rm src/*.so
-	if [ -e mrgsolve.Rcheck ] rm -rf mrgsolve.Rchecks
+	if [ -d mrgsolve.Rcheck ]; then 
+	  rm -rf mrgsolve.Rcheck
+	fi
+	R CMD REMOVE mrgsolve
 
 datasets:
 	Rscript inst/maintenance/datasets.R

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PACKAGE=mrgsolve
 VERSION=$(shell grep Version DESCRIPTION |awk '{print $$2}')
 TARBALL=${PACKAGE}_${VERSION}.tar.gz
 PKGDIR=.
-export _MRGSOLVE_SKIP_MODLIB_BUILD_=true
+export _MRGSOLVE_SKIP_MODLIB_BUILD_=yes
 LOAD_CANDIDATE=library(mrgsolve, lib.loc="mrgsolve.Rcheck")
 TEST_UNIT=testthat::test_dir("inst/maintenance/unit",stop_on_failure=TRUE)
 
@@ -37,11 +37,11 @@ check-only:
 	make doc
 	R CMD check  ${TARBALL} --no-manual --no-test
 
+cran: export _MRGSOLVE_SKIP_MODLIB_BUILD_=no
 cran:
 	make house
 	make doc
 	make build
-	export _MRGSOLVE_SKIP_MODLIB_BUILD_=false
 	R CMD CHECK --as-cran ${TARBALL}
 
 spelling:
@@ -124,9 +124,9 @@ check-winhub:
 doxygen: 
 	doxygen doxyfile
 	
+modlib: export _MRGSOLVE_SKIP_MODLIB_BUILD_=no
 modlib: 
-	export _MRGSOLVE_SKIP_MODLIB_BUILD_=true
-	Rscript -e 'testthat::test_dir("inst/maintenance/unit")'
+	Rscript -e 'testthat::test_file("inst/maintenance/unit/test-modlib.R")'
 
 # possibly no longer in use
 drone:

--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,7 @@ test2:
 clean:
 	rm src/*.o
 	rm src/*.so
+	if [ -e mrgsolve.Rcheck ] rm -rf mrgsolve.Rchecks
 
 datasets:
 	Rscript inst/maintenance/datasets.R

--- a/R/Aaaa.R
+++ b/R/Aaaa.R
@@ -80,9 +80,10 @@ Reserved_cvar <- c("SOLVERTIME","table","ETA","EPS", "AMT", "CMT",
                    "ID", "TIME", "EVID","simeps", "self", "simeta",
                    "NEWIND", "DONE", "CFONSTOP", "DXDTZERO",
                    "CFONSTOP","INITSOLV","_F", "_R","_ALAG",
-                   "SETINIT", "report", "_VARS_", "VARS")
+                   "SETINIT", "report", "_VARS_", "VARS", 
+                   "SS_ADVANCE")
 
-Reserved <- c("ID", "amt", "cmt", "ii", "ss","evid",
+Reserved <- c("ID", "amt", "cmt", "ii", "ss", "evid",
               "addl", "rate","time", Reserved_cvar,
               "AMT", "CMT", "II", "SS", "ADDL", "RATE", "THETA",
               paste0("pred_", c("CL", "VC", "V", "V2", "KA", "Q", "VP", "V3")),

--- a/R/class_mrgmod.R
+++ b/R/class_mrgmod.R
@@ -86,15 +86,18 @@ check_us <- function(x,cmt,ans) {
 check_globals <- function(x,cmt) {
   ans <- character(0)
   us <-  any(charthere(x,"_"))
-  res <- any(is.element(x,Reserved_cvar))
+  res <- any(is.element(x, Reserved_cvar))
   if(res) {
-    tmp <- paste(x[is.element(x,Reserved_cvar)],collapse=" ")
-    ans <- c(ans,paste0("Reserved words in model names: ",tmp))
+    tmp <- paste(x[is.element(x, Reserved_cvar)],collapse=" ")
+    ans <- c(ans, paste0("Reserved words in model names: ",tmp))
   }
   if(us) {
     ans <- check_us(x,cmt,ans) 
   }
-  return(ans)
+  if(length(ans) > 0) {
+    stop(ans, call. = FALSE)
+  }
+  return(invisible(NULL))
 }
 
 protomod <- list(model=character(0),

--- a/R/compile.R
+++ b/R/compile.R
@@ -104,7 +104,6 @@ generate_rdefs <- function(pars,
           cmtdef,
           dxdef,
           pardef,
-          plugin[["nm-vars"]][["nm-def"]],
           etal,
           epsl
           )

--- a/R/model_include.R
+++ b/R/model_include.R
@@ -167,4 +167,8 @@ plugins[["nm-vars"]] <- list(
   code  = c("// nm-vars plugin", "#define _MRGSOLVE_USING_NM_VARS_")
 )
 
+plugins[["autodec"]] <- list(
+  name = "autodec", code = "// auto-dec plugin"
+)
+
 # nocov end

--- a/R/modlib.R
+++ b/R/modlib.R
@@ -55,7 +55,8 @@
 ##' mod <- mread("viral2", modlib())
 ##' mod <- mread("pred1",  modlib())
 ##' mod <- mread("pbpk",   modlib())
-##' mod <- mread("1005",   modlib()) # embedded NONMEM result
+##' mod <- mread("1005",   modlib())      # embedded NONMEM result
+##' mod <- mread('nm-example", moodlib()) # model with nonmem-like syntax
 ##' 
 ##' mrgsolve:::code(mod)
 ##' }
@@ -74,7 +75,7 @@ modlib <- function(model = NULL,...,list=FALSE)  {
 modlib_models <- c(
   "pk1cmt", "pk2cmt", "pk3cmt", "pk", "pk1", "pk2", "popex",
   "irm1", "irm2", "irm3", "pred1", "emax", "tmdd", "viral1", 
-  "viral2", "effect", "1005"
+  "viral2", "effect", "1005", "nm-example"
 )
 #nocov end
 
@@ -315,4 +316,3 @@ code <- function(x) {
   }
   return(what)
 }
-

--- a/R/modlib.R
+++ b/R/modlib.R
@@ -1,4 +1,4 @@
-# Copyright (C) 2013 - 2020  Metrum Research Group
+# Copyright (C) 2013 - 2021  Metrum Research Group
 #
 # This file is part of mrgsolve.
 #
@@ -56,7 +56,7 @@
 ##' mod <- mread("pred1",  modlib())
 ##' mod <- mread("pbpk",   modlib())
 ##' mod <- mread("1005",   modlib())      # embedded NONMEM result
-##' mod <- mread('nm-example", moodlib()) # model with nonmem-like syntax
+##' mod <- mread("nm-like", moodlib()) # model with nonmem-like syntax
 ##' 
 ##' mrgsolve:::code(mod)
 ##' }
@@ -75,7 +75,7 @@ modlib <- function(model = NULL,...,list=FALSE)  {
 modlib_models <- c(
   "pk1cmt", "pk2cmt", "pk3cmt", "pk", "pk1", "pk2", "popex",
   "irm1", "irm2", "irm3", "pred1", "emax", "tmdd", "viral1", 
-  "viral2", "effect", "1005", "nm-example"
+  "viral2", "effect", "1005", "nm-like"
 )
 #nocov end
 

--- a/R/modlib.R
+++ b/R/modlib.R
@@ -56,7 +56,7 @@
 ##' mod <- mread("pred1",  modlib())
 ##' mod <- mread("pbpk",   modlib())
 ##' mod <- mread("1005",   modlib())      # embedded NONMEM result
-##' mod <- mread("nm-like", moodlib()) # model with nonmem-like syntax
+##' mod <- mread("nm-like", modlib()) # model with nonmem-like syntax
 ##' 
 ##' mrgsolve:::code(mod)
 ##' }

--- a/R/modspec.R
+++ b/R/modspec.R
@@ -687,23 +687,28 @@ evaluate_at_code <- function(x, cl, block, pos, env = list(), named = FALSE) {
   x
 }
 
-find_autodec <- function(code) {
+autodec_find <- function(code) {
   keep <- grep("=", code, fixed = TRUE)
   code <- code[keep]
   if(length(code)==0) return(NULL)
-  ans <- regmatches(code, regexpr("[_[:alnum:]]+ *=[^=]?", code, perl = TRUE))
+  ans <- regmatches(code, regexpr("[_[:alnum:]]+ *=([^=]|$)", code, perl = TRUE))
   unique(sub(" *=.?$", "", ans, perl = TRUE))
+}
+
+autodec_vars <- function(code, rdefs, build) {
+  vars <- autodec_find(code)
+  rdefs <- strsplit(rdefs, " ", fixed = TRUE)
+  rdefs <- s_pick(rdefs, 2)
+  cpp <- build[["cpp_variables"]][["var"]]
+  vars <- setdiff(vars, c(Reserved, rdefs, Reserved_nm, cpp))  
+  vars
 }
 
 autodec_namespace <- function(plugin, code, rdefs, build) {
   if(!("autodec" %in% names(plugin))) {
     return(NULL)  
   }
-  vars <- find_autodec(code)
-  rdefs <- strsplit(rdefs, " ", fixed = TRUE)
-  rdefs <- s_pick(rdefs, 2)
-  cpp <- build[["cpp_variables"]][["var"]]
-  vars <- setdiff(vars, c(Reserved, rdefs, Reserved_nm, cpp))
+  vars <- autodec_vars(code, rdefs, build)
   ans <- paste0("  double ", vars, ";")
   wrap_namespace(ans, "")
 }

--- a/R/modspec.R
+++ b/R/modspec.R
@@ -687,6 +687,31 @@ evaluate_at_code <- function(x, cl, block, pos, env = list(), named = FALSE) {
   x
 }
 
+get_valid_capture <- function(param, omega, sigma, build, mread.env) {
+  n_omega <- sum(nrow(omega))
+  if(n_omega > 0) {
+    .eta <- paste0("ETA(",seq_len(n_omega),")")  
+  } else {
+    .eta <- NULL  
+  }
+  n_sigma <- sum(nrow(sigma))
+  if(n_sigma > 0) {
+    .eps <- paste0("EPS(",seq_len(n_sigma),")")
+  } else {
+    .eps <- NULL  
+  }
+  ans <- c(
+    names(param), 
+    unlist(labels(omega)), 
+    unlist(labels(sigma)),
+    .eta,
+    .eps,
+    build[["cpp_variables"]][["var"]], 
+    mread.env[["autov"]]
+  )
+  unique(ans)
+}
+
 #' Find assignments and capture lhs
 #' 
 #' @keywords internal

--- a/R/modspec.R
+++ b/R/modspec.R
@@ -687,4 +687,23 @@ evaluate_at_code <- function(x, cl, block, pos, env = list(), named = FALSE) {
   x
 }
 
+find_autodec <- function(code) {
+  keep <- grep("=", code, fixed = TRUE)
+  code <- code[keep]
+  if(length(code)==0) return(NULL)
+  ans <- regmatches(code, regexpr("[_[:alnum:]]+ *=[^=]?", code, perl = TRUE))
+  unique(sub(" *=.?$", "", ans, perl = TRUE))
+}
 
+autodec_namespace <- function(plugin, code, rdefs, build) {
+  if(!("autodec" %in% names(plugin))) {
+    return(NULL)  
+  }
+  vars <- find_autodec(code)
+  rdefs <- strsplit(rdefs, " ", fixed = TRUE)
+  rdefs <- s_pick(rdefs, 2)
+  cpp <- build[["cpp_variables"]][["var"]]
+  vars <- setdiff(vars, c(Reserved, rdefs, Reserved_nm, cpp))
+  ans <- paste0("  double ", vars, ";")
+  wrap_namespace(ans, "")
+}

--- a/R/modspec.R
+++ b/R/modspec.R
@@ -687,6 +687,10 @@ evaluate_at_code <- function(x, cl, block, pos, env = list(), named = FALSE) {
   x
 }
 
+#' Find assignments and capture lhs
+#' 
+#' @keywords internal
+#' @noRd
 autodec_find <- function(code) {
   keep <- grep("=", code, fixed = TRUE)
   code <- code[keep]
@@ -698,7 +702,11 @@ autodec_find <- function(code) {
   ans[!grepl(".", ans, fixed = TRUE)]
 }
 
-autodec_vars <- function(code, rdefs, build, blocks = NULL) {
+#' Call `autodec_find` ona list of code chunks
+#' 
+#' @keywords internal
+#' @noRd
+autodec_vars <- function(code, blocks = NULL) {
   if(is.null(code)) return(NULL)
   if(is.list(code)) {
     code <- unlist(code[blocks], use.names = FALSE)  
@@ -706,6 +714,19 @@ autodec_vars <- function(code, rdefs, build, blocks = NULL) {
   autodec_find(code)
 }
 
+#' Clean up `autodec` candidates
+#' 
+#' @details 
+#' 
+#' Remove
+#' 
+#' - Anything already showing up as a pre-processor definition
+#' - Anyting that is in a reserved word list
+#' - Anything that already was declared with a type
+#' 
+#' @md
+#' @keywords internal
+#' @noRd
 autodec_clean <- function(vars, rdefs, build) {
   rdefs <- strsplit(rdefs, " ", fixed = TRUE)
   rdefs <- s_pick(rdefs, 2)
@@ -714,6 +735,10 @@ autodec_clean <- function(vars, rdefs, build) {
   vars
 }
 
+#' Format and save `autodec` to be used later
+#' 
+#' @keywords internal
+#' @noRd
 autodec_save <- function(vars, build, env) {
   if(length(vars) ==0) {
     env[["autov"]] <- NULL
@@ -730,6 +755,10 @@ autodec_save <- function(vars, build, env) {
   return(invisible(NULL))
 }
 
+#' Format `autodec` as an unnamed namespace 
+#' 
+#' @keywords internal
+#' @noRd
 autodec_namespace <- function(build, env) {
   if(length(env[["autov"]])==0) {
     return(NULL)      

--- a/R/modspec.R
+++ b/R/modspec.R
@@ -43,8 +43,31 @@ write_capture <- function(x) {
 ## can be stated in $SET and then passed to mrgsim
 set_args <- c(
   "Req", "obsonly", "recsort",
-  "carry.out","Trequest","trequest"
+  "carry.out","Trequest","trequest", 
+  "carry_out", "Request"
 )
+
+set_simargs <- function(x, SET) {
+  simargs <- SET[is.element(names(SET), set_args)]
+  if(length(simargs) > 0) {
+    x@args <- combine_list(x@args, simargs)
+  }   
+  x
+}
+
+check_pkmodel <- function(x, subr, spec) {
+  # ADVAN 13 is the ODEs
+  # Two compartments for ADVAN 2, 3 compartments for ADVAN 4
+  # Check $MAIN for the proper symbols
+  if(x@advan %in% c(1,2,3,4)) {
+    if(subr[["n"]] != neq(x)) {
+      stop("$PKMODEL requires  ", subr[["n"]] , 
+           " compartments in $CMT or $INIT.", call. = FALSE)
+    }
+    check_pred_symbols(x, spec[["MAIN"]])
+  }
+  return(invisible(NULL))
+}
 
 check_spec_contents <- function(x, crump = TRUE, warn = TRUE, ...) {
   invalid <- setdiff(x,block_list)

--- a/R/modspec.R
+++ b/R/modspec.R
@@ -690,9 +690,12 @@ evaluate_at_code <- function(x, cl, block, pos, env = list(), named = FALSE) {
 autodec_find <- function(code) {
   keep <- grep("=", code, fixed = TRUE)
   code <- code[keep]
-  if(length(code)==0) return(NULL)
-  ans <- regmatches(code, regexpr("[_[:alnum:]]+ *=([^=]|$)", code, perl = TRUE))
-  unique(sub(" *=.?$", "", ans, perl = TRUE))
+  if(length(code)==0) {
+    return(NULL)
+  }
+  ans <- regmatches(code, regexpr("[._[:alnum:]]+ *=([^=]|$)", code, perl = TRUE))
+  ans <- unique(sub(" *=.?$", "", ans, perl = TRUE))
+  ans[!grepl(".", ans, fixed = TRUE)]
 }
 
 autodec_vars <- function(code, rdefs, build) {

--- a/R/mread.R
+++ b/R/mread.R
@@ -209,7 +209,7 @@ mread <- function(model, project = getOption("mrgsolve.project", getwd()),
   ENV <- eval_ENV_block(spec[["ENV"]],build$project)
   if("SET" %in% names(spec)) spec[["SET"]] <- ""
   if("ENV" %in% names(spec)) spec[["ENV"]] <- ""
-
+  
   # Make a list of NULL equal to length of spec
   # Each code block can contribute to / occupy one
   # slot for each of param/fixed/init/omega/sigma
@@ -449,6 +449,13 @@ mread <- function(model, project = getOption("mrgsolve.project", getwd()),
     dbsyms = args[["dbsyms"]]
   )
   
+  autodec_reals <- autodec_namespace(
+    plugin, 
+    code = unlist(spec[c("PREAMBLE", "MAIN", "ODE", "TABLE")], use.names=FALSE),
+    rdefs = rd, 
+    build = build
+  )
+  
   ## IN soloc directory
   cwd <- getwd()
   setwd(build$soloc)
@@ -490,6 +497,7 @@ mread <- function(model, project = getOption("mrgsolve.project", getwd()),
     "\n// GLOBAL CODE BLOCK:",
     "// GLOBAL VARS FROM BLOCKS & TYPEDEFS:",
     mread.env[["global"]],
+    autodec_reals,
     "\n// GLOBAL START USER CODE:",
     spec[["GLOBAL"]],
     "\n// DEFS:",

--- a/R/mread.R
+++ b/R/mread.R
@@ -354,10 +354,13 @@ mread <- function(model, project = getOption("mrgsolve.project", getwd()),
     spec[["ODE"]] <- c(spec[["ODE"]], paste0("dxdt_", vcmt, "=0;"))
   }
   
-  ## Handle nm-vars plugin
+  # Handle nm-vars plugin
+  # This needs to happen before rdefs
   if("nm-vars" %in% names(plugin)) {
     nmv  <- find_nm_vars(spec)
-    plugin[["nm-vars"]][["nm-def"]] <- generate_nmdefs(nmv)
+    dfs <- generate_nmdefs(nmv)
+    rd <- c(rd, dfs)
+    plugin[["nm-vars"]][["nm-def"]] <- dfs
     build[["nm-vars"]] <- nmv
     audit_nm_vars(
       spec,
@@ -369,6 +372,7 @@ mread <- function(model, project = getOption("mrgsolve.project", getwd()),
     )
     audit <- FALSE
   }
+
   # autodec
   if("autodec" %in% names(plugin)) {
     auto_blocks <- c("PREAMBLE", "MAIN", "PRED", "ODE", "TABLE")

--- a/R/nm-mode.R
+++ b/R/nm-mode.R
@@ -51,7 +51,7 @@ find_nm_vars <- function(spec) {
 find_nm_vars_impl <- function(code) {
   nul <- data.frame(V1 = 0, V2 = 0, V3 = 0)[0,]
   if(!is.character(code)) return(nul)
-  re1 <- "(A|A_0|DADT)\\(([0-9]+)\\)"
+  re1 <- "\\b(A|A_0|DADT)\\(([0-9]+)\\)"
   re2 <- "\\b(F|R|D|ALAG)([0-9]+)\\b"
   # gregexec exists in R 4.1; rolling my own for now
   m1 <- gregexecdf(re1, code) 

--- a/inst/maintenance/unit/test-misc-syntax.R
+++ b/inst/maintenance/unit/test-misc-syntax.R
@@ -19,3 +19,17 @@ test_that("THETA(n) is allowed", {
     regexp="Reserved words in model names: THETA"
   )
 })
+
+test_that("autodec + nm-vars functional test2", {
+  eps <- 1e-4
+  mod <- modlib("nm-like", delta = 0.1, preclean = TRUE, capture = "KA,INH")  
+  dose <- ev(amt = 100, D2I = 2, cmt = 2, rate = -2)
+  out <- mrgsim(mod, dose)
+  tmax <- out$time[which.max(out$A2)]
+  expect_true((tmax-2) < eps)
+  expect_true(all(out$KA==mod$THETA3))
+  expect_true("INH" %in% names(out))
+  dose <- ev(amt = 100, cmt = 1, F1I = 0.81)
+  out <- mrgsim(mod, dose)
+  expect_true((out$A1[2]-0.81*dose$amt[1]) < eps)
+})

--- a/inst/maintenance/unit/test-misc-syntax.R
+++ b/inst/maintenance/unit/test-misc-syntax.R
@@ -26,10 +26,10 @@ test_that("autodec + nm-vars functional test2", {
   dose <- ev(amt = 100, D2I = 2, cmt = 2, rate = -2)
   out <- mrgsim(mod, dose)
   tmax <- out$time[which.max(out$A2)]
-  expect_true((tmax-2) < eps)
+  expect_true(abs(tmax-2) < eps)
   expect_true(all(out$KA==mod$THETA3))
   expect_true("INH" %in% names(out))
   dose <- ev(amt = 100, cmt = 1, F1I = 0.81)
   out <- mrgsim(mod, dose)
-  expect_true((out$A1[2]-0.81*dose$amt[1]) < eps)
+  expect_true(abs(out$A1[2]-0.81*dose$amt[1]) < eps)
 })

--- a/inst/maintenance/unit/test-modlib.R
+++ b/inst/maintenance/unit/test-modlib.R
@@ -100,7 +100,7 @@ test_that("all modlib models", {
   expect_is(x[[1]],"mrgmod")
   expect_is(x[[2]],"mrgsims")
   
-  x <- test_lib("nm-example")
+  x <- test_lib("nm-like")
   expect_is(x[[1]],"mrgmod")
   expect_is(x[[2]],"mrgsims")
 

--- a/inst/maintenance/unit/test-modlib.R
+++ b/inst/maintenance/unit/test-modlib.R
@@ -32,7 +32,7 @@ test_that("all modlib models", {
   }
   
   skip_if(
-    identical(Sys.getenv("_MRGSOLVE_SKIP_MODLIB_BUILD_"),"true"), 
+    identical(Sys.getenv("_MRGSOLVE_SKIP_MODLIB_BUILD_"),"true"),
     message = "skipping modlib builds"
   )
   
@@ -99,6 +99,11 @@ test_that("all modlib models", {
   x <- test_lib("pred1")
   expect_is(x[[1]],"mrgmod")
   expect_is(x[[2]],"mrgsims")
+  
+  x <- test_lib("nm-example")
+  expect_is(x[[1]],"mrgmod")
+  expect_is(x[[2]],"mrgsims")
+
 })
 
 test_that("pk2iv uses V1 to scale CENT", {

--- a/inst/maintenance/unit/test-modlib.R
+++ b/inst/maintenance/unit/test-modlib.R
@@ -32,7 +32,7 @@ test_that("all modlib models", {
   }
   
   skip_if(
-    identical(Sys.getenv("_MRGSOLVE_SKIP_MODLIB_BUILD_"),"true"),
+    Sys.getenv("_MRGSOLVE_SKIP_MODLIB_BUILD_") == "yes",
     message = "skipping modlib builds"
   )
   

--- a/inst/models/MODLIST
+++ b/inst/models/MODLIST
@@ -17,3 +17,4 @@ popex
 pred1
 pbpk
 1005
+nm-example

--- a/inst/models/MODLIST
+++ b/inst/models/MODLIST
@@ -17,4 +17,4 @@ popex
 pred1
 pbpk
 1005
-nm-example
+nm-like

--- a/inst/models/nm-like.cpp
+++ b/inst/models/nm-like.cpp
@@ -3,7 +3,7 @@ $PROB Model written with some nonmem-like syntax features
 $PLUGIN nm-vars autodec
 
 $PARAM
-THETA1 = 1, THETA2 = 21, THETA3 = 1.3, WT = 70, F1I = 0.5
+THETA1 = 1, THETA2 = 21, THETA3 = 1.3, WT = 70, F1I = 0.5, D2I = 2
 KIN = 100, KOUT = 0.1, IC50 = 10, IMAX = 0.9
 
 $CMT @number 3
@@ -14,6 +14,7 @@ V  = THETA(2);
 KA = THETA(3);
 
 F1 = F1I;
+D2 = D2I;
 A_0(3) = KIN / KOUT;
 
 $DES 

--- a/inst/models/nm-like.cpp
+++ b/inst/models/nm-like.cpp
@@ -22,7 +22,7 @@ INH = IMAX*CP/(IC50 + CP);
   
 DADT(1) = -KA*A(1);
 DADT(2) =  KA*A(1) - (CL/V)*A(2);
-DADT(3) = KIN * (1-INH) - KOUT * A(3);
+DADT(3) =  KIN * (1-INH) - KOUT * A(3);
 
 $ERROR
 CP = A(2)/V;

--- a/inst/models/nm-like.cpp
+++ b/inst/models/nm-like.cpp
@@ -1,14 +1,14 @@
-[ prob ] Model written with some nonmem-like syntax features
+$PROB Model written with some nonmem-like syntax features
 
-[ plugin ] nm-vars autodec
+$PLUGIN nm-vars autodec
 
-[ param ] 
+$PARAM
 THETA1 = 1, THETA2 = 21, THETA3 = 1.3, WT = 70, F1I = 0.5
 KIN = 100, KOUT = 0.1, IC50 = 10, IMAX = 0.9
 
-[ cmt ] @number 3
+$CMT @number 3
 
-[ pk ] 
+$PK
 CL = THETA(1) * pow(WT/70, 0.75); 
 V  = THETA(2); 
 KA = THETA(3);
@@ -16,7 +16,7 @@ KA = THETA(3);
 F1 = F1I;
 A_0(3) = KIN / KOUT;
 
-[ des ] 
+$DES 
 DADT(1) = -KA*A(1);
 DADT(2) =  KA*A(1) - (CL/V)*A(2);
 
@@ -24,5 +24,5 @@ CP = A(2)/V;
 INH = IMAX*CP/(IC50 + CP);
 DADT(3) = KIN * (1-INH) - KOUT * A(3);
 
-[ error ] 
+$ERROR
 CP = A(2)/V;

--- a/inst/models/nm-like.cpp
+++ b/inst/models/nm-like.cpp
@@ -17,11 +17,11 @@ F1 = F1I;
 A_0(3) = KIN / KOUT;
 
 $DES 
-DADT(1) = -KA*A(1);
-DADT(2) =  KA*A(1) - (CL/V)*A(2);
-
 CP = A(2)/V;
 INH = IMAX*CP/(IC50 + CP);
+  
+DADT(1) = -KA*A(1);
+DADT(2) =  KA*A(1) - (CL/V)*A(2);
 DADT(3) = KIN * (1-INH) - KOUT * A(3);
 
 $ERROR

--- a/inst/models/nm-like.cpp
+++ b/inst/models/nm-like.cpp
@@ -1,0 +1,28 @@
+[ prob ] Model written with some nonmem-like syntax features
+
+[ plugin ] nm-vars autodec
+
+[ param ] 
+THETA1 = 1, THETA2 = 21, THETA3 = 1.3, WT = 70, F1I = 0.5
+KIN = 100, KOUT = 0.1, IC50 = 10, IMAX = 0.9
+
+[ cmt ] @number 3
+
+[ pk ] 
+CL = THETA(1) * pow(WT/70, 0.75); 
+V  = THETA(2); 
+KA = THETA(3);
+
+F1 = F1I;
+A_0(3) = KIN / KOUT;
+
+[ des ] 
+DADT(1) = -KA*A(1);
+DADT(2) =  KA*A(1) - (CL/V)*A(2);
+
+CP = A(2)/V;
+INH = IMAX*CP/(IC50 + CP);
+DADT(3) = KIN * (1-INH) - KOUT * A(3);
+
+[ error ] 
+CP = A(2)/V;

--- a/man/modlib.Rd
+++ b/man/modlib.Rd
@@ -28,28 +28,3 @@ Call \code{modlib(list=TRUE)} to list available models.  Once the model
 is loaded (see examples below), call \code{as.list(mod)$code} to see
 model code and equations.
 }
-\examples{
-\dontrun{
-mod <- mread("pk1cmt", modlib())
-mod <- mread("pk2cmt", modlib()) 
-mod <- mread("pk3cmt", modlib()) 
-mod <- mread("pk1",    modlib())
-mod <- mread("pk2",    modlib())
-mod <- mread("popex",  modlib())
-mod <- mread("irm1",   modlib()) 
-mod <- mread("irm2",   modlib()) 
-mod <- mread("irm3",   modlib()) 
-mod <- mread("irm4",   modlib())
-mod <- mread("emax",   modlib())
-mod <- mread("effect", modlib())
-mod <- mread("tmdd",   modlib())
-mod <- mread("viral1", modlib())
-mod <- mread("viral2", modlib())
-mod <- mread("pred1",  modlib())
-mod <- mread("pbpk",   modlib())
-mod <- mread("1005",   modlib()) # embedded NONMEM result
-
-mrgsolve:::code(mod)
-}
-
-}

--- a/man/modlib.Rd
+++ b/man/modlib.Rd
@@ -48,7 +48,7 @@ mod <- mread("viral2", modlib())
 mod <- mread("pred1",  modlib())
 mod <- mread("pbpk",   modlib())
 mod <- mread("1005",   modlib())      # embedded NONMEM result
-mod <- mread("nm-like", moodlib()) # model with nonmem-like syntax
+mod <- mread("nm-like", modlib()) # model with nonmem-like syntax
 
 mrgsolve:::code(mod)
 }

--- a/man/modlib.Rd
+++ b/man/modlib.Rd
@@ -28,3 +28,29 @@ Call \code{modlib(list=TRUE)} to list available models.  Once the model
 is loaded (see examples below), call \code{as.list(mod)$code} to see
 model code and equations.
 }
+\examples{
+\dontrun{
+mod <- mread("pk1cmt", modlib())
+mod <- mread("pk2cmt", modlib()) 
+mod <- mread("pk3cmt", modlib()) 
+mod <- mread("pk1",    modlib())
+mod <- mread("pk2",    modlib())
+mod <- mread("popex",  modlib())
+mod <- mread("irm1",   modlib()) 
+mod <- mread("irm2",   modlib()) 
+mod <- mread("irm3",   modlib()) 
+mod <- mread("irm4",   modlib())
+mod <- mread("emax",   modlib())
+mod <- mread("effect", modlib())
+mod <- mread("tmdd",   modlib())
+mod <- mread("viral1", modlib())
+mod <- mread("viral2", modlib())
+mod <- mread("pred1",  modlib())
+mod <- mread("pbpk",   modlib())
+mod <- mread("1005",   modlib())      # embedded NONMEM result
+mod <- mread("nm-like", moodlib()) # model with nonmem-like syntax
+
+mrgsolve:::code(mod)
+}
+
+}

--- a/tests/testthat/test-modspec.R
+++ b/tests/testthat/test-modspec.R
@@ -410,21 +410,22 @@ test_that("parse content using low-level handlers - OMEGA, SIGMA", {
 test_that("autodec", {
   x <- mrgsolve:::autodec_find("a = 1;")  
   expect_equal(x, "a")
-  x <- mrgsolve:::autodec_find("a == 1;")  
-  expect_equal(x, character(0))
-  x <- mrgsolve:::autodec_find("if(x == 2) y = 3;")  
-  expect_equal(x, "y")
-  x <- mrgsolve:::autodec_find("if(NEWIND <= 1 ) {")  
-  expect_equal(x, character(0))
-  x <- mrgsolve:::autodec_find("if(NEWIND >= 1 ) {")  
-  expect_equal(x, character(0))
-  x <- mrgsolve:::autodec_find("if(NEWIND != 1 ) {")  
-  expect_equal(x, character(0))
+  x <- mrgsolve:::autodec_find("a=1;")  
+  expect_equal(x, "a")
   x <- mrgsolve:::autodec_find("double a_2 = 1;")
   expect_equal(x, "a_2")
+  x <- mrgsolve:::autodec_find("if(x == 2) y = 3;")  
+  expect_equal(x, "y")
+  x <- mrgsolve:::autodec_find("a == 1;")  
+  expect_equal(x, character(0))
+  x <- mrgsolve:::autodec_find("if(NEWIND <= 1 ) {")  
+  expect_equal(x, character(0))
+  x <- mrgsolve:::autodec_find("if(EVID >= 1 ) {")  
+  expect_equal(x, character(0))
+  x <- mrgsolve:::autodec_find("if(TIME != 1 ) {")  
+  expect_equal(x, character(0))
   x <- mrgsolve:::autodec_find("self.foo = 1;")
   expect_equal(x, character(0))
-  
   code <- strsplit(split = "\n", '
     double a = 2;
     b = 3;

--- a/tests/testthat/test-modspec.R
+++ b/tests/testthat/test-modspec.R
@@ -109,7 +109,7 @@ test_that("Commented model", {
   $CAPTURE 
     kaya = KA // Capturing KA
   ' 
-
+  
   expect_is(mod <- mcode("commented", code,compile=FALSE),"mrgmod")
   expect_identical(param(mod),param(CL=2,VC=10,KA=3))
   expect_identical(init(mod),init(x=0,y=3,h=3))
@@ -162,7 +162,7 @@ test_that("HANDLEMATRIX", {
 })
 
 test_that("inventory of internal variables", {
-code <- '
+  code <- '
 [ global ] 
 #define a 1
 int b = 2; 
@@ -405,4 +405,28 @@ test_that("parse content using low-level handlers - OMEGA, SIGMA", {
     mrgsolve:::HANDLEMATRIX(x = "123", object = "parameters", as_object = TRUE), 
     "cannot have both @object and @as_object in a block"
   )
+})
+
+test_that("autodec", {
+  a <- mrgsolve:::autodec_find("a = 1;")  
+  expect_equal(a, "a")
+  b <- mrgsolve:::autodec_find("a == 1;")  
+  expect_equal(b, character(0))
+  c <- mrgsolve:::autodec_find("if(x == 2) y = 3;")  
+  expect_equal(c, "y")
+  d <- mrgsolve:::autodec_find("if(NEWIND <=1 ) {")  
+  expect_equal(d, character(0))
+  code <- strsplit(split = "\n", '
+    double a = 2;
+    b = 3;
+    if(c==2) d = 1;
+    b=(123);
+    k = 
+  ')[[1]]
+  e <- mrgsolve:::autodec_vars(
+    code, 
+    rdefs = "#define h j", 
+    build = new.env()
+  )
+  expect_equal(e, c("a", "b", "d", "k"))
 })

--- a/tests/testthat/test-modspec.R
+++ b/tests/testthat/test-modspec.R
@@ -408,14 +408,23 @@ test_that("parse content using low-level handlers - OMEGA, SIGMA", {
 })
 
 test_that("autodec", {
-  a <- mrgsolve:::autodec_find("a = 1;")  
-  expect_equal(a, "a")
-  b <- mrgsolve:::autodec_find("a == 1;")  
-  expect_equal(b, character(0))
-  c <- mrgsolve:::autodec_find("if(x == 2) y = 3;")  
-  expect_equal(c, "y")
-  d <- mrgsolve:::autodec_find("if(NEWIND <=1 ) {")  
-  expect_equal(d, character(0))
+  x <- mrgsolve:::autodec_find("a = 1;")  
+  expect_equal(x, "a")
+  x <- mrgsolve:::autodec_find("a == 1;")  
+  expect_equal(x, character(0))
+  x <- mrgsolve:::autodec_find("if(x == 2) y = 3;")  
+  expect_equal(x, "y")
+  x <- mrgsolve:::autodec_find("if(NEWIND <= 1 ) {")  
+  expect_equal(x, character(0))
+  x <- mrgsolve:::autodec_find("if(NEWIND >= 1 ) {")  
+  expect_equal(x, character(0))
+  x <- mrgsolve:::autodec_find("if(NEWIND != 1 ) {")  
+  expect_equal(x, character(0))
+  x <- mrgsolve:::autodec_find("double a_2 = 1;")
+  expect_equal(x, "a_2")
+  x <- mrgsolve:::autodec_find("self.foo = 1;")
+  expect_equal(x, character(0))
+  
   code <- strsplit(split = "\n", '
     double a = 2;
     b = 3;
@@ -423,10 +432,10 @@ test_that("autodec", {
     b=(123);
     k = 
   ')[[1]]
-  e <- mrgsolve:::autodec_vars(
+  x <- mrgsolve:::autodec_vars(
     code, 
     rdefs = "#define h j", 
     build = new.env()
   )
-  expect_equal(e, c("a", "b", "d", "k"))
+  expect_equal(x, c("a", "b", "d", "k"))
 })

--- a/tests/testthat/test-modspec.R
+++ b/tests/testthat/test-modspec.R
@@ -439,4 +439,21 @@ test_that("autodec", {
     build = new.env()
   )
   expect_equal(x, c("a", "b", "d", "k"))
+  
+  code <- '
+  [ param ] tvcl = 1, tvvc = 2
+  [ plugin ] autodec
+  [ main ] 
+  cl = tvcl;
+  v2 = tvvc;
+  ka = 1;
+  double F1 = 0.9;
+  [ table ] 
+  double err = EPS(1);
+  CP = cent/v2;
+  '
+  mod <- mcode("autodec1", code, compile = FALSE)
+  cpp <- as.list(mod)$cpp_variables
+  expect_equal(cpp$var, c("F1", "err", "cl", "v2", "ka", "CP"))
+  expect_equal(cpp$context, c("main", "table", rep("auto", 4)))
 })

--- a/tests/testthat/test-modspec.R
+++ b/tests/testthat/test-modspec.R
@@ -433,20 +433,21 @@ test_that("autodec", {
     b=(123);
     k = 
   ')[[1]]
-  x <- mrgsolve:::autodec_vars(
-    code, 
-    rdefs = "#define h j", 
-    build = new.env()
-  )
+  x <- mrgsolve:::autodec_vars(code)
   expect_equal(x, c("a", "b", "d", "k"))
   
   code <- '
   [ param ] tvcl = 1, tvvc = 2
+  [ cmt ] GUT CENT
   [ plugin ] autodec
   [ main ] 
   cl = tvcl;
   v2 = tvvc;
   ka = 1;
+  F_CENT = 1;
+  if(NEWIND <=1 ) {
+    D_CENT = 4;  
+  }
   double F1 = 0.9;
   [ table ] 
   double err = EPS(1);

--- a/tests/testthat/test-modspec.R
+++ b/tests/testthat/test-modspec.R
@@ -407,7 +407,7 @@ test_that("parse content using low-level handlers - OMEGA, SIGMA", {
   )
 })
 
-test_that("autodec", {
+test_that("autodec parsing", {
   x <- mrgsolve:::autodec_find("a = 1;")  
   expect_equal(x, "a")
   x <- mrgsolve:::autodec_find("a=1;")  
@@ -436,6 +436,9 @@ test_that("autodec", {
   x <- mrgsolve:::autodec_vars(code)
   expect_equal(x, c("a", "b", "d", "k"))
   
+})
+
+test_that("autodec models", {
   code <- ' 
   [ plugin ] autodec
   [ param ] a = 1, b = 2
@@ -465,7 +468,6 @@ test_that("autodec", {
   l <- as.list(mod)
   expect_equal(l$cpp_variables$var, c("c", "d"))
   
-
   code <- '
   [ param ] tvcl = 1, tvvc = 2
   [ cmt ] GUT CENT
@@ -488,4 +490,34 @@ test_that("autodec", {
   expect_equal(cpp$var, c("F1", "err", "cl", "v2", "ka", "CP"))
   expect_equal(cpp$context, c("main", "table", rep("auto", 4)))
 
+})
+
+test_that("autodec models with nm-vars", {
+  code <- '
+  [ param ] tvcl = 1, tvvc = 2
+  [ cmt ] GUT CENT
+  [ plugin ] autodec nm-vars
+  [ main ] 
+  double km = 2.5;
+  cl = tvcl;
+  v2 = tvvc;
+  ka = 1;
+  F_GUT = 1.2;
+  F1 = 1.2;
+  if(NEWIND<=1) {
+    D2 = 4;  
+  }
+  ALAG2 = 0.2;
+  A_0(2) = 5;
+  [ table ] 
+  double err = EPS(1);
+  CP = cent/v2;
+  [ ode ] 
+  DADT(1) = 0;
+  DADT(2) = 1; 
+  '
+  mod <- mcode("autodec5", code, compile = FALSE)
+  cpp <- as.list(mod)$cpp_variables
+  expect_equal(cpp$var, c("km","err", "cl", "v2", "ka", "CP"))
+  expect_equal(cpp$context, c("main", "table",  rep("auto", 4)))
 })

--- a/tests/testthat/test-modspec.R
+++ b/tests/testthat/test-modspec.R
@@ -436,6 +436,36 @@ test_that("autodec", {
   x <- mrgsolve:::autodec_vars(code)
   expect_equal(x, c("a", "b", "d", "k"))
   
+  code <- ' 
+  [ plugin ] autodec
+  [ param ] a = 1, b = 2
+  '
+  expect_s4_class(mod <- mcode("autodec2", code, compile = FALSE), "mrgmod")
+  l <- as.list(mod)
+  expect_equal(nrow(l$cpp_variables), 0)
+  
+  code <- ' 
+  [ plugin ] autodec
+  [ param ] a = 1, b = 2
+  [ main ] 
+  double c = 3;
+  '
+  expect_s4_class(mod <- mcode("autodec3", code, compile = FALSE), "mrgmod")
+  l <- as.list(mod)
+  expect_equal(l$cpp_variables$var, "c")
+  
+  code <- ' 
+  [ plugin ] autodec
+  [ param ] a = 1, b = 2
+  [ main ] 
+  double c = 3;
+  d = 4;
+  '
+  expect_s4_class(mod <- mcode("autodec4", code, compile = FALSE), "mrgmod")
+  l <- as.list(mod)
+  expect_equal(l$cpp_variables$var, c("c", "d"))
+  
+
   code <- '
   [ param ] tvcl = 1, tvvc = 2
   [ cmt ] GUT CENT
@@ -453,8 +483,9 @@ test_that("autodec", {
   double err = EPS(1);
   CP = cent/v2;
   '
-  mod <- mcode("autodec1", code, compile = FALSE)
+  mod <- mcode("autodec5", code, compile = FALSE)
   cpp <- as.list(mod)$cpp_variables
   expect_equal(cpp$var, c("F1", "err", "cl", "v2", "ka", "CP"))
   expect_equal(cpp$context, c("main", "table", rep("auto", 4)))
+
 })


### PR DESCRIPTION
# Summary

- This pr adds a plugin called `autodec`
- Searches model code, finds assignments, and declares them
  - Candidates must be valid C++ variables ... `[_a-zA-Z0-9]`
  - We also pick up symbols that contain dots and drop them in case assignments are made to, for example, `self`
- Candidate assignments are scanned for 
    - Items already existing in model definitions (e.g. parameters, compartments, etc)
    - Items declared with a type 
    - Items in reserved word list
- There is a new `modlib()` model called `nm-like` which is a basic model coded with both `nm-vars` and `autodec`
- Major re-org of the `mread()` function not a lot of change in functionality (outside of `autodec`) but stuff had to be moved   around so that some pieces deferred 


