### PR TITLE
Dynamic capture of nm-var items

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -65,7 +65,7 @@ Encoding: UTF-8
 Language: en-US
 LazyLoad: yes
 NeedsCompilation: yes
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.0
 SystemRequirements: C++11
 Collate: 
     'RcppExports.R'

--- a/R/modspec.R
+++ b/R/modspec.R
@@ -767,6 +767,9 @@ get_valid_capture <- function(param, omega, sigma, build, mread.env) {
     build[["cpp_variables"]][["var"]], 
     mread.env[["autov"]]
   )
+  if(isTRUE(mread.env[["using_nm-vars"]])) {
+    ans <- c(ans, build[["nm-vars"]][["match"]][["match"]])  
+  }
   unique(ans)
 }
 

--- a/inst/maintenance/unit/test-capture.R
+++ b/inst/maintenance/unit/test-capture.R
@@ -61,7 +61,7 @@ $OMEGA @labels OGA2
 $CAPTURE CL VP = V2
 '
 
-test_that("capture via mread", {
+test_that("capture via mread [SLV-TEST-0008]", {
   mod <- mcode("capture-mread", code, capture = "Q,a=b,OGA2,z") 
   out <- outvars(mod)
   expect_equal(out$capture, c("CL", "VP", "Q", "a", "OGA2", "z"))
@@ -74,7 +74,23 @@ test_that("capture via mread", {
   expect_equal(outvars(mod)$capture, res)
 })
 
-test_that("capture pp directive via mread", {
+test_that("dynamic capture under nm-vars [SLV-TEST-0009]", {
+  code <- '
+  $plugin nm-vars
+  $cmt @number 1
+  $main F1 = 1.23;
+  '
+  mod <- mcode(
+    "dynamic-capture-f1", 
+    code, 
+    compile = FALSE, 
+    capture = "F1"
+  )
+  expect_is(mod, "mrgmod")
+  expect_equal(mod@capture, c(F1 = "F1"))
+})
+
+test_that("capture pp directive via mread [SLV-TEST-0010]", {
   mod <- modlib("irm3", capture = "STIM", compile = FALSE)  
   expect_equal(outvars(mod)$capture, c("CP", "STIM"))
 })

--- a/inst/stories.yaml
+++ b/inst/stories.yaml
@@ -1,5 +1,16 @@
 # Please add stories at the top ------------------------------------------
 
+SLV-S005: 
+  name: dynamic capture
+  description: > 
+    As a user, I want to name model variables for capture at 
+    compile time in the mread call.
+  ProductRisk: low-risk
+  tests: 
+  - SLV-TEST-0008
+  - SLV-TEST-0009
+  - SLV-TEST-0010
+
 SLV-S004: 
   name: evid 3 with lag time
   description: > 


### PR DESCRIPTION
# Summary

When checking for valid (dynamic) capture names, we weren't including variables from `nm-vars` as valid items to capture.  For example, `F1` is a special, `nm-vars` variable and if I tried to capture this dynamically (on model load) it would not recognize it as a valid capture item. 

This pull request adds those `nm-vars` variables into the valid capture list.

We also create a user story for dynamic capture; number and collect existing and new tests under that story.