### PR TITLE
Drop cxx11

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -66,7 +66,6 @@ Language: en-US
 LazyLoad: yes
 NeedsCompilation: yes
 RoxygenNote: 7.2.3
-SystemRequirements: C++14
 Collate: 
     'RcppExports.R'
     'utils.R'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,7 @@ URL: https://github.com/metrumresearchgroup/mrgsolve
 BugReports: 
     https://github.com/metrumresearchgroup/mrgsolve/issues
 Depends:
-    R (>= 3.5),
+    R (>= 3.6.2),
     methods
 Imports:
     Rcpp (>= 1.0.7),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -66,7 +66,7 @@ Language: en-US
 LazyLoad: yes
 NeedsCompilation: yes
 RoxygenNote: 7.2.3
-SystemRequirements: C++11
+SystemRequirements: C++14
 Collate: 
     'RcppExports.R'
     'utils.R'

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,4 +1,4 @@
 PKG_LIBS = $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)  
 PKG_CPPFLAGS = -I../inst/include -I../inst/base -I.
-CXX_STD = CXX11
+CXX_STD = CXX14
 

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,4 +1,2 @@
 PKG_LIBS = $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)  
 PKG_CPPFLAGS = -I../inst/include -I../inst/base -I.
-CXX_STD = CXX14
-

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,3 +1,3 @@
 PKG_CPPFLAGS =  -I../inst/include -I../inst/base -g -I.
 PKG_LIBS = $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS) 
-CXX_STD = CXX11
+CXX_STD = CXX14

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,3 +1,2 @@
 PKG_CPPFLAGS =  -I../inst/include -I../inst/base -g -I.
 PKG_LIBS = $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS) 
-CXX_STD = CXX14


### PR DESCRIPTION
This PR drops any statement of a C++ standard. This seems to be required 
See: https://cran.r-project.org/web/checks/check_results_mrgsolve.html

A lot of people are saying to just drop it. I'd personally rather just leave it in but it looks like CRAN is going to complain if it finds `CXX11`. 

One question I have: should we start depending on a later version of R? Maybe it's time to bump that up. I don't think there is much to worry about wrt CXX version if R >= 4.0.

https://developer.r-project.org/blosxom.cgi/R-devel/2023/02/21#n2023-02-21
https://cran.r-project.org/doc/manuals/r-devel/R-exts.html#C-standards