### PR TITLE
don't reset system when evid is 4 and ss != 0

### DIFF
--- a/src/datarecord.cpp
+++ b/src/datarecord.cpp
@@ -189,21 +189,22 @@ void datarecord::implement(odeproblem* prob) {
     prob->y(eq_n, Amt);
     break;
   case 4:
-    for(int i=0; i < prob->neq(); ++i) {
-      prob->y(i,0.0);
-      prob->on(i);
-      prob->rate0(i,0.0);
-    } {
-      prob->init_call(Time);
-      if(!Armed) break;
-      if(Rate > 0) {
-        this->evid(5);
-      } else {
-        this->evid(1);
+    if(this->ss()==0) {
+      for(int i=0; i < prob->neq(); ++i) {
+        prob->y(i,0.0);
+        prob->on(i);
+        prob->rate0(i,0.0);
       }
-      this-> implement(prob);
-      return;
+      prob->init_call(Time);
     }
+    if(!Armed) break;
+    if(Rate > 0) {
+      this->evid(5);
+    } else {
+      this->evid(1);
+    }
+    this-> implement(prob);
+    return;
   }
   prob->lsoda_init();
 }


### PR DESCRIPTION
```r
> test_that("evid==4 with ss==1 [SLV-TEST-0019]", {
+   mod <- house()
+   dat <- as_data_set(
+     evd(amt = 100, evid = 4, ss = 1, ii = 12), 
+     evd(amt = 100, evid = 1, ss = 1, ii = 12),
+     evd(amt = 100, evid = 4, ss = 0, ii = 0),
+     evd(amt = 100, evid = 1, ss = 0, ii = 0)
+   )
+   sim <- mrgsim(mod, dat, end = 5, output = "df")
+   expect_true(all(sim$CP[sim$ID==1] == sim$CP[sim$ID==2]))
+   expect_true(all(sim$CP[sim$ID==1] == sim$CP[sim$ID==3]))
+   expect_true(all(sim$CP[sim$ID==1] == sim$CP[sim$ID==4]))
+ })
── Failure (Line 10): evid==4 with ss==1 [SLV-TEST-0019] ───────────────────────
all(sim$CP[sim$ID == 1] == sim$CP[sim$ID == 2]) is not TRUE

`actual`:   FALSE
`expected`: TRUE 

Error in reporter$stop_if_needed() : Test failed
> packageVersion("mrgsolve")
[1] ‘1.0.4’
```