### PR TITLE
change name of template parameters to work with nm-vars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,9 @@ test1:
 test2:
 	Rscript -e 'testthat::test_dir("inst/maintenance/unit")'
 
+test-cpp: 
+	Rscript -e 'testthat::test_dir("inst/maintenance/unit-cpp")'
+
 clean:
 	rm src/*.o
 	rm src/*.so

--- a/inst/maintenance/unit-cpp/test-cpp.R
+++ b/inst/maintenance/unit-cpp/test-cpp.R
@@ -1,0 +1,26 @@
+
+library(testthat)
+library(mrgsolve)
+library(dplyr)
+
+Sys.setenv(R_TESTS="")
+options("mrgsolve_mread_quiet"=TRUE)
+
+context("test-cpp")
+
+code <- '
+[ plugin ] nm-vars, mrgx, Rcpp
+
+[ cmt ] @number 1
+
+[ des ]  
+DADT(1) = -0.1 * A(1);
+'
+
+test_that("build a model with mrgx and nm-vars", {
+  expect_is(
+    mcode("test-cpp-mrgx-nm-vars", code, quiet = TRUE), 
+    "mrgmod"
+  )
+})
+

--- a/inst/maintenance/unit-cpp/tests.csv
+++ b/inst/maintenance/unit-cpp/tests.csv
@@ -1,0 +1,2 @@
+result,call,diff,short,file,first,last
+TRUE,expect_inherits(mod, "mrgmod"),,,test-cpp.R,22,24

--- a/inst/maintenance/unit-cpp/tests.csv
+++ b/inst/maintenance/unit-cpp/tests.csv
@@ -1,2 +1,0 @@
-result,call,diff,short,file,first,last
-TRUE,expect_inherits(mod, "mrgmod"),,,test-cpp.R,22,24

--- a/inst/mrgx/mrgx.h
+++ b/inst/mrgx/mrgx.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2013 - 2019  Metrum Research Group, LLC
+// Copyright (C) 2013 - 2022  Metrum Research Group
 //
 // This file is part of mrgsolve.
 //
@@ -128,8 +128,8 @@ double rlognorm(const double mean, const double sd, const double lower,
  * @param self the model data object
  * @return an object from the model environment
  */
-template<typename T>
-T get(const std::string name, const databox& self) {
+template<typename _T___>
+_T___ get(const std::string name, const databox& self) {
   Rcpp::Environment env = get_envir(self);
   return env[name];
 }
@@ -147,8 +147,8 @@ T get(const std::string name, const databox& self) {
  * @param name name of the R object to get
  * @return an object from the global environment
  */
-template<typename T>
-T get(const std::string name) {
+template<typename _T___>
+_T___ get(const std::string name) {
   Rcpp::Environment env = Rcpp::Environment::global_env();
   return env[name];
 } 
@@ -180,10 +180,10 @@ T get(const std::string name) {
  * @param name name of the object to get
  * @return an object from the package namespace
  */
-template<typename T>
-T get(const std::string package, const std::string name) {
+template<typename _T___>
+_T___ get(const std::string package, const std::string name) {
   Rcpp::Environment env = Rcpp::Environment::namespace_env(package);
-  T ans = env[name];
+  _T___ ans = env[name];
   return ans;
 }
 
@@ -194,8 +194,8 @@ T get(const std::string package, const std::string name) {
  * @param filename the name of the RDS file to read
  * @return an object saved in the RDS file
  */
-template<typename T>
-T readRDS(const std::string filename) {
+template<typename _T___>
+_T___ readRDS(const std::string filename) {
   Rcpp::Function readRDS = get<Rcpp::Function>("base", "readRDS");
   return readRDS(filename);
 }


### PR DESCRIPTION
# Summary 
When we added `T` macro for NONMEM syntax, it interfered with how the templates were written when both plugins were invoked.