### PR TITLE
Allow autodec skip; fix audit problem

### DIFF
--- a/R/model_include.R
+++ b/R/model_include.R
@@ -1,4 +1,4 @@
-# Copyright (C) 2013 - 2019  Metrum Research Group, LLC
+# Copyright (C) 2013 - 2022 Metrum Research Group
 #
 # This file is part of mrgsolve.
 #
@@ -29,6 +29,7 @@ get_plugins <- function(what, env) {
   }
   x <- lapply(what,get_plugin)
   names(x) <- s_pick(x,"name")
+  # TODO: register other plugins if needed
   env[["using_nm-vars"]] <- "nm-vars" %in% names(x)
   x
 }

--- a/R/model_include.R
+++ b/R/model_include.R
@@ -21,7 +21,7 @@ plugins[[".depends"]] <- list(mrgx=c("Rcpp"))
 
 include_order <- c("RcppArmadillo", "Rcpp","BH", "mrgx")
 
-get_plugins <- function(what) {
+get_plugins <- function(what, env) {
   what <- c(cvec_cs(what), "base")
   what <- unique(c(get_depends(what),what))
   if(all(c("Rcpp", "RcppArmadillo") %in% what)) {
@@ -29,6 +29,8 @@ get_plugins <- function(what) {
   }
   x <- lapply(what,get_plugin)
   names(x) <- s_pick(x,"name")
+  env[["using_autodec"]] <- "autodec" %in% names(x)
+  env[["using_nm-vars"]] <- "nm-vars" %in% names(x)
   x
 }
 

--- a/R/model_include.R
+++ b/R/model_include.R
@@ -29,7 +29,6 @@ get_plugins <- function(what, env) {
   }
   x <- lapply(what,get_plugin)
   names(x) <- s_pick(x,"name")
-  env[["using_autodec"]] <- "autodec" %in% names(x)
   env[["using_nm-vars"]] <- "nm-vars" %in% names(x)
   x
 }

--- a/R/modspec.R
+++ b/R/modspec.R
@@ -631,6 +631,8 @@ parse_env <- function(spec, incoming_names = names(spec),project,ENV=new.env()) 
   mread.env$annot <- vector("list", n)
   mread.env$ode   <- vector("list", n)
   mread.env$audit_dadt <- FALSE
+  mread.env$using_autodec <- FALSE
+  mread.env$`using_nm-vars` <- FALSE
   mread.env$namespace <- vector("list", n)
   mread.env$capture <- vector("list", n)
   mread.env$error <- character(0)
@@ -764,6 +766,13 @@ autodec_vars <- function(code, blocks = NULL) {
 
 #' Clean up `autodec` candidates
 #' 
+#' @param vars candidates
+#' @param rdefs compartments and parameters that will be implemented with 
+#' C++ pre-processor defines
+#' @param build the model `build` object; this contains variables that will 
+#' be globally declared
+#' @param skip additional names to scrub
+#' 
 #' @details 
 #' 
 #' Remove
@@ -775,11 +784,12 @@ autodec_vars <- function(code, blocks = NULL) {
 #' @md
 #' @keywords internal
 #' @noRd
-autodec_clean <- function(vars, rdefs, build) {
+autodec_clean <- function(vars, rdefs, build, skip = NULL) {
   rdefs <- strsplit(rdefs, " ", fixed = TRUE)
   rdefs <- s_pick(rdefs, 2)
   cpp <- build[["cpp_variables"]][["var"]]
-  vars <- setdiff(vars, c(Reserved, rdefs, Reserved_nm, cpp))  
+  vars <- setdiff(vars, c(Reserved, rdefs, Reserved_nm, cpp))
+  vars <- setdiff(vars, skip)
   vars
 }
 

--- a/R/modspec.R
+++ b/R/modspec.R
@@ -631,8 +631,9 @@ parse_env <- function(spec, incoming_names = names(spec),project,ENV=new.env()) 
   mread.env$annot <- vector("list", n)
   mread.env$ode   <- vector("list", n)
   mread.env$audit_dadt <- FALSE
-  mread.env$using_autodec <- FALSE
   mread.env$`using_nm-vars` <- FALSE
+  # TODO:
+  #mread.env$using_autodec <- FALSE
   mread.env$namespace <- vector("list", n)
   mread.env$capture <- vector("list", n)
   mread.env$error <- character(0)

--- a/R/modspec.R
+++ b/R/modspec.R
@@ -789,7 +789,9 @@ autodec_clean <- function(vars, rdefs, build, skip = NULL) {
   rdefs <- strsplit(rdefs, " ", fixed = TRUE)
   rdefs <- s_pick(rdefs, 2)
   cpp <- build[["cpp_variables"]][["var"]]
-  vars <- setdiff(vars, c(Reserved, rdefs, Reserved_nm, cpp))
+  vars <- setdiff(vars, c(Reserved, rdefs, cpp))
+  # We are not cleaning Reserved_nm here; this will be checked in  
+  # autodec_nm_vars
   vars <- setdiff(vars, skip)
   vars
 }

--- a/R/mread.R
+++ b/R/mread.R
@@ -424,6 +424,7 @@ mread <- function(model, project = getOption("mrgsolve.project", getwd()),
   check_globals(mread.env[["move_global"]], Cmt(x))
   
   # This must come after audit
+  # TODO: harmonize with other audit process
   if(!has_name("ODE", spec)) {
     spec[["ODE"]] <- "DXDTZERO();"
   } else {

--- a/R/mread.R
+++ b/R/mread.R
@@ -354,7 +354,6 @@ mread <- function(model, project = getOption("mrgsolve.project", getwd()),
   }
   
   # Handle nm-vars plugin
-  # This needs to happen before rdefs
   if("nm-vars" %in% names(plugin)) {
     nmv  <- find_nm_vars(spec)
     dfs <- generate_nmdefs(nmv)
@@ -375,10 +374,17 @@ mread <- function(model, project = getOption("mrgsolve.project", getwd()),
     auto_blocks <- c("PREAMBLE", "MAIN", "PRED", "ODE", "TABLE")
     auto_skip <- cvec_cs(ENV[["MRGSOLVE_AUTODEC_SKIP"]])
     autov <- autodec_vars(spec, blocks = auto_blocks)
-    autov <- autodec_clean(autov, rdefs = rd, build = build, skip = auto_skip)
+    autov <- autodec_clean(
+      autov, 
+      rdefs = rd, 
+      build = build, 
+      skip = auto_skip
+    )
+    autodec_nm_vars(autov, mread.env)
     autodec_save(autov, build, mread.env)
     mread.env[["autodec"]] <- autodec_namespace(build, mread.env)
   }
+
   # Rcpp
   if("Rcpp" %in% names(plugin)) {
     spec <- global_rcpp(spec)

--- a/R/nm-mode.R
+++ b/R/nm-mode.R
@@ -118,6 +118,22 @@ audit_nm_vars <- function(x, param, init, build, nmv, env) {
   return(invisible(TRUE))
 }
 
+autodec_nm_vars <- function(x, env) {
+  if(!env[["using_nm-vars"]]) return(invisible(TRUE))
+  err <- c()
+  if(any(x %in% Reserved_nm)) {
+    bad <- intersect(x, Reserved_nm)
+    err <- c(err, "Reserved names found via autodec:")
+    err <- c(err, paste0("--| reserved: ", bad))
+  }
+  if(length(err) > 0) {
+    msg <- "improper use of special variables with [nm-vars] plugin\n"
+    err <- paste0(c(msg, err), collapse = "\n")
+    stop(err, call. = FALSE)  
+  }
+  return(invisible(TRUE))
+}
+
 audit_nm_vars_range <- function(x, cmtn, audit_dadt) {
   err <- c()
   # Look for compartment indices out of range

--- a/inst/maintenance/unit/test-misc-syntax.R
+++ b/inst/maintenance/unit/test-misc-syntax.R
@@ -20,7 +20,7 @@ test_that("THETA(n) is allowed", {
   )
 })
 
-test_that("autodec + nm-vars functional test2", {
+test_that("autodec + nm-vars functional test", {
   eps <- 1e-4
   mod <- modlib("nm-like", delta = 0.1, preclean = TRUE, capture = "KA,INH")  
   dose <- ev(amt = 100, D2I = 2, cmt = 2, rate = -2)
@@ -32,4 +32,18 @@ test_that("autodec + nm-vars functional test2", {
   dose <- ev(amt = 100, cmt = 1, F1I = 0.81)
   out <- mrgsim(mod, dose)
   expect_true(abs(out$A1[2]-0.81*dose$amt[1]) < eps)
+})
+
+test_that("autodec + nm-vars using nm reserved", {
+  code <- '
+  $PLUGIN autodec nm-vars
+  $MAIN 
+  A = 1; 
+  B = 2;
+  F1 = 5;
+  '
+  expect_error(
+    mcode("auto-nm-reserved", code, compile = FALSE), 
+    regexp="reserved: A", fixed = TRUE
+  )
 })

--- a/tests/testthat/test-modspec.R
+++ b/tests/testthat/test-modspec.R
@@ -521,3 +521,19 @@ test_that("autodec models with nm-vars", {
   expect_equal(cpp$var, c("km","err", "cl", "v2", "ka", "CP"))
   expect_equal(cpp$context, c("main", "table",  rep("auto", 4)))
 })
+
+test_that("autodec variables can be skipped", {
+  code <- '
+  [ plugin ] autodec
+  [ env ] MRGSOLVE_AUTODEC_SKIP = "a, c"
+  [ main ] 
+  a = 1; 
+  b = 2; 
+  c = 3; 
+  d = 4;
+  double e = 5;
+  '
+  mod <- mcode("autodec-skip", code, compile = FALSE)
+  cpp <- as.list(mod)$cpp_variables
+  expect_equal(cpp$var, c("e", "b", "d"))
+})


### PR DESCRIPTION
# Summary 

- Implements an `autodec` escape hatch, allowing users to list variables to NOT declare in case they are getting picked up
  - This is set in `$ENV MRGSOLVE_AUTODEC_SKIP = c(...)`
  - Some documentation was added to `autodec_clean()` since that was getting more complicated; this is not exported and the docs are for people reading the code only

- Also: I'm just seeing that there is an auditing problem that was introduced with `nm-vars` plugin; basically, we need to skip auditing ODEs for standard models when the `nm-vars` plugin is in play
  - Added `mread.env` slots (logical) indicating whether or not `nm-vars` are in play
  - This is checked prior to standard auditing
  - I plan to harmonize this a bit more down the road ... less piecemeal

- Added a check for reserved names when `nm-vars` in invoked along with `autodec`; this wasn't in place before
  - For example, you should be able to use `A` when `nm-vars` isn't in play; but when it is, it should be reserved and error when `A` is declared
  - This most recent check picks up `A` when it is found by `autodec`
  
