### PR TITLE
use identical to check value of run in nmext and nmxml

### DIFF
--- a/R/nmxml.R
+++ b/R/nmxml.R
@@ -102,7 +102,7 @@ nmxml <- function(run = numeric(0), project = character(0),
     if(missing(run) | missing(project)) {
       wstop("both file and run or project are missing")
     }
-    if(run=="@cppstem") {
+    if(identical(run, "@cppstem")) {
       run <- env$root
     }
     target <- file.path(project, run, paste0(run, ".xml"))
@@ -246,7 +246,7 @@ nmext <- function(run = NA_real_, project = getwd(),
     setwd(env[["project"]])
   }
   
-  if(run=="@cppstem") {
+  if(identical(run, "@cppstem")) {
     run <- env$root
   }
 

--- a/inst/stories.yaml
+++ b/inst/stories.yaml
@@ -1,4 +1,11 @@
 # Please add stories at the top ------------------------------------------
+SLV-0011: 
+  name: import estimates from NONMEM
+  description: > 
+    As a user, I want to import parameter estimates from a NONMEM run.
+  ProductRisk: low-risk
+  tests: 
+  - SLV-TEST-0023
 SLV-0010: 
   name: share root with NONMEM
   description: > 

--- a/tests/testthat/nm/1005-path-ext.mod
+++ b/tests/testthat/nm/1005-path-ext.mod
@@ -1,0 +1,4 @@
+[ nmext ] 
+path = "nonmem/1005/1005.ext"
+root = "cppfile"
+

--- a/tests/testthat/nm/1005-path-xml.mod
+++ b/tests/testthat/nm/1005-path-xml.mod
@@ -1,0 +1,4 @@
+[ nmxml ] 
+path = "nonmem/1005/1005.xml"
+root = "cppfile"
+

--- a/tests/testthat/test-nmxml.R
+++ b/tests/testthat/test-nmxml.R
@@ -356,7 +356,7 @@ test_that("nm source file is available via as.list", {
 
 test_that("use cpp file stem as nm run number nmext [SLV-TEST-0021]", {
   skip_if_not(file.exists("nm/cppstem-nmext/1005.cpp"))
-  mod <- mread("1005", project = "nm/cppstem-nmext")
+  mod <- mread("1005", project = "nm/cppstem-nmext", compile = FALSE)
   expect_is(mod, "mrgmod")
   nmext_file <- basename(as.list(mod)[["nm_import"]])
   expect_equal(nmext_file, "1005.ext")
@@ -364,7 +364,21 @@ test_that("use cpp file stem as nm run number nmext [SLV-TEST-0021]", {
 
 test_that("use cpp file stem as nm run number nmxml [SLV-TEST-0022]", {
   skip_if_not(file.exists("nm/cppstem-nmxml/1005.cpp"))
-  mod <- mread("1005", project = "nm/cppstem-nmxml")
+  mod <- mread("1005", project = "nm/cppstem-nmxml", compile = FALSE)
+  expect_is(mod, "mrgmod")
+  nmxml_file <- basename(as.list(mod)[["nm_import"]])
+  expect_equal(nmxml_file, "1005.xml")
+})
+
+test_that("provide path rather than run and project [SLV-TEST-023]", {
+  skip_if_not(file.exists("nm/1005-path-ext.mod"))
+  mod <- mread("1005-path-ext.mod", project = "nm", compile = FALSE)
+  expect_is(mod, "mrgmod")
+  nmext_file <- basename(as.list(mod)[["nm_import"]])
+  expect_equal(nmext_file, "1005.ext")
+  
+  skip_if_not(file.exists("nm/1005-path-xml.mod"))
+  mod <- mread("1005-path-xml.mod", project = "nm", compile = FALSE)
   expect_is(mod, "mrgmod")
   nmxml_file <- basename(as.list(mod)[["nm_import"]])
   expect_equal(nmxml_file, "1005.xml")


### PR DESCRIPTION
# Summary

This PR fixes a bug in `NMEXT` and `NMXML` where the `run` argument may take it's default value of `NA` (nmext) or `NULL` (nmxml) and then be tested for equality with `"@cppstem"`. This bug was introduced in version 1.0.7 with the `"@cppstem"` feature. 

The test of `run` was updated to use `identical()` rather than `==`.  The PR also adds two unit test models where we bypass the `run` + `project` setup and specify `path` instead. The `NMEXT` test will fail if using version 1.0.7 but pass with this PR. I didn't check this with `NMXML`, but updated the test logic to `identical()` anyway and the test should pass with this PR. 

Some tests were modified to avoid actually compiling the models as compilation is not needed for these tests. 
