### PR TITLE
Always warn when simeta(n) or simeps(n) is found

### DIFF
--- a/R/modspec.R
+++ b/R/modspec.R
@@ -81,7 +81,7 @@ check_sim_eta_eps_n <- function(x, spec) {
     warning(
       "simeta(n) was requested; ", 
       "resimulating single ETA values is now discouraged and will soon be deprecated; ", 
-      "use simeps() to resimulate all ETA; ",
+      "use simeta() to resimulate all ETA; ",
       "silence this warning by setting MRGSOLVE_RESIM_N_WARN to FALSE in $ENV."
     )
   }

--- a/R/modspec.R
+++ b/R/modspec.R
@@ -70,32 +70,28 @@ check_pkmodel <- function(x, subr, spec) {
 }
 
 check_sim_eta_eps_n <- function(x, spec) {
+  if(isFALSE(env_get_env(x)$MRGSOLVE_RESIM_N_WARN)) {
+    return(invisible(NULL))  
+  }
   main <- spec[["MAIN"]]
   tab <- spec[["TABLE"]]
   simeta_n <- grep("\\bsimeta\\(\\s*[0-9]+\\s*\\)", main, perl = TRUE)
   simeps_n <- grep("\\bsimeps\\(\\s*[0-9]+\\s*\\)", tab,  perl = TRUE)
-  has_off_diag <- function(mat) {
-    if(nrow(mat)==0) return(FALSE)
-    offd <- as.double(mat[lower.tri(mat, diag = FALSE)])
-    any(abs(offd) > 1e-12)
-  }
   if(length(simeta_n) > 0) {
-    omega <- as.matrix(omat(x))
-    if(has_off_diag(omega)) {
-      warning(
-        "simeta(n) was requested, but ETA are correlated; ", 
-        "use simeta() to resimulate all ETA."
-      )
-    }
+    warning(
+      "simeta(n) was requested; ", 
+      "resimulating single ETA values is now discouraged and will soon be deprecated; ", 
+      "use simeps() to resimulate all ETA; ",
+      "silence this warning by setting MRGSOLVE_RESIM_N_WARN to FALSE in $ENV."
+    )
   }
   if(length(simeps_n) > 0) {
-    sigma <- as.matrix(smat(x))
-    if(has_off_diag(sigma)) {
-      warning(
-        "simeps(n) was requested, but EPS are correlated; ", 
-        "use simeps() to resimulate all EPS."
-      )
-    }
+    warning(
+      "simeps(n) was requested; ", 
+      "resimulating single EPS values is now discouraged and will soon be deprecated; ", 
+      "use simeps() to resimulate all EPS; ",
+      "silence this warning by setting MRGSOLVE_RESIM_N_WARN to FALSE in $ENV."
+    )
   }
   return(invisible(NULL))
 }

--- a/inst/maintenance/build_housemodel.R
+++ b/inst/maintenance/build_housemodel.R
@@ -27,6 +27,7 @@ fun <- function() {
   source("R/init.R")
   source("R/funset.R")
   source("R/update.R")
+  source("R/env.R")
   proj <- file.path("inst", "project")
   mod <- mread("housemodel", proj, compile = FALSE, udll=FALSE, ns = FALSE)
   cpp <- normalizePath(list.files(mod@soloc, full.names=TRUE))

--- a/inst/maintenance/unit/test-simeta.R
+++ b/inst/maintenance/unit/test-simeta.R
@@ -188,7 +188,7 @@ test_that("warn when simeps(n) is called with off diagonals", {
   $SIGMA @block 
   1 0.1 2
   $TABLE
-  simeta();
+  simeps();
   ' 
   expect_silent(mcode("simeps-n-nowarn", code, compile = FALSE))
   code <- '

--- a/inst/maintenance/unit/test-simeta.R
+++ b/inst/maintenance/unit/test-simeta.R
@@ -1,4 +1,4 @@
-# Copyright (C) 2013 - 2021  Metrum Research Group
+# Copyright (C) 2013 - 2022  Metrum Research Group
 #
 # This file is part of mrgsolve.
 #
@@ -87,7 +87,7 @@ test_that("resimulate all eta", {
 })
 
 test_that("resimulate specific eta", {
-  
+  skip_if(TRUE, message="resim(n) is deprecated")
   set.seed(5678)
   # simeta with n = 1 (simeta(3))
   n1 <-  mrgsim_df(mod, param = list(n = 1, mode = 2)) 
@@ -125,12 +125,14 @@ test_that("resimulate all or specific eps", {
   expect_false(any(duplicated(unlist(all))))
   
   # simeps with n = 2 (simeps(2))
+  skip_if(TRUE, message="resim(n) is deprecated")
   n <-  mrgsim(mod, data = data, param = list(n = 2, mode = 5))
   expect_true(all(n$a==n$a[1]))
   expect_false(any(duplicated(n$b)))
 })
 
 test_that("invalid value for n when calling simeta or simeps", {
+  skip_if(TRUE, message="resim(n) is deprecated")
   expect_error(
     mrgsim(mod, param = list(mode = 2, n = 100)), 
     "simeta index out of bounds"
@@ -150,21 +152,22 @@ test_that("warn when simeta(n) is called with off diagonals", {
   ' 
   expect_warning(
     mcode("simeta-n-warn", code, compile = FALSE), 
-    regexp = "ETA are correlated", 
+    regexp = "values is now discouraged and will soon be deprecated", 
     fixed  = TRUE
   )
-  code <- '
-  $OMEGA  
-  1 0.1 2
-  $MAIN 
-  simeta(2);
-  ' 
-  expect_silent(mcode("simeta-n-nowarn", code, compile = FALSE))
   code <- '
   $OMEGA @block 
   1 0.1 2
   $MAIN 
   simeta();
+  ' 
+  expect_silent(mcode("simeta-n-nowarn-1", code, compile = FALSE))
+  code <- '
+  $ENV MRGSOLVE_RESIM_N_WARN = FALSE
+  $OMEGA @block 
+  1 0.1 2
+  $MAIN 
+  simeta(2);
   ' 
   expect_silent(mcode("simeta-n-nowarn-2", code, compile = FALSE))
 })
@@ -178,21 +181,22 @@ test_that("warn when simeps(n) is called with off diagonals", {
   ' 
   expect_warning(
     mcode("simeps-n-warn", code, compile = FALSE), 
-    regexp = "EPS are correlated", 
+    regexp = "values is now discouraged and will soon be deprecated", 
     fixed  = TRUE
   )
-  code <- '
-  $SIGMA
-  1 0.1 2
-  $TABLE
-  simeps(2);
-  ' 
-  expect_silent(mcode("simeps-n-nowarn", code, compile = FALSE))
   code <- '
   $SIGMA @block 
   1 0.1 2
   $TABLE
   simeta();
+  ' 
+  expect_silent(mcode("simeps-n-nowarn", code, compile = FALSE))
+  code <- '
+  $ENV MRGSOLVE_RESIM_N_WARN = FALSE
+  $SIGMA @block 
+  1 0.1 2
+  $TABLE
+  simeps(1);
   ' 
   expect_silent(mcode("simeps-n-nowarn-2", code, compile = FALSE))
 })


### PR DESCRIPTION
# Summary

- This always warns when `simeta(n)` or `simeps(n)` is found on model load
- The warning can be silenced with a model environment variable (`MRGSOLVE_RESIM_N_WARN = FALSE`)
- This only warns; the `simeta(n)` / `simeps(n)` functionality still works  
- Next step will be to remove the functionality and error