### PR TITLE
Fix/cran

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: mrgsolve
 Title: Simulate from ODE-Based Models
-Version: 1.0.1
+Version: 1.0.1.9000
 Authors@R: 
     c(person(given = "Kyle T", family = "Baron",
              role = c("aut", "cre"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: mrgsolve
 Title: Simulate from ODE-Based Models
-Version: 1.0.1.9000
+Version: 1.0.3
 Authors@R: 
     c(person(given = "Kyle T", family = "Baron",
              role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,10 @@
 # mrgsolve 1.0.3
 
-- Removed `assert()` statement in LSODA code found by CRAN check.
+- Removed `assert()` statement in LSODA code found by CRAN check (#943).
 
 # mrgsolve 1.0.2
 
-- Test class using `inherits()` not `class()` from CRAN check.
+- Test class using `inherits()` not `class()` from CRAN check (#943).
 
 # mrgsolve 1.0.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# mrgsolve (development version)
+
 # mrgsolve 1.0.1
 
 - Add `LOG()`, `EXP()`, `SQRT()` macros when `nm-vars` plugin is invoked 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,10 @@
-# mrgsolve (development version)
+# mrgsolve 1.0.3
+
+- Removed `assert()` statement in LSODA code found by CRAN check.
+
+# mrgsolve 1.0.2
+
+- Test class using `inherits()` not `class()` from CRAN check.
 
 # mrgsolve 1.0.1
 

--- a/R/class_mrgmod.R
+++ b/R/class_mrgmod.R
@@ -654,7 +654,7 @@ loadso.mrgmod <- function(x,...) {
     try(dyn.unload(sofile),silent=TRUE)
   }
   foo <- try(dyn.load(sofile))
-  if(class(foo)=="try-catch") {
+  if(inherits(foo, "try-error")) {
     wstop("[loadso] failed to load the model dll file")
   }
   return(invisible(x))

--- a/src/lsoda_functions.h
+++ b/src/lsoda_functions.h
@@ -272,7 +272,10 @@ c-----------------------------------------------------------------------
 void LSODA::stoda(const size_t neq, vector<double> &y, LSODA_ODE_SYSTEM_TYPE f,
                   dtype _data)
 {
-    assert(neq + 1 == y.size());
+    //assert(neq + 1 == y.size());
+    if((neq+1) != y.size()) {
+      Rcpp::stop("[lsoda] y is not the right size in stoda.");    
+    }
 
     size_t corflag = 0, orderflag = 0;
     size_t i = 0, i1 = 0, j = 0, m = 0, ncf = 0;


### PR DESCRIPTION
# Changes requested by cran 
- Test using `inherits()`, not `class()` (1.0.2)
- Remove call to `assert()` from lsoda code (1.0.3)

# Background
- Version `1.0.1` was validated, tagged and released
- Went to submit that to CRAN and they requested changes in two batches, leading to `1.0.2` (first request) and `1.0.3` (second request)
- Version `1.0.3` is now heading to CRAN, so we'll merge these (minor) changes into production