### PR TITLE
Refactor/model include

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -65,7 +65,7 @@ Encoding: UTF-8
 Language: en-US
 LazyLoad: yes
 NeedsCompilation: yes
-RoxygenNote: 7.2.0
+RoxygenNote: 7.2.1
 SystemRequirements: C++11
 Collate: 
     'RcppExports.R'

--- a/R/mread.R
+++ b/R/mread.R
@@ -476,7 +476,8 @@ mread <- function(model, project = getOption("mrgsolve.project", getwd()),
   }
   
   cat(
-    paste0("// Source MD5: ", build[["md5"]], "\n"),
+    paste0("// Source MD5: ", build[["md5"]]),
+    "\n// PLUGINS:",
     plugin_code(plugin),
     ## This should get moved to rd
     "\n// FIXED:",
@@ -488,9 +489,9 @@ mread <- function(model, project = getOption("mrgsolve.project", getwd()),
     "\n// MODEL HEADER FILES:",
     incl("mrgsolv.h"), 
     incl("modelheader.h"),
-    "\n//INCLUDE databox functions:",
+    "\n// INCLUDE databox functions:",
     incl("databox_cpp.h"),
-    "\n//USING plugins",
+    "\n// USING plugins:",
     plugin_using(plugin),
     "\n// GLOBAL CODE BLOCK:",
     "// GLOBAL VARS FROM BLOCKS & TYPEDEFS:",

--- a/inst/base/databox_cpp.h
+++ b/inst/base/databox_cpp.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2013 - 2020  Metrum Research Group
+// Copyright (C) 2013 - 2023  Metrum Research Group
 //
 // This file is part of mrgsolve.
 //

--- a/inst/base/databox_cpp.h
+++ b/inst/base/databox_cpp.h
@@ -15,6 +15,10 @@
 // You should have received a copy of the GNU General Public License
 // along with mrgsolve.  If not, see <http://www.gnu.org/licenses/>.
 
+
+#ifndef DATABOX_CPP_H
+#define DATABOX_CPP_H
+
 void databox::mevent(double time, int evid) {
   mrgsolve::evdata ev(time,evid);
   mevector.push_back(ev);
@@ -39,3 +43,5 @@ double databox::tad() {
   if((evid == 1) || (evid == 4)) told = time;
   return told < 0 ? -1.0 : time - told;
 }
+
+#endif

--- a/inst/base/mrgsolv.h
+++ b/inst/base/mrgsolv.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2013 - 2019  Metrum Research Group, LLC
+// Copyright (C) 2013 - 2022  Metrum Research Group
 //
 // This file is part of mrgsolve.
 //
@@ -76,6 +76,7 @@ template <class type1, class type2> void report(type1 a, type2 b) {
 namespace mrg = mrgsolve;
 
 //! member functions mevent and tad come in via housemodel; see inst/base/databox.cpp
+
 
 /**
  * Model data passed to the model.  

--- a/inst/mrgx/mrgx.h
+++ b/inst/mrgx/mrgx.h
@@ -22,7 +22,10 @@
 #ifndef MRGX_H
 #define MRGX_H
 
-#include "modelheader.h"
+
+//#include "modelheader.h"
+//#include "databox_cpp.h"
+#include "mrgsolv.h"
 
 /** 
  * @defgroup mrgx mrgx functions

--- a/inst/mrgx/mrgx.h
+++ b/inst/mrgx/mrgx.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2013 - 2022  Metrum Research Group
+// Copyright (C) 2013 - 2023  Metrum Research Group
 //
 // This file is part of mrgsolve.
 //
@@ -22,9 +22,6 @@
 #ifndef MRGX_H
 #define MRGX_H
 
-
-//#include "modelheader.h"
-//#include "databox_cpp.h"
 #include "mrgsolv.h"
 
 /** 
@@ -219,4 +216,3 @@ Rcpp::Function mt_fun() {
 }
 
 #endif
-

--- a/src/housemodel-mread-header.h
+++ b/src/housemodel-mread-header.h
@@ -1,5 +1,6 @@
 // Source MD5: 509e24de6401c4c7d8c72c3487b55e52
 
+// PLUGINS:
 
 // FIXED:
 // No fixed parameters.
@@ -13,10 +14,10 @@
 #include "mrgsolv.h"
 #include "modelheader.h"
 
-//INCLUDE databox functions:
+// INCLUDE databox functions:
 #include "databox_cpp.h"
 
-//USING plugins
+// USING plugins:
 
 // GLOBAL CODE BLOCK:
 // GLOBAL VARS FROM BLOCKS & TYPEDEFS:


### PR DESCRIPTION
- This PR refactors the files that get included when building a model. The change was initiated because I realized we are including more than necessary. 

- Along the way, I noticed a missing include-guard that was added

- I initially thought the source of the problem was the order in which the model code was getting written; that wasn't it but we'll keep some of the linting in that file consistent with the contributing guide

