### PR TITLE
Proper generation of param and init lists in TOUCH_FUNS

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: mrgsolve
 Title: Simulate from ODE-Based Models
-Version: 1.0.5
+Version: 1.0.5.9000
 Authors@R: 
     c(person(given = "Kyle T", family = "Baron",
              role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## Bugs Fixed
 
-- Fix bug where parameter and compartments lists were not getting generated 
+- Fix bug where parameter and compartment lists were not getting generated 
   properly when `mrgsolve` was not loaded (#1013).
 
 # mrgsolve 1.0.5

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# mrgsolve (development version)
+
 # mrgsolve 1.0.5
 
 - Changed behavior for dosing records where EVID = 4 and SS != 0 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # mrgsolve (development version)
 
+## Bugs Fixed
+
+- Fix bug where parameter and compartments lists were not getting generated 
+  properly when `mrgsolve` was not loaded (#1013).
+
 # mrgsolve 1.0.5
 
 - Changed behavior for dosing records where EVID = 4 and SS != 0 

--- a/src/devtran.cpp
+++ b/src/devtran.cpp
@@ -87,12 +87,14 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
   request = request - 1;
   
   // Parameters; clone names
-  const Rcpp::List Param = mod.slot("param");
+  const Rcpp::S4 ParamS4 = mod.slot("param");
+  const Rcpp::List Param = ParamS4.slot("data");
   Rcpp::CharacterVector paramnames(Param.names());
   paramnames = Rcpp::clone(paramnames);
   
   // Compartments; clone names
-  const Rcpp::List Init = mod.slot("init");
+  const Rcpp::S4 InitS4 = mod.slot("init");
+  const Rcpp::List Init = InitS4.slot("data");
   Rcpp::CharacterVector cmtnames(Init.names());
   cmtnames = Rcpp::clone(cmtnames);
   Rcpp::NumericVector init(Init.size());

--- a/src/odeproblem.cpp
+++ b/src/odeproblem.cpp
@@ -716,8 +716,10 @@ Rcpp::List TOUCH_FUNS(const Rcpp::List& funs,
   Rcpp::List ans;
   
   Rcpp::Environment envir = mod.slot("envir");
-  Rcpp::List lparam = mod.slot("param");
-  Rcpp::List linit = mod.slot("init");
+  Rcpp::S4 paramS4 = mod.slot("param");
+  Rcpp::List lparam = paramS4.slot("data");
+  Rcpp::S4 initS4 = mod.slot("init");
+  Rcpp::List linit = initS4.slot("data");
   Rcpp::CharacterVector capture = mod.slot("capture");
   
   lparam = Rcpp::clone(lparam);


### PR DESCRIPTION
# Summary 

In `TOUCH_FUNS`, we get the `param` and `init` slots and Rcpp is able to coerce those to lists _when mrgsolve is loaded_. 

Apparently, when mrgsolve is not loaded, it cannot do this coercion.  This was discovered after `1.0.5` was released and @rymarinelli and @kyleam tested reverse dependencies.

I didn't intend to have Rcpp coerce these data structures (it was a coding mistake). So this PR codes correctly: to get the list of parameters or compartment initial values, we need to do two steps:

1. Get `param` (or `init`) slot from the model object
2. Get `data` slot from the `param` (or `init`) object

When we do this correctly (without relying on Rcpp to coerce), at  least one revdep  now works. 
