### PR TITLE
Straighten out logic for self.stop_id() and self.stop_id_cf()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,9 +128,10 @@ modlib: export _MRGSOLVE_SKIP_MODLIB_BUILD_=no
 modlib: 
 	Rscript -e 'testthat::test_file("inst/maintenance/unit/test-modlib.R")'
 
-# possibly no longer in use
+# this is in use
 drone:
 	make house
+	R -s -e 'devtools::install_deps(upgrade = '"'"'always'"'"', dependencies=TRUE)'
 	R CMD build --md5 $(PKGDIR) 
 	R CMD check --as-cran ${TARBALL}
 	export _MRGSOLVE_SKIP_MODLIB_BUILD_=false

--- a/inst/base/modelheader.h
+++ b/inst/base/modelheader.h
@@ -128,10 +128,11 @@ typedef double capture;
 #define CFONSTOP() (self.CFONSTOP = true); // Carry forward on stop
 #define SYSTEMNOTADVANCING (self.SYSTEMOFF)
 #define SOLVINGPROBLEM (self.solving)
-#define _SETINIT if(self.newind <=1) // Convenience
-#define _STOP_ID() (self.SYSTEMOFF=2);
-#define _STOP_ID_CF() (self.SYSTEMOFF=1);
-#define _STOP_ERROR() (self.SYSTEMOFF=9);
+#define _SETINIT if(self.newind <= 1) // Convenience
+#define _STOP_ID() (self.SYSTEMOFF = 1); // Stop this ID, log record, and fill NA after that
+#define _STOP_ID_CF() (self.SYSTEMOFF = 2); // Stop this ID and carry forward
+#define _STOP_ID_NA() (self.SYSTEMOFF = 3); // Fill na
+#define _STOP_ERROR() (self.SYSTEMOFF = 9); // CRUMP
 
 // Macro to insert dxdt_CMT = 0; for all compartments
 #define DXDTZERO() for(int _i_ = 0; _i_ < _nEQ; ++_i_) _DADT_[_i_] = 0;

--- a/inst/base/mrgsolv.h
+++ b/inst/base/mrgsolv.h
@@ -102,8 +102,8 @@ public:
   bool CFONSTOP; ///< carry forward on stop indicator
   void* envir; ///< model environment
   void stop() {SYSTEMOFF=9;}///< stops the problem when the next record is started
-  void stop_id() {SYSTEMOFF=1;}///< stops solving for the current id, filling with NA
-  void stop_id_cf(){SYSTEMOFF=2;}///< stops solving for the current id, filling last value
+  void stop_id() {SYSTEMOFF=2;}///< stops solving for the current id, filling with NA
+  void stop_id_cf(){SYSTEMOFF=1;}///< stops solving for the current id, filling last value
   std::vector<mrgsolve::evdata> mevector;///< a collection of model events to pass back
   void mevent(double time, int evid);///< constructor for evdata objects
   double mtime(double time);///< creates evdata object for simple model event time

--- a/inst/maintenance/unit/test-stop-id.R
+++ b/inst/maintenance/unit/test-stop-id.R
@@ -1,0 +1,64 @@
+library(testthat)
+library(mrgsolve)
+
+Sys.setenv(R_TESTS="")
+options("mrgsolve_mread_quiet"=TRUE)
+
+context("test-stop-id")
+
+code <- '
+$PROB
+We can make the simulation stop for the current ID and fill either 
+NA or the last value; OR we can just make the simulation stop with error.
+$PARAM STOP_CF = 0, STOP_NA = 0, STOP_CRUMP = 0
+$CMT A
+$ODE dxdt_A = 1;
+$MAIN
+if(NEWIND <=1) capture stopped = 0;
+$ERROR
+if(STOP_CF==1) {
+  if(TIME==4) {
+    self.stop_id_cf();
+    stopped = 1;
+  }
+}
+if(STOP_NA==1) {
+  if(TIME==3) {
+    self.stop_id(); 
+    stopped = 1;
+  }
+}
+if(STOP_CRUMP==1) {
+  self.stop();
+}
+'
+
+mod <- mcode("test-stop-id", code, end = 6)
+
+test_that("Stop the current ID and carry forward", {
+  mod <- param(mod, STOP_CF = 1, STOP_NA = 0, STOP_CRUMP = 0)
+  out <- mrgsim_df(mod)  
+  pre <- out[out$time <= 3,,drop=FALSE]
+  post <- out[out$time > 3,,drop=FALSE]
+  expect_true(all(pre$stopped==0))
+  expect_true(all(post$stopped==1))
+  expect_equal(pre$A, c(0,1,2,3))
+  expect_true(all(post$A==4))
+})
+
+test_that("Stop the current ID and fill NA", {
+  mod <- param(mod, STOP_NA = 1, STOP_CF = 0, STOP_CRUMP = 0)
+  out <- mrgsim_df(mod)  
+  pre <- out[!is.na(out$time),,drop=FALSE]
+  post <- out[is.na(out$time),,drop=FALSE]
+  expect_equal(nrow(pre), 4)
+  expect_equal(pre$A, c(0,1,2,3))
+  expect_equal(pre$stopped, c(0,0,0,1))
+  expect_equal(nrow(post), 3)
+  expect_true(all(is.na(post)))
+})
+
+test_that("Stop the entire simulation", {
+  mod <- param(mod, STOP_NA = 0, STOP_CF = 0, STOP_CRUMP = 1)
+  expect_error(mrgsim_df(mod), regexp="the problem was stopped at user request.")
+})

