### PR TITLE
Recode NONMEM-based model in internal model library

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: mrgsolve
 Title: Simulate from ODE-Based Models
-Version: 1.0.9
+Version: 1.0.9.9000
 Authors@R: 
     c(person(given = "Kyle T", family = "Baron",
              role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# mrgsolve (development version)
+
 # mrgsolve 1.0.9
 
 - Fix signatures for `compiled.mrgmod()` and `as_tibble.mrgsims()` based on new

--- a/inst/models/1005.cpp
+++ b/inst/models/1005.cpp
@@ -5,13 +5,7 @@ Run
 file.show(system.file("nonmem", "1005", "1005.ctl", package = "mrgsolve")) 
 for equivalent NONMEM control stream. 
 
-Updated 10 Jan 2022 to use autodec and nm-vars plugins.
-
-[ PLUGIN ] autodec nm-vars
-  
-[ CMT ] @number 3
-  
-[ PKMODEL ] ncmt = 2, depot = TRUE
+[ PKMODEL ] cmt = "GUT CENT PERIPH", depot = TRUE
 
 [ PARAM ] SEX = 0, WT = 70
 
@@ -20,17 +14,17 @@ project = system.file("nonmem", package = "mrgsolve")
 run = "@cppstem"
 
 [ PK ] 
-CL = THETA(1)*exp(ETA(1)) * pow(THETA(6),SEX) * pow(WT/70.0,THETA(7));
-V2 = THETA(2)*exp(ETA(2));
-KA = THETA(3)*exp(ETA(3));
-Q  = THETA(4);
-V3 = THETA(5);
-S2 = V2;
+double CL = THETA(1)*exp(ETA(1)) * pow(THETA(6),SEX) * pow(WT/70.0,THETA(7));
+double V2 = THETA(2)*exp(ETA(2));
+double KA = THETA(3)*exp(ETA(3));
+double Q  = THETA(4);
+double V3 = THETA(5);
+double S2 = V2;
 
 [ ERROR ] 
-F = A2/S2;
-Y = F*(1+EPS(1)) + EPS(2); 
-IPRED = F; 
+double F = CENT/S2;
+double Y = F*(1+EPS(1)) + EPS(2); 
+double IPRED = F; 
 
-[ CAPTURE ]
+[ CAPTURE ] 
 CL Q V2 V3 KA ETA(1) ETA(2) ETA(3) IPRED


### PR DESCRIPTION
# Summary

Recoding this model so that it uses the traditional model specification syntax. 