### PR TITLE
reset rownames when expanding event object on ID

### DIFF
--- a/R/events.R
+++ b/R/events.R
@@ -161,6 +161,7 @@ setMethod("ev", "missing", function(time=0, amt=0, evid=1, cmt=1, ID=numeric(0),
         rownames(data) <- NULL
       } else {
         data <- expand_event_object(data,ID)
+        rownames(data) <- NULL
       }
       
     } else {


### PR DESCRIPTION
Ugly row names when expanding event object for ID; this just resets them.