### PR TITLE
fixes gen rdefs issue for nm-vars with no frda

### DIFF
--- a/R/nm-mode.R
+++ b/R/nm-mode.R
@@ -35,6 +35,7 @@ find_nm_vars <- function(spec) {
     is_frda <- as.integer(m[["prefix"]] %in% FRDA)
     m <- m[order(is_frda, m[["prefix"]], m[["cmt"]]),, drop = FALSE]
     ans[["frda"]] <- m[m[["prefix"]] %in% FRDA,,drop=FALSE]    
+    ans[["found_frda"]] <- nrow(ans[["frda"]]) > 0
     rownames(m) <- NULL
     ans[["match"]] <- m
     ans[["cmtn"]] <- sort(unique(m[["cmt"]]))
@@ -64,7 +65,7 @@ find_nm_vars_impl <- function(code) {
 }
 
 generate_nmdefs <- function(x) {
-  if(isFALSE(x[["found_any"]])) return(NULL)
+  if(isFALSE(x[["found_frda"]])) return(NULL)
   ans <- paste0(
     "#define ", 
     x[["frda"]][["match"]],

--- a/inst/maintenance/unit/test-nm-vars.R
+++ b/inst/maintenance/unit/test-nm-vars.R
@@ -219,3 +219,14 @@ test_that("nm-vars functional test", {
   expect_equal(out2$b[1], log(mod2$VC), tolerance = 1e-3)
   expect_equal(out2$c[1], sqrt(mod2$KA), tolerance = 1e-3)
 })
+
+test_that("nm-vars no frda items", {
+  code <- '
+  $plugin nm-vars
+  $cmt A1
+  $main A_0(1) = 1;
+'
+  mod <- mcode("test nmvars with no frda", code, compile = FALSE)
+  a <- readLines(file.path(soloc(mod), "foo-mread-header.h"))
+  expect_false(any(grepl("#define  __[]", a, fixed = TRUE)))
+})

--- a/inst/maintenance/unit/test-nm-vars.R
+++ b/inst/maintenance/unit/test-nm-vars.R
@@ -226,7 +226,7 @@ test_that("nm-vars no frda items", {
   $cmt A1
   $main A_0(1) = 1;
 '
-  mod <- mcode("test nmvars with no frda", code, compile = FALSE)
-  a <- readLines(file.path(soloc(mod), "foo-mread-header.h"))
+  mod <- mcode("u229", code, compile = FALSE)
+  a <- readLines(file.path(soloc(mod), "u229-mread-header.h"))
   expect_false(any(grepl("#define  __[]", a, fixed = TRUE)))
 })


### PR DESCRIPTION
# Summary

When processing a model with `nm-vars`, if there wasn't an `FRDA` item, we'd write out a bad pre-processor definition. This PR  implements check of `found_frda` rather than `found_any` when deciding whether or not to try to write a definition out. Also noticed that we were carrying `found_frda` in the object, but it was never set. 