### PR TITLE
Only process lag time if EVID is 1 or 4

### DIFF
--- a/inst/maintenance/unit/test-z-alag-f.R
+++ b/inst/maintenance/unit/test-z-alag-f.R
@@ -155,3 +155,14 @@ test_that("ALAG is set from data", {
   
 })
 
+test_that("ALAG does not change records with EVID 3", {
+  data1 <- c(
+    ev(amt = 100), 
+    ev(amt = 0, evid = 3, time = 8), 
+    ev(amt = 100, time = 12)
+  )
+  data2 <- mutate(data1, ALAG1 = c(0, 5, 0))
+  out1 <- mrgsim(mod, data1, end = 24)
+  out2 <- mrgsim(mod, data2, end = 24)
+  expect_equal(out1@data, out2@data)
+})

--- a/inst/maintenance/unit/test-z-alag-f.R
+++ b/inst/maintenance/unit/test-z-alag-f.R
@@ -155,7 +155,7 @@ test_that("ALAG is set from data", {
   
 })
 
-test_that("ALAG does not change records with EVID 3", {
+test_that("ALAG does not change records with EVID 3 [SLV-00777-01]", {
   data1 <- c(
     ev(amt = 100), 
     ev(amt = 0, evid = 3, time = 8), 

--- a/inst/maintenance/unit/test-z-alag-f.R
+++ b/inst/maintenance/unit/test-z-alag-f.R
@@ -155,7 +155,7 @@ test_that("ALAG is set from data", {
   
 })
 
-test_that("ALAG does not change records with EVID 3 [SLV-00777-01]", {
+test_that("ALAG does not change records with EVID 3 [SLV-00969-01]", {
   data1 <- c(
     ev(amt = 100), 
     ev(amt = 0, evid = 3, time = 8), 

--- a/src/devtran.cpp
+++ b/src/devtran.cpp
@@ -499,7 +499,7 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
             prob.rate_main(this_rec);
           }
           
-          if(prob.alag(this_cmtn) > mindt) { // there is a valid lagtime
+          if(prob.alag(this_cmtn) > mindt && this_rec->is_dose()) { // there is a valid lagtime
             
             if(this_rec->ss() > 0) {
               this_rec->steady(&prob, a[i], Fn,solver);


### PR DESCRIPTION
# Summary 

- ALAG was affecting timing of any event record
- The PR limits this so that only EVID 1 or EVID 4 records are offset by ALAG


Test in maintenance test-z-alag-f.R