### PR TITLE
mute define for ARMA CXX11

### DIFF
--- a/inst/include/RcppInclude.h
+++ b/inst/include/RcppInclude.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2013 - 2017  Metrum Research Group, LLC
+// Copyright (C) 2013 - 2022  Metrum Research Group
 //
 // This file is part of mrgsolve.
 //
@@ -15,6 +15,6 @@
 // You should have received a copy of the GNU General Public License
 // along with mrgsolve.  If not, see <http://www.gnu.org/licenses/>.
 
-#define ARMA_DONT_USE_CXX11
+//#define ARMA_DONT_USE_CXX11
 #include <RcppArmadillo.h>
 #define NDEBUG 1


### PR DESCRIPTION
This ARMA CXX11 directive is no longer needed b/c mrgsolve is building with CXX11 and ARMA requires it; we were getting unneeded warnings when compiling.

http://dirk.eddelbuettel.com/blog/2020/10/20/