### PR TITLE
Fix generic signature problems identified with new R-devel

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: mrgsolve
 Title: Simulate from ODE-Based Models
-Version: 1.0.8.9000
+Version: 1.0.8.9001
 Authors@R: 
     c(person(given = "Kyle T", family = "Baron",
              role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # mrgsolve (development version)
 
-- Fix signatures for `compile()` and `as_tibble()` methods based on new R-devel
-  check findings (#1065).
+- Fix signatures for `compiled.mrgmod()` and `as_tibble.mrgsims()` based on new
+  R-devel check findings (#1065).
 
 # mrgsolve 1.0.8
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # mrgsolve (development version)
 
+- Fix signatures for `compile()` and `as_tibble()` methods based on new R-devel
+  check findings (#1065).
+
 # mrgsolve 1.0.8
 
 - `SIGMA()` is a new model macro which allows users to access on-diagonal

--- a/R/compile.R
+++ b/R/compile.R
@@ -1,4 +1,4 @@
-# Copyright (C) 2013 - 2019  Metrum Research Group, LLC
+# Copyright (C) 2013 - 2023  Metrum Research Group
 #
 # This file is part of mrgsolve.
 #
@@ -130,7 +130,7 @@ compiled <- function(x,...) UseMethod("compiled")
 #' @export
 compiled.default <- function(x,...) return(FALSE)
 #' @export
-compiled.mrgmod <- function(x,status=NULL) {
+compiled.mrgmod <- function(x, status = NULL, ...) {
     if(is.null(status)) return(x@shlib$compiled)
     x@shlib$compiled <- status
     return(x)

--- a/R/mrgsims.R
+++ b/R/mrgsims.R
@@ -235,29 +235,18 @@ slice.mrgsims <- function(.data,...) {
 }
 
 ##' @rdname mrgsims_dplyr
-##' @param .data_ mrgsims object
 ##' @export
-as_data_frame.mrgsims <- function(.data_,...) {
-  as_tibble(as.data.frame(.data_),...)
+as_data_frame.mrgsims <- function(x,...) {
+  as_tibble(as.data.frame(x),...)
 }
 
-#' @param .rows passed to [tibble::as_tibble()]
-#' @param .name_repair passed to [tibble::as_tibble()]
-#' @param rownames passed to [tibble::as_tibble()]
+
+#' @param x mrgsims object.
+#' 
 #' @rdname mrgsims_dplyr
 #' @export
-as_tibble.mrgsims <- function(x, 
-                              .rows = NULL, 
-                              .name_repair = c("check_unique", "unique", 
-                                               "universal", "minimal"), 
-                              rownames = NULL, ...) {
-  as_tibble(
-    as.data.frame(x), 
-    .rows = .rows, 
-    .name_repair = .name_repair, 
-    rownames = rownames, 
-    ...
-  )  
+as_tibble.mrgsims <- function(x, ...) {
+  as_tibble(as.data.frame(x), ...)  
 }
 
 #' @rdname mrgsims_dplyr

--- a/R/mrgsims.R
+++ b/R/mrgsims.R
@@ -241,10 +241,23 @@ as_data_frame.mrgsims <- function(.data_,...) {
   as_tibble(as.data.frame(.data_),...)
 }
 
-##' @rdname mrgsims_dplyr
-##' @export
-as_tibble.mrgsims <- function(.data_,...) {
-  as_tibble(as.data.frame(.data_),...)  
+#' @param .rows passed to [tibble::as_tibble()]
+#' @param .name_repair passed to [tibble::as_tibble()]
+#' @param rownames passed to [tibble::as_tibble()]
+#' @rdname mrgsims_dplyr
+#' @export
+as_tibble.mrgsims <- function(x, 
+                              .rows = NULL, 
+                              .name_repair = c("check_unique", "unique", 
+                                               "universal", "minimal"), 
+                              rownames = NULL, ...) {
+  as_tibble(
+    as.data.frame(x), 
+    .rows = .rows, 
+    .name_repair = .name_repair, 
+    rownames = rownames, 
+    ...
+  )  
 }
 
 #' @rdname mrgsims_dplyr

--- a/man/mrgsims_dplyr.Rd
+++ b/man/mrgsims_dplyr.Rd
@@ -37,15 +37,9 @@
 
 \method{slice}{mrgsims}(.data, ...)
 
-as_data_frame.mrgsims(.data_, ...)
+as_data_frame.mrgsims(x, ...)
 
-\method{as_tibble}{mrgsims}(
-  x,
-  .rows = NULL,
-  .name_repair = c("check_unique", "unique", "universal", "minimal"),
-  rownames = NULL,
-  ...
-)
+\method{as_tibble}{mrgsims}(x, ...)
 
 as.tbl.mrgsims(x, ...)
 }
@@ -64,15 +58,7 @@ as.tbl.mrgsims(x, ...)
 
 \item{.dots}{passed to various \code{dplyr} functions}
 
-\item{.data_}{mrgsims object}
-
-\item{x}{passed to \link[dplyr:tbl_df]{dplyr::as.tbl}}
-
-\item{.rows}{passed to [tibble::as_tibble()]}
-
-\item{.name_repair}{passed to [tibble::as_tibble()]}
-
-\item{rownames}{passed to [tibble::as_tibble()]}
+\item{x}{mrgsims object.}
 }
 \description{
 These methods modify the data in a mrgsims object and return a data frame.

--- a/man/mrgsims_dplyr.Rd
+++ b/man/mrgsims_dplyr.Rd
@@ -39,7 +39,13 @@
 
 as_data_frame.mrgsims(.data_, ...)
 
-\method{as_tibble}{mrgsims}(.data_, ...)
+\method{as_tibble}{mrgsims}(
+  x,
+  .rows = NULL,
+  .name_repair = c("check_unique", "unique", "universal", "minimal"),
+  rownames = NULL,
+  ...
+)
 
 as.tbl.mrgsims(x, ...)
 }
@@ -61,6 +67,12 @@ as.tbl.mrgsims(x, ...)
 \item{.data_}{mrgsims object}
 
 \item{x}{passed to \link[dplyr:tbl_df]{dplyr::as.tbl}}
+
+\item{.rows}{passed to [tibble::as_tibble()]}
+
+\item{.name_repair}{passed to [tibble::as_tibble()]}
+
+\item{rownames}{passed to [tibble::as_tibble()]}
 }
 \description{
 These methods modify the data in a mrgsims object and return a data frame.


### PR DESCRIPTION
# Summary

CRAN has come up with some methods where the signature does not match the generic. This has been there for a long time and I guess R-devel changed a bit to detect this; it isn't there in R-release or R-devel up to a couple of days ago. 

@kyleam - I'm not worried about the `compile()` method. But I really want to be able to have an `as_tibble()` method for the simulation output class. I had the signature right at some point but the generic changed and that caused the problems. 

I'm heading toward just getting the methods matched up with the generics and sending that back. That seemed to fix the issue when testing R-devel from yesterday. Wondering about your thoughts on safe / sustainable approach going forward?

# Results 

```
Dear maintainer,

Please see the problems shown on
<https://cran.r-project.org/web/checks/check_results_mrgsolve.html>.

Please correct before 2023-03-22 to safely retain your package on CRAN.

Best,
-k
```

https://cran.r-project.org/web/checks/check_results_mrgsolve.html


# Tests

## Reproduce check issue on `1.0.8`

I've only been able to reproduce on (very) recent R-devel.

```
R CMD check mrgsolve_1.0.8.tar.gz
* using log directory ‘/Users/kyleb/git/m4solve/mrgsolve.Rcheck’
* using R Under development (unstable) (2023-03-07 r83950)
* using platform: aarch64-apple-darwin20 (64-bit)
* R was compiled by
    Apple clang version 13.0.0 (clang-1300.0.29.3)
    GNU Fortran (GCC) 12.0.1 20220312 (experimental)
* running under: macOS Ventura 13.2
...
* checking dependencies in R code ... OK
* checking S3 generic/method consistency ... WARNING
compiled:
  function(x, ...)
compiled.mrgmod:
  function(x, status)

as_tibble:
  function(x, ..., .rows, .name_repair, rownames)
as_tibble.mrgsims:
  function(.data_, ...)

See section ‘Generic functions and methods’ in the ‘Writing R
Extensions’ manual.
* checking replacement functions ... OK
* checking foreign function calls ... OK

```

The changes in this PR seem to fix the issue 


```
 R CMD check mrgsolve_1.0.8.9001.tar.gz
* using log directory ‘/Users/kyleb/git/m4solve/mrgsolve.Rcheck’
* using R Under development (unstable) (2023-03-07 r83950)
* using platform: aarch64-apple-darwin20 (64-bit)
* R was compiled by
    Apple clang version 13.0.0 (clang-1300.0.29.3)
    GNU Fortran (GCC) 12.0.1 20220312 (experimental)
* running under: macOS Ventura 13.2
...
* checking dependencies in R code ... OK
* checking S3 generic/method consistency ... OK
*
```