### PR TITLE
Warn when simetan or simepsn is requested ETA or EPS are correlated

### DIFF
--- a/R/modspec.R
+++ b/R/modspec.R
@@ -71,10 +71,12 @@ check_pkmodel <- function(x, subr, spec) {
 
 check_sim_eta_eps_n <- function(x, spec) {
   main <- spec[["MAIN"]]
+  tab <- spec[["TABLE"]]
   has_simeta_n <- any(grepl("simeta\\(\\s*[0-9]+\\s*\\)", main))
+  has_simeps_n <- any(grepl("simeps\\(\\s*[0-9]+\\s*\\)", tab))
   if(has_simeta_n) {
     omega <- as.matrix(omat(x))
-    offd <- omega[lower.tri(omega, diag=FALSE)]
+    offd <- as.double(omega[lower.tri(omega, diag = FALSE)])
     if(any(abs(offd) > 1e-12)) {
       warning(
         "simeta(n) was requested, but ETA are correlated; ", 
@@ -82,12 +84,10 @@ check_sim_eta_eps_n <- function(x, spec) {
       )
     }
   }
-  tab <- spec[["TABLE"]]
-  has_simeps_n <- any(grepl("simeps\\(\\s*[0-9]+\\s*\\)", tab))
   if(has_simeps_n) {
     sigma <- as.matrix(smat(x))
     if(nrow(sigma) > 0) {
-      offd <- sigma[lower.tri(sigma, diag=FALSE)]
+      offd <- as.double(sigma[lower.tri(sigma, diag = FALSE)])
       if(any(abs(offd) > 1e-12)) {
         warning(
           "simeps(n) was requested, but EPS are correlated; ", 

--- a/R/modspec.R
+++ b/R/modspec.R
@@ -72,8 +72,8 @@ check_pkmodel <- function(x, subr, spec) {
 check_sim_eta_eps_n <- function(x, spec) {
   main <- spec[["MAIN"]]
   tab <- spec[["TABLE"]]
-  simeta_n <- grep("simeta\\(\\s*[0-9]+\\s*\\)", main, perl = TRUE)
-  simeps_n <- grep("simeps\\(\\s*[0-9]+\\s*\\)", tab, perl = TRUE)
+  simeta_n <- grep("\\bsimeta\\(\\s*[0-9]+\\s*\\)", main, perl = TRUE)
+  simeps_n <- grep("\\bsimeps\\(\\s*[0-9]+\\s*\\)", tab,  perl = TRUE)
   has_off_diag <- function(mat) {
     if(nrow(mat)==0) return(FALSE)
     offd <- as.double(mat[lower.tri(mat, diag = FALSE)])

--- a/R/modspec.R
+++ b/R/modspec.R
@@ -76,12 +76,14 @@ check_sim_eta_eps_n <- function(x, spec) {
   has_simeps_n <- any(grepl("simeps\\(\\s*[0-9]+\\s*\\)", tab))
   if(has_simeta_n) {
     omega <- as.matrix(omat(x))
-    offd <- as.double(omega[lower.tri(omega, diag = FALSE)])
-    if(any(abs(offd) > 1e-12)) {
-      warning(
-        "simeta(n) was requested, but ETA are correlated; ", 
-        "use simeta() to resimulate all ETA."
-      )
+    if(nrow(omega) > 0) {
+      offd <- as.double(omega[lower.tri(omega, diag = FALSE)])
+      if(any(abs(offd) > 1e-12)) {
+        warning(
+          "simeta(n) was requested, but ETA are correlated; ", 
+          "use simeta() to resimulate all ETA."
+        )
+      }
     }
   }
   if(has_simeps_n) {

--- a/R/modspec.R
+++ b/R/modspec.R
@@ -72,30 +72,29 @@ check_pkmodel <- function(x, subr, spec) {
 check_sim_eta_eps_n <- function(x, spec) {
   main <- spec[["MAIN"]]
   tab <- spec[["TABLE"]]
-  has_simeta_n <- any(grepl("simeta\\(\\s*[0-9]+\\s*\\)", main))
-  has_simeps_n <- any(grepl("simeps\\(\\s*[0-9]+\\s*\\)", tab))
-  if(has_simeta_n) {
+  simeta_n <- grep("simeta\\(\\s*[0-9]+\\s*\\)", main, perl = TRUE)
+  simeps_n <- grep("simeps\\(\\s*[0-9]+\\s*\\)", tab, perl = TRUE)
+  has_off_diag <- function(mat) {
+    if(nrow(mat)==0) return(FALSE)
+    offd <- as.double(mat[lower.tri(mat, diag = FALSE)])
+    any(abs(offd) > 1e-12)
+  }
+  if(length(simeta_n) > 0) {
     omega <- as.matrix(omat(x))
-    if(nrow(omega) > 0) {
-      offd <- as.double(omega[lower.tri(omega, diag = FALSE)])
-      if(any(abs(offd) > 1e-12)) {
-        warning(
-          "simeta(n) was requested, but ETA are correlated; ", 
-          "use simeta() to resimulate all ETA."
-        )
-      }
+    if(has_off_diag(omega)) {
+      warning(
+        "simeta(n) was requested, but ETA are correlated; ", 
+        "use simeta() to resimulate all ETA."
+      )
     }
   }
-  if(has_simeps_n) {
+  if(length(simeps_n) > 0) {
     sigma <- as.matrix(smat(x))
-    if(nrow(sigma) > 0) {
-      offd <- as.double(sigma[lower.tri(sigma, diag = FALSE)])
-      if(any(abs(offd) > 1e-12)) {
-        warning(
-          "simeps(n) was requested, but EPS are correlated; ", 
-          "use simeps() to resimulate all EPS."
-        )
-      }
+    if(has_off_diag(sigma)) {
+      warning(
+        "simeps(n) was requested, but EPS are correlated; ", 
+        "use simeps() to resimulate all EPS."
+      )
     }
   }
   return(invisible(NULL))

--- a/R/modspec.R
+++ b/R/modspec.R
@@ -69,6 +69,36 @@ check_pkmodel <- function(x, subr, spec) {
   return(invisible(NULL))
 }
 
+check_sim_eta_eps_n <- function(x, spec) {
+  main <- spec[["MAIN"]]
+  has_simeta_n <- any(grepl("simeta\\(\\s*[0-9]+\\s*\\)", main))
+  if(has_simeta_n) {
+    omega <- as.matrix(omat(x))
+    offd <- omega[lower.tri(omega, diag=FALSE)]
+    if(any(abs(offd) > 1e-12)) {
+      warning(
+        "simeta(n) was requested, but ETA are correlated; ", 
+        "use simeta() to resimulate all ETA."
+      )
+    }
+  }
+  tab <- spec[["TABLE"]]
+  has_simeps_n <- any(grepl("simeps\\(\\s*[0-9]+\\s*\\)", tab))
+  if(has_simeps_n) {
+    sigma <- as.matrix(smat(x))
+    if(nrow(sigma) > 0) {
+      offd <- sigma[lower.tri(sigma, diag=FALSE)]
+      if(any(abs(offd) > 1e-12)) {
+        warning(
+          "simeps(n) was requested, but EPS are correlated; ", 
+          "use simeps() to resimulate all EPS."
+        )
+      }
+    }
+  }
+  return(invisible(NULL))
+}
+
 check_spec_contents <- function(x, crump = TRUE, warn = TRUE, ...) {
   invalid <- setdiff(x,block_list)
   valid <- intersect(x,block_list)

--- a/R/mread.R
+++ b/R/mread.R
@@ -421,6 +421,7 @@ mread <- function(model, project = getOption("mrgsolve.project", getwd()),
   # Check mod ----
   check_pkmodel(x, subr, spec)
   check_globals(mread.env[["move_global"]], Cmt(x))
+  check_sim_eta_eps_n(x, spec)
   
   # This must come after audit
   if(!has_name("ODE", spec)) {

--- a/inst/maintenance/unit/test-simeta.R
+++ b/inst/maintenance/unit/test-simeta.R
@@ -140,3 +140,59 @@ test_that("invalid value for n when calling simeta or simeps", {
     "simeps index out of bounds"
   )
 })
+
+test_that("warn when simeta(n) is called with off diagonals", {
+  code <- '
+  $OMEGA @block 
+  1 0.1 2
+  $MAIN 
+  simeta(2);
+  ' 
+  expect_warning(
+    mcode("simeta-n-warn", code, compile = FALSE), 
+    regexp = "ETA are correlated", 
+    fixed  = TRUE
+  )
+  code <- '
+  $OMEGA  
+  1 0.1 2
+  $MAIN 
+  simeta(2);
+  ' 
+  expect_silent(mcode("simeta-n-nowarn", code, compile = FALSE))
+  code <- '
+  $OMEGA @block 
+  1 0.1 2
+  $MAIN 
+  simeta();
+  ' 
+  expect_silent(mcode("simeta-n-nowarn-2", code, compile = FALSE))
+})
+
+test_that("warn when simeps(n) is called with off diagonals", {
+  code <- '
+  $SIGMA @block 
+  1 0.1 2
+  $TABLE
+  simeps(2);
+  ' 
+  expect_warning(
+    mcode("simeps-n-warn", code, compile = FALSE), 
+    regexp = "EPS are correlated", 
+    fixed  = TRUE
+  )
+  code <- '
+  $SIGMA
+  1 0.1 2
+  $TABLE
+  simeps(2);
+  ' 
+  expect_silent(mcode("simeps-n-nowarn", code, compile = FALSE))
+  code <- '
+  $SIGMA @block 
+  1 0.1 2
+  $TABLE
+  simeta();
+  ' 
+  expect_silent(mcode("simeps-n-nowarn-2", code, compile = FALSE))
+})


### PR DESCRIPTION
# Summary

- look for `simeta(n)` in `$MAIN` or `simeps(n)` in `$TABLE`
- warn if any off diagonals for `OMEGA` or `SIGMA` are non zero