--- a/src/devtran.cpp
+++ b/src/devtran.cpp
@@ -418,7 +418,7 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
         // for an individual; no other calls to any model functions will
         // be made
         // SYSTEMOFF = 1 --> copy model results to the line
-        // SYSTEMOFF != 1 --> fill NA
+        // SYSTEMOFF != 0, !=1 --> fill NA
         unsigned short int status = prob.systemoff();
         if(status==9) CRUMP("the problem was stopped at user request.");
         if(status==999) CRUMP("999 sent from the model.");

--- a/src/devtran.cpp
+++ b/src/devtran.cpp
@@ -414,9 +414,14 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
       this_rec->id(id);
       
       if(prob.systemoff()) {
+        // This starts a loop that will finish the remaining records 
+        // for an individual; no other calls to any model functions will
+        // be made
+        // SYSTEMOFF = 1 --> copy model results to the line
+        // SYSTEMOFF = 2 --> fill NA
         unsigned short int status = prob.systemoff();
         if(status==9) CRUMP("the problem was stopped at user request.");
-        if(status==999) CRUMP("999 sent from the model");
+        if(status==999) CRUMP("999 sent from the model.");
         if(this_rec->output()) {
           if(status==1) {
             ans(crow,0) = this_rec->id();
@@ -430,7 +435,7 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
           } else {
             for(int k=0; k < ans.ncol(); ++k) {
               ans(crow,k) = NA_REAL;
-            }
+            } 
           }
           ++crow;
         }

--- a/src/devtran.cpp
+++ b/src/devtran.cpp
@@ -418,7 +418,7 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
         // for an individual; no other calls to any model functions will
         // be made
         // SYSTEMOFF = 1 --> copy model results to the line
-        // SYSTEMOFF = 2 --> fill NA
+        // SYSTEMOFF != 1 --> fill NA
         unsigned short int status = prob.systemoff();
         if(status==9) CRUMP("the problem was stopped at user request.");
         if(status==999) CRUMP("999 sent from the model.");


### PR DESCRIPTION
# Summary

- `self.stop_id()` should fill the current row and then fill `NA_real_` in all columns for the remaining rows
- `self.stop_id_cf()` should fill the current row and then use that value to fill compartments and captures the rest of the way
- Added a test for this since functions / codes were previously confused


# Verify 
- in `src/devtran.cpp`

```c
      if(prob.systemoff()) {
        // This starts a loop that will finish the remaining records 
        // for an individual; no other calls to any model functions will
        // be made
        // SYSTEMOFF = 1 --> copy model results to the line
        // SYSTEMOFF != 1 --> fill NA
        unsigned short int status = prob.systemoff();
        if(status==9) CRUMP("the problem was stopped at user request.");
        if(status==999) CRUMP("999 sent from the model.");
        if(this_rec->output()) {
          if(status==1) {
            ans(crow,0) = this_rec->id();
            ans(crow,1) = this_rec->time();
            for(unsigned int k=0; k < n_capture; ++k) {
              ans(crow,(k+capture_start)) = prob.capture(capture[k+1]);
            }
            for(unsigned int k=0; k < nreq; ++k) {
              ans(crow,(k+req_start)) = prob.y(request[k]);
            }
          } else {
            for(int k=0; k < ans.ncol(); ++k) {
              ans(crow,k) = NA_REAL;
            } 
          }
          ++crow;
        }
        continue;
      }


```