### PR TITLE
Fix mread_cache when the full path is passed

### DIFF
--- a/R/mread.R
+++ b/R/mread.R
@@ -159,7 +159,7 @@ mread <- function(model, project = getOption("mrgsolve.project", getwd()),
                   capture = NULL,
                   preclean = FALSE, recover = FALSE, ...) {
   
-  if(charthere(model, "/")) {
+  if(!identical(basename(model), as.character(model))) {
     project <- dirname(model)
     model <- basename(model)
   }
@@ -600,7 +600,7 @@ mread_cache <- function(model = NULL,
                         preclean = FALSE, 
                         capture = NULL, ...) {
   
-  if (charthere(model, "/")) {
+  if (!identical(basename(model), as.character(model))) {
     project <- dirname(model)
     model <- basename(model)
   }

--- a/R/mread.R
+++ b/R/mread.R
@@ -600,6 +600,11 @@ mread_cache <- function(model = NULL,
                         preclean = FALSE, 
                         capture = NULL, ...) {
   
+  if (charthere(model, "/")) {
+    project <- dirname(model)
+    model <- basename(model)
+  }
+  
   if(is.character(capture)) preclean <- TRUE
   
   build <- new_build(file, model, project, soloc, code, preclean) 

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -44,8 +44,6 @@ test_that("model caches via mread_cache", {
   expect_equal(mod2@args$foo,mo@args$foo)
 })
 
-
-
 test_that("model caches via mcode_cache", {
   code <- '
   $PARAM A = 1 
@@ -58,6 +56,10 @@ test_that("model caches via mcode_cache", {
   expect_false(identical(mod,mod3))
 })
 
+test_that("mread_cache with full path to cpp file", {
+  skip_if(!file.exists("nm/1005-xml.cpp"))
+  mod <- mread_cache("nm/1005-xml.cpp", compile = FALSE)
+  expect_is(mod, "mrgmod")
+})
 
 mrgsolve:::update_wait_time(2)
-


### PR DESCRIPTION
See #1050 

This PR adds a bit of code that was already in `mread()` for dealing with this input.

A test was added for this scenario as well.