### PR TITLE
Fix/alag addl

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -65,7 +65,7 @@ Encoding: UTF-8
 Language: en-US
 LazyLoad: yes
 NeedsCompilation: yes
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.0
 SystemRequirements: C++11
 Collate: 
     'RcppExports.R'

--- a/inst/include/datarecord.h
+++ b/inst/include/datarecord.h
@@ -112,6 +112,8 @@ public:
   
   void phantom_rec() {Output=false; Fromdata=false;}
   bool is_phantom() {return !Output && !Fromdata;}
+  bool is_lagged() {return Lagged;}
+  void lagged() {Lagged = true;}
 
   double Time; ///< record time
   double Id; ///< record ID value

--- a/inst/include/datarecord.h
+++ b/inst/include/datarecord.h
@@ -88,7 +88,7 @@ public:
   double ii(){return Ii;}
   
   void schedule(std::vector<rec_ptr>& thisi, double maxtime, bool put_ev_first, 
-                const unsigned int maxpos, double Fn);
+                const unsigned int maxpos, double Fn, double lagt);
   void implement(odeproblem* prob);
   void steady_zero(odeproblem* prob, LSODA& solver);
   void steady_infusion(odeproblem* prob,reclist& thisi,LSODA& solver);
@@ -119,6 +119,7 @@ public:
   unsigned short int Evid; ///< record event ID
   bool Output; ///< should this record be included in output?
   bool Fromdata; ///< is this record from the original data set?
+  bool Lagged; ///< this record was added as result of ALAG
   short int Cmt; ///< record compartment number
   unsigned int Addl; ///< number of additional doses
   unsigned short int Ss; ///< record steady-state indicator

