### PR TITLE
Pass SIGMA into model functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # mrgsolve (development version)
 
+- New model macro called `SIGMA()` which allows the user to access on-diagonal 
+  elements of `SIGMA` in the model (e.g. `SIGMA(2)`) (#1051, #1052).
+
 # mrgsolve 1.0.7
 
 - `$NMXML` and `$NMEXT` now accept the `run` argument set to `"@cppstem"` (i.e  

--- a/inst/base/modelheader.h
+++ b/inst/base/modelheader.h
@@ -116,8 +116,9 @@ typedef double capture;
 // random effects.  These might get used,
 // but users are allowed to insert labels to
 // avoid directly accessing the macros.
-#define ETA(a) self.ETA.at(a-1)
-#define EPS(a) self.EPS.at(a-1)
+#define ETA(a)   self.ETA.at(a-1)
+#define EPS(a)   self.EPS.at(a-1)
+#define SIGMA(a) self.SIGMA.at(a-1)
 #define _xETA(a) self.ETA[a-1]
 #define _xEPS(a) self.EPS[a-1]
 

--- a/inst/base/mrgsolv.h
+++ b/inst/base/mrgsolv.h
@@ -89,6 +89,7 @@ class databox {
 public: 
   std::vector<double> ETA; ///< vector of ETA values
   std::vector<double> EPS; ///< vector of EPS values
+  std::vector<double> SIGMA; ///< vector of on-diagonal sigma elements
   unsigned int newind; ///< new individual flag
   double time; ///< current simulation time
   int evid;  ///< event ID flag

--- a/inst/include/odeproblem.h
+++ b/inst/include/odeproblem.h
@@ -122,6 +122,7 @@ public:
 
   void omega(const Rcpp::S4& mod);
   void sigma(const Rcpp::S4& mod);
+  void copy_sigma_diagonals();
 
   arma::mat mv_omega(int n);
   arma::mat mv_sigma(int n);

--- a/inst/maintenance/unit/test-misc-syntax.R
+++ b/inst/maintenance/unit/test-misc-syntax.R
@@ -5,20 +5,34 @@ library(dplyr)
 Sys.setenv(R_TESTS="")
 options("mrgsolve_mread_quiet"=TRUE)
 
+theta_sigma_n <- '
+[ param ] THETA1 = 1.2, SN = 1
+[ SIGMA ] 1.1 2.2 3.3 4.4
+[ main ] 
+capture CL = THETA(1);
+[ error ] 
+capture SIGMA2 = SIGMA(SN);
+
+'
+mod_th_sg_n <- mcode("theta_sigma_n", theta_sigma_n)
+
 test_that("THETA(n) is allowed", {
-  code <- '
-  [ param ] THETA1 = 1.2;
-  [ main ] 
-  capture CL = THETA(1);
-  '
-  mod <- mcode("thetan", code)
-  out <- mrgsim(mod, end = 1)
+  out <- mrgsim(mod_th_sg_n, end = 1)
   expect_equal(out$CL[1], 1.2)
   expect_error(
     mcode("thetan2", "[param] THETA = 2"), 
     regexp="Reserved words in model names: THETA"
   )
 })
+
+test_that("Access SIGMA(n)", {
+  out <- mrgsim(mod_th_sg_n, end = -1, param = list(SN = 2))
+  expect_equal(out$SIGMA2, 2.2)
+  out <- mrgsim(mod_th_sg_n, end = -1, param = list(SN = 4))
+  expect_equal(out$SIGMA2, 4.4)
+})
+
+mod_th_sg_n <- NULL
 
 test_that("autodec + nm-vars functional test", {
   eps <- 1e-4

--- a/inst/maintenance/unit/test-misc-syntax.R
+++ b/inst/maintenance/unit/test-misc-syntax.R
@@ -25,7 +25,7 @@ test_that("THETA(n) is allowed", {
   )
 })
 
-test_that("Access SIGMA(n)", {
+test_that("Access SIGMA(n) [SLV-TEST-0090]", {
   out <- mrgsim(mod_th_sg_n, end = -1, param = list(SN = 2))
   expect_equal(out$SIGMA2, 2.2)
   out <- mrgsim(mod_th_sg_n, end = -1, param = list(SN = 4))

--- a/inst/stories.yaml
+++ b/inst/stories.yaml
@@ -1,4 +1,11 @@
 # Please add stories at the top ------------------------------------------
+SLV-0011: 
+  name: access SIGMA(n) in the model
+  description: > 
+    As a user, I want to access on-diagonal elements of SIGMA inside the model.
+  ProductRisk: low-risk
+  tests: 
+  - SLV-TEST-0090
 SLV-0010: 
   name: share root with NONMEM
   description: > 

--- a/src/devtran.cpp
+++ b/src/devtran.cpp
@@ -306,6 +306,7 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
   if(neps > 0) {
     prob.set_eps();
     eps = prob.mv_sigma(NN);
+    prob.copy_sigma_diagonals();
   }
   
   Rcpp::CharacterVector tran_names;

--- a/src/odeproblem.cpp
+++ b/src/odeproblem.cpp
@@ -93,6 +93,7 @@ odeproblem::odeproblem(Rcpp::List param,
   d.id = 1.0;
   d.EPS.assign(50,0.0);
   d.ETA.assign(50,0.0);
+  d.SIGMA.assign(5,0.0);
   d.CFONSTOP = false;
   d.cmt = 0;
   d.amt = 0;
@@ -769,6 +770,15 @@ void odeproblem::sigma(const Rcpp::S4& mod) {
   // if(!(Sigma.is_symmetric())) {
   //   Sigma  = symmatl(Sigma);
   // }
+}
+
+void odeproblem::copy_sigma_diagonals() {
+  if(d.SIGMA.size() < Sigma.n_cols) {
+    d.SIGMA.assign(Sigma.n_cols, 0.0);  
+  }
+  for(size_t i = 0; i < Sigma.n_cols; ++i) {
+    d.SIGMA[i] = Sigma(i,i);  
+  }
 }
 
 arma::mat odeproblem::mv_omega(int n) {


### PR DESCRIPTION
# Summary

This PR implements the ability to access on diagonal elements of `SIGMA` in the model functions. 

The data are stored as a numeric vector in `self.SIGMA`. This is zero- based indexing. There is 1-based indexing through the `SIGMA()` macro (see unit test). 

