### PR TITLE
handle slightly negative eigenvalue when simulating

### DIFF
--- a/src/mrgsolve.cpp
+++ b/src/mrgsolve.cpp
@@ -130,17 +130,19 @@ arma::mat MVGAUSS(arma::mat& OMEGA, int n) {
   
   arma::vec eigval;
   arma::mat eigvec;
-  arma::eig_sym(eigval,eigvec, OMEGA);
+  arma::eig_sym(eigval, eigvec, OMEGA);
   
-  int ncol = OMEGA.n_cols;
+  if(arma::min(eigval) < 0.0) {
+    for(unsigned int i = 0; i < eigval.size(); ++i) {
+      eigval[i] = std::max(0.0, eigval[i]);
+    }  
+  }
   
-  arma::mat X = arma::randn<arma::mat>(n,ncol);
+  arma::mat X = arma::randn<arma::mat>(n, OMEGA.n_cols);
   
   eigval = arma::sqrt(eigval);
-  
-  arma::mat Z = arma::diagmat(eigval);
-  
-  X = eigvec * Z * X.t();
+
+  X = eigvec * arma::diagmat(eigval) * X.t();
   
   return X.t();
 }


### PR DESCRIPTION
# Summary

- `MASS::mvrnorm` will accept covariance matrices with small negative eigenvalues, setting them to zero
- this PR implements the same behavior
- note: mrgsolve has historically checked for positive determinant for incoming model matrices and is working toward changing the check to be based on eigen values instead


# Example

Showing both MASS and mrgsolve simulating from a matrix with negative eigenvalue

``` r
mat <- mrgsolve::bmat(
1.53394, 
1.22232, 0.974014,
2.78342 , 2.211570, 9.86881
)

mat
#>         [,1]     [,2]    [,3]
#> [1,] 1.53394 1.222320 2.78342
#> [2,] 1.22232 0.974014 2.21157
#> [3,] 2.78342 2.211570 9.86881

eigen(mat)$values
#> [1]  1.130541e+01  1.071351e+00 -7.148461e-08
det(mat)
#> [1] -8.658264e-07

set.seed(1010)
a <- MASS::mvrnorm(1000000, c(0,0,0), mat)
b <- mrgsolve::mvgauss(mat,  1000000)

cov(a)
#>          [,1]      [,2]     [,3]
#> [1,] 1.533910 1.2223026 2.778312
#> [2,] 1.222303 0.9740056 2.207535
#> [3,] 2.778312 2.2075348 9.832882
cov(b)
#>          [,1]      [,2]     [,3]
#> [1,] 1.532405 1.2211011 2.777505
#> [2,] 1.221101 0.9730461 2.206862
#> [3,] 2.777505 2.2068619 9.854215
```

<sup>Created on 2022-03-28 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