--- a/inst/maintenance/unit/test-D-R-F.R
+++ b/inst/maintenance/unit/test-D-R-F.R
@@ -233,7 +233,7 @@ test_that("tad is correctly calculated for addl doses with lag", {
   dose <- ev(amt = 100, ii = 10, addl = 10,  time = 160) 
   out <- mrgsim(
     mod, dose, 
-    delta = 1, recsort = 3,
+    delta = 1, 
     tad = TRUE, 
     start = 200,  end = 224, add = 199.999, 
     output = "df"

--- a/inst/maintenance/unit/test-D-R-F.R
+++ b/inst/maintenance/unit/test-D-R-F.R
@@ -229,12 +229,13 @@ test_that("Infusion duration (R_) with lag time and F", {
 test_that("tad is correctly calculated for addl doses with lag", {
   # the start time is after the first dose record 
   # so all dosing records are additional doses
+  mod <- param(mod, LAGT = 1)
   dose <- ev(amt = 100, ii = 10, addl = 10,  time = 160) 
   out <- mrgsim(
     mod, dose, 
-    delta = 2, end = 3,
-    tad = TRUE, recsort = 1, 
-    start = 200,  end = 200+46, add = 199.999, 
+    delta = 1, recsort = 3,
+    tad = TRUE, 
+    start = 200,  end = 224, add = 199.999, 
     output = "df"
   )
   # there was a dose at 160, 170, ... [200, 210, 220, 230, 240]
@@ -242,8 +243,8 @@ test_that("tad is correctly calculated for addl doses with lag", {
   doses <- seq(200, 240, 10) 
   dose_rec <- which(out$time %in% doses)
   expect_true(all(out$tad[dose_rec]==0))
-  expect_true(all(out$tad[dose_rec+1]==2))
-  expect_true(all(out$tad[dose_rec+3]==6))
+  expect_true(all(out$tad[dose_rec+1]==1))
+  expect_true(all(out$tad[dose_rec+3]==3))
   
   # The most recent dose when we started was  at 190
   # The first observation time was at 199.999

--- a/inst/maintenance/unit/test-D-R-F.R
+++ b/inst/maintenance/unit/test-D-R-F.R
@@ -231,22 +231,39 @@ test_that("tad is correctly calculated for addl doses with lag", {
   # so all dosing records are additional doses
   mod <- param(mod, LAGT = 1)
   dose <- ev(amt = 100, ii = 10, addl = 10,  time = 160) 
+  doses <- seq(200, 240, 10) 
+  
+  # With recsort = 1
   out <- mrgsim(
     mod, dose, 
-    delta = 1, 
+    delta = 1, recsort = 1, 
     tad = TRUE, 
     start = 200,  end = 224, add = 199.999, 
     output = "df"
   )
   # there was a dose at 160, 170, ... [200, 210, 220, 230, 240]
   # and observation records every 2 hours 
-  doses <- seq(200, 240, 10) 
   dose_rec <- which(out$time %in% doses)
-  expect_true(all(out$tad[dose_rec]==0))
+  expect_true(all(out$tad[dose_rec]==10))
   expect_true(all(out$tad[dose_rec+1]==1))
   expect_true(all(out$tad[dose_rec+3]==3))
   
   # The most recent dose when we started was  at 190
   # The first observation time was at 199.999
   expect_true(abs(out$tad[1] - 9.999) < 1e-10)
+
+  # With recsort = 4
+  out <- mrgsim(
+    mod, dose, 
+    delta = 1, recsort = 4, 
+    tad = TRUE, 
+    start = 200,  end = 224, add = 199.999, 
+    output = "df"
+  )
+  # there was a dose at 160, 170, ... [200, 210, 220, 230, 240]
+  # and observation records every 2 hours 
+  dose_rec <- which(out$time %in% doses)
+  expect_true(all(out$tad[dose_rec]==0))
+  
 })
+

--- a/src/datarecord.cpp
+++ b/src/datarecord.cpp
@@ -557,12 +557,8 @@ void datarecord::schedule(std::vector<rec_ptr>& thisi, double maxtime,
     this_evid = Rate > 0 ? 5 : 1;
   }
   
-  if(this->int_infusion()) {
-    thisi.reserve(thisi.size() + n_dose);  
-  } else {
-    thisi.reserve(thisi.size() + n_dose); 
-  }
-  
+  thisi.reserve(thisi.size() + n_dose); 
+
   double ontime = 0;
   
   int mp = 1000000000;

--- a/src/datarecord.cpp
+++ b/src/datarecord.cpp
@@ -46,6 +46,7 @@ datarecord::datarecord(double time_, int pos_, bool output_) {
   Id = 1;
   Fromdata=false;
   Armed = false;
+  Lagged = false;
 }
 
 
@@ -64,6 +65,7 @@ datarecord::datarecord(double time_, short int cmt_, int pos_, double id_) {
   Output = true;
   Armed = false;
   Fromdata = true;
+  Lagged = false;
 }
 
 // Data set event
@@ -84,6 +86,7 @@ datarecord::datarecord(short int cmt_, int evid_, double amt_, double time_,
   Output = false;
   Armed = true;
   Fromdata = false;
+  Lagged = false;
 }
 
 
@@ -106,6 +109,7 @@ datarecord::datarecord(short int cmt_, int evid_, double amt_,
   Output = false;
   Armed = true;
   Fromdata = false;
+  Lagged = false;
 }
 
 
@@ -533,7 +537,9 @@ void datarecord::steady_zero(odeproblem* prob, LSODA& solver) {
 }
 
 void datarecord::schedule(std::vector<rec_ptr>& thisi, double maxtime, 
-                          bool addl_ev_first, const unsigned int maxpos, double Fn) {
+                          bool addl_ev_first, 
+                          const unsigned int maxpos, double Fn, 
+                          double lagt) {
   
   if(Addl ==0) return;
   
@@ -562,6 +568,8 @@ void datarecord::schedule(std::vector<rec_ptr>& thisi, double maxtime,
     if(ontime > maxtime) break;
     
     rec_ptr evon = NEWREC(Cmt, this_evid, Amt, ontime, Rate, nextpos, Id);
+    
+    evon->Lagged = Lagged;
     
     thisi.push_back(evon);
     

--- a/src/datarecord.cpp
+++ b/src/datarecord.cpp
@@ -541,7 +541,15 @@ void datarecord::schedule(std::vector<rec_ptr>& thisi, double maxtime,
                           const unsigned int maxpos, double Fn, 
                           double lagt) {
   
-  if(Addl ==0) return;
+  if(Addl==0) return;
+  
+  bool add_parent_doses = lagt > 1e-12;
+  
+  int n_dose = Addl;
+  
+  if(add_parent_doses) {
+    n_dose = n_dose + n_dose;
+  }
   
   unsigned int this_evid = Evid;
   
@@ -550,9 +558,9 @@ void datarecord::schedule(std::vector<rec_ptr>& thisi, double maxtime,
   }
   
   if(this->int_infusion()) {
-    thisi.reserve(thisi.size() + Addl);  
+    thisi.reserve(thisi.size() + n_dose);  
   } else {
-    thisi.reserve(thisi.size() + Addl); 
+    thisi.reserve(thisi.size() + n_dose); 
   }
   
   double ontime = 0;
@@ -561,17 +569,21 @@ void datarecord::schedule(std::vector<rec_ptr>& thisi, double maxtime,
   
   int nextpos = addl_ev_first ?  -1000000000 : mp;
   
-  for(unsigned int k=1; k<=Addl; ++k) {
+  for(unsigned int k = 1; k <= Addl; ++k) {
     
     ontime = Time + Ii*double(k);
     
     if(ontime > maxtime) break;
     
+    if(add_parent_doses) {
+      rec_ptr ev_parent = NEWREC(Cmt, this_evid, Amt, ontime-lagt, Rate, nextpos, Id);
+      ev_parent -> unarm(); 
+      ev_parent -> phantom_rec();
+      thisi.push_back(ev_parent);      
+    }
+    
     rec_ptr evon = NEWREC(Cmt, this_evid, Amt, ontime, Rate, nextpos, Id);
-    
     evon->Lagged = Lagged;
-    
     thisi.push_back(evon);
-    
   }
 }  

--- a/src/devtran.cpp
+++ b/src/devtran.cpp
@@ -568,18 +568,8 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
         
         if(tad) { // Adjusts told for lagtime
           if(!this_rec->Lagged && this_rec->is_dose()) {
-            say(tto);
-            say(this_rec->Lagged);
             told = tto;
           }
-          // if(this_rec->is_dose()) {
-          //   if(this_rec->armed() && !this_rec->Lagged) {
-          //     told = tto - prob.alag(this_cmtn);  
-          //   }
-          //   if(!this_rec->armed() && !this_rec->Lagged) {
-          //     told = tto;  
-          //   }
-          //}
         }
       } // is_dose
       

--- a/src/devtran.cpp
+++ b/src/devtran.cpp
@@ -487,7 +487,10 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
       if(j != 0) {
         prob.newind(2);
         prob.set_d(this_rec);
-        prob.init_call_record(tto);
+        if(!this_rec->is_lagged()) {
+          // TODO: what other records should we skip?
+          prob.init_call_record(tto);
+        }
       }
       
       // Some non-observation event happening
@@ -527,7 +530,7 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
             rec_ptr newev = NEWREC(*this_rec);
             newev->pos(__ALAG_POS);
             newev->phantom_rec();
-            newev->Lagged = true;
+            newev->lagged();
             newev->time(this_rec->time() + prob.alag(this_cmtn));
             newev->ss(0);
             reclist::iterator alagit = a[i].begin()+j;
@@ -567,7 +570,7 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
         }
         
         if(tad) { // Adjusts told for lagtime
-          if(!this_rec->Lagged && this_rec->is_dose()) {
+          if(!this_rec->is_lagged() && this_rec->is_dose()) {
             told = tto;
           }
         }
@@ -587,7 +590,9 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
         }
       }
       
-      prob.table_call();
+      if(!this_rec->is_lagged()) {
+        prob.table_call();
+      }
       
       if(prob.any_mtime()) {
         if(prob.newind() <=1) mtimehx.clear();  


### PR DESCRIPTION
# Summary 

- When there is a lag time for doses, there are actually two dosing records: one (the parent) at the real time of the dose and one that includes the lag time when the dose is actually put into the compartment. The parent dose record is disabled so that it doesn't actually do anything
- when additional doses with lag time were scheduled, only the _actual_ additional doses were getting scheduled (the doses at the time the dose actually enters the system). This was fine for implementing the dosing, but it wrecks the internal TAD calculation as well as any TAD calculation that the user tries to implement in the model.
- The "real" dose must be implemented in addition to the "lagged" dose in order for TAD to work

This PR

1. Adds a `bool` lag time indicator to each record object; we can tell if a dosing record is the apparent dose (Lagged is false) or the actual dose (Lagged is true)
2. When additional doses are aded, we now add two doses; one parent dose (unarmed) and the Lagged dose
3. We also don't call `$MAIN` or `$TABLE` when we come across a `Lagged` dose
4. We  call `$MAIN` or `$TABLE` only for the apparent dose times, not for these "phantom", lagged doses 

 

# Example code 


``` r
library(mrgsolve)
#> 
#> Attaching package: 'mrgsolve'
#> The following object is masked from 'package:stats':
#> 
#>     filter
library(dplyr)
#> 
#> Attaching package: 'dplyr'
#> The following objects are masked from 'package:stats':
#> 
#>     filter, lag
#> The following objects are masked from 'package:base':
#> 
#>     intersect, setdiff, setequal, union

code <- '
$PLUGIN nm-vars autodec
$CMT @number 2
$PKMODEL depot = TRUE
$MAIN 
CL = 1; 
V = 20; 
KA = 1.5;
ALAG1 = 1;
D1 = 1;
'

mod <- mcode("foo", code, delta =1)
#> Building foo ...
#> done.
dose <- ev(amt = 100, ii = 10, addl = 10, rate =0, time = 160) # %>% realize_addl()
out <- mrgsim(
  mod, dose, recsort = 4, 
  tad = TRUE, 
  start = 200, 
  end = 224, 
  add = 199.999, 
  carry_out = "evid" 
)

out %>% 
  filter(time >= 190) %>% 
  as.data.frame() %>% head()
#>   ID    time   tad evid           A1       A2
#> 1  1 199.999 9.999    0 1.373017e-04 144.9602
#> 2  1 200.000 0.000    0 1.370960e-04 144.9530
#> 3  1 201.000 1.000    0 1.000000e+02 137.8836
#> 4  1 202.000 2.000    0 2.231302e+01 206.4796
#> 5  1 203.000 3.000    0 4.978708e+00 213.2158
#> 6  1 204.000 4.000    0 1.110900e+00 206.5671
```

<sup>Created on 2022-06-11 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>