### PR TITLE
Add & syntax for ev_rx

### DIFF
--- a/R/class_rx.R
+++ b/R/class_rx.R
@@ -1,4 +1,4 @@
-# Copyright (C) 2013 - 2019  Metrum Research Group, LLC
+# Copyright (C) 2013 - 2023  Metrum Research Group
 #
 # This file is part of mrgsolve.
 #
@@ -22,17 +22,17 @@ NULL
 ##' Create intervention objects from Rx input
 ##' 
 ##' See details below for Rx specification. Actual parsing is done
-##' by [parse_rx]; this function can be used to debug Rx inputs.
+##' by [parse_rx()]; this function can be used to debug Rx inputs.
 ##' 
-##' @param x a model object or `character` Rx input 
-##' @param y `character` Rx input; see details
-##' @param df if `TRUE` then a data frame is returned
-##' @param ... not used at this time
+##' @param x a model object or `character` Rx input. 
+##' @param y `character` Rx input; see details.
+##' @param df if `TRUE` then a data frame is returned.
+##' @param ... not used at this time.
 ##' 
 ##' @section Rx specification:
 ##' 
 ##' - The dose is found at the start of the string by sequential digits; this 
-##'   may be integer, decimal, or in scientific notation
+##'   may be integer, decimal, or specified in scientific notation
 ##' - Use `in` to identify the dosing compartment number; must be integer
 ##' - Use `q` to identify the dosing interval; must be integer or 
 ##'   decimal number (but not scientific notation)
@@ -46,8 +46,8 @@ NULL
 ##' 
 ##' @return The method dispatched on model object (`mrgmod`) returns another
 ##' model object.  The `character` method returns an event object.  The
-##' `parse_rx` function return a list named with 
-##' arguments for the event object constructor [ev].
+##' `parse_rx` function return a list named with arguments for the event 
+##' object constructor [ev()].
 ##' 
 ##' @examples
 ##' # example("ev_rx")

--- a/R/class_rx.R
+++ b/R/class_rx.R
@@ -86,13 +86,14 @@ setMethod("ev_rx", signature=c("mrgmod", "character"), function(x,y,...) {
 
 ##' @rdname ev_rx
 ##' @export
-setMethod("ev_rx", signature=c("character","missing"), function(x,df = FALSE,...) {
+setMethod("ev_rx", signature=c("character","missing"), function(x, df = FALSE, 
+                                                                ...) {
   x <- parse_rx(x)
   if(is.list(x[[1]])) {
     x <- lapply(x, do.call, what = ev)  
-    x <- do.call(ev_seq,x)
+    x <- do.call(ev_seq, x)
   } else {
-    x <- do.call(ev,x)
+    x <- do.call(ev, x)
   }
   if(df) return(as.data.frame(x))
   return(x)
@@ -101,7 +102,7 @@ setMethod("ev_rx", signature=c("character","missing"), function(x,df = FALSE,...
 ##' @rdname ev_rx
 ##' @export
 parse_rx <- function(x) {
-  x <- strsplit(x, "then|,")[[1]]
+  x <- strsplit(x, "then|,", perl = TRUE)[[1]]
   x <- trimws(x)
   x <- lapply(x, parse_this_rx)
   if(length(x)==1) return(x[[1]])
@@ -109,6 +110,14 @@ parse_rx <- function(x) {
 }
 
 parse_this_rx <- function(x) {
+  if(charthere(x, "&")) {
+    sp <- strsplit(x, "&", fixed = TRUE)[[1]]
+    sp <- sapply(sp, trimws, USE.NAMES = FALSE)
+    sp <- lapply(sp, parse_this_rx)
+    ev <- lapply(sp, do.call, what = ev)
+    ev <- do.call("c", ev)
+    return(list(ev))
+  }
   dose <- reg_exec_match(x, "^ *(\\d+[\\.]*\\d*[Ee\\+\\-]{0,2}\\d*)")[[1]]
   amt <- as.numeric(dose[2])
   if(is.na(amt)) {

--- a/R/class_rx.R
+++ b/R/class_rx.R
@@ -40,8 +40,9 @@ NULL
 ##'   decimal number
 ##' - Use `x` to indicate total number of doses; must be integer
 ##' - Use `then` or `,` to separate dosing periods
-##' - User `after` to insert a lag in the start of a period; integer or 
+##' - Use `after` to insert a lag in the start of a period; integer or 
 ##'   decimal number (but not scientific notation)
+##' - Use `&` to implement multiple doses at the same time
 ##' 
 ##' @return The method dispatched on model object (`mrgmod`) returns another
 ##' model object.  The `character` method returns an event object.  The
@@ -68,6 +69,8 @@ NULL
 ##' ev_rx("100 over 2.23")
 ##' 
 ##' ev_rx("100 q 12 x 3")
+##' 
+##' ev_rx("100 in 1 & 200 in 2") 
 ##' 
 ##' parse_rx("100 mg q 24 then 200 mg q12")
 ##' 

--- a/man/ev_rx.Rd
+++ b/man/ev_rx.Rd
@@ -16,29 +16,29 @@ ev_rx(x, y, ...)
 parse_rx(x)
 }
 \arguments{
-\item{x}{a model object or \code{character} Rx input}
+\item{x}{a model object or \code{character} Rx input.}
 
-\item{y}{\code{character} Rx input; see details}
+\item{y}{\code{character} Rx input; see details.}
 
-\item{...}{not used at this time}
+\item{...}{not used at this time.}
 
-\item{df}{if \code{TRUE} then a data frame is returned}
+\item{df}{if \code{TRUE} then a data frame is returned.}
 }
 \value{
 The method dispatched on model object (\code{mrgmod}) returns another
 model object.  The \code{character} method returns an event object.  The
-\code{parse_rx} function return a list named with
-arguments for the event object constructor \link{ev}.
+\code{parse_rx} function return a list named with arguments for the event
+object constructor \code{\link[=ev]{ev()}}.
 }
 \description{
 See details below for Rx specification. Actual parsing is done
-by \link{parse_rx}; this function can be used to debug Rx inputs.
+by \code{\link[=parse_rx]{parse_rx()}}; this function can be used to debug Rx inputs.
 }
 \section{Rx specification}{
 
 \itemize{
 \item The dose is found at the start of the string by sequential digits; this
-may be integer, decimal, or in scientific notation
+may be integer, decimal, or specified in scientific notation
 \item Use \verb{in} to identify the dosing compartment number; must be integer
 \item Use \code{q} to identify the dosing interval; must be integer or
 decimal number (but not scientific notation)

--- a/man/ev_rx.Rd
+++ b/man/ev_rx.Rd
@@ -46,8 +46,9 @@ decimal number (but not scientific notation)
 decimal number
 \item Use \code{x} to indicate total number of doses; must be integer
 \item Use \code{then} or \verb{,} to separate dosing periods
-\item User \code{after} to insert a lag in the start of a period; integer or
+\item Use \code{after} to insert a lag in the start of a period; integer or
 decimal number (but not scientific notation)
+\item Use \code{&} to implement multiple doses at the same time
 }
 }
 
@@ -71,6 +72,8 @@ ev_rx("100.2E-2 q4")
 ev_rx("100 over 2.23")
 
 ev_rx("100 q 12 x 3")
+
+ev_rx("100 in 1 & 200 in 2") 
 
 parse_rx("100 mg q 24 then 200 mg q12")
 

--- a/tests/testthat/test-ev_rx.R
+++ b/tests/testthat/test-ev_rx.R
@@ -43,7 +43,7 @@ test_that("parse dose only - infusion", {
   a <- ev_rx("100 over 2")
   b <- ev(amt = 100, rate = 100/2)
   expect_identical(a,b)
-
+  
   a <- ev_rx("100 ov 2")
   expect_identical(a,b)
 })
@@ -66,7 +66,7 @@ test_that("parse multiple - infusion / bolus", {
   c <- ev(amt = 200, ii = 24, addl = 1)
   d <- ev_seq(b,c)
   expect_identical(a,d)
-
+  
   a <- ev_rx("100 over 10 q 12 x 3 ,  200 q 24 x 2")
   expect_identical(a,d)
 })
@@ -81,11 +81,11 @@ test_that("dose can be in decimal or scientific", {
   a <- ev_rx("1.23E4")
   b <- ev(amt = 1.23E4)
   expect_identical(a,b)
-
+  
   a <- ev_rx("1.23e-4")
   b <- ev(amt = 1.23e-4)
   expect_identical(a,b)
-
+  
   a <- ev_rx("1.23E+4")
   b <- ev(amt = 1.23E+4)
   expect_identical(a,b)
@@ -101,7 +101,7 @@ test_that("after parameter can be decimal", {
   a <- ev_rx("1000 after 2")
   b <- ev(amt = 1000, time =2)
   expect_identical(a,b)
-
+  
   a <- ev_rx("1000 after 2.93")
   b <- ev(amt = 1000, time=2.93)
   expect_identical(a,b)
@@ -113,9 +113,10 @@ test_that("two events at the same time", {
   expect_identical(a,b)
   
   a <- ev_rx("100 in 1 & 200 in 2 then 300 in 3 after 10")  
-  b <- c(ev(amt = 100, cmt = 1), ev(amt = 200, cmt = 2), 
-         ev(amt = 300, cmt = 3, time = 10))
-  expect_identical(a$time, b$time)
-  expect_identical(a$amt, b$amt)
-  expect_identical(a$cmt, b$cmt)
+  b <- c(
+    ev(amt = 100, cmt = 1, ii = 0, addl = 0), 
+    ev(amt = 200, cmt = 2, ii = 0, addl = 0), 
+    ev(amt = 300, cmt = 3, ii = 0, addl = 0, time = 10)
+  )
+  expect_identical(a,b)
 })

--- a/tests/testthat/test-ev_rx.R
+++ b/tests/testthat/test-ev_rx.R
@@ -107,4 +107,15 @@ test_that("after parameter can be decimal", {
   expect_identical(a,b)
 })
 
-
+test_that("two events at the same time", {
+  a <- ev_rx("100 in 1 & 200 in 2 after 4")  
+  b <- c(ev(amt = 100, cmt = 1), ev(amt = 200, cmt = 2, time = 4))
+  expect_identical(a,b)
+  
+  a <- ev_rx("100 in 1 & 200 in 2 then 300 in 3 after 10")  
+  b <- c(ev(amt = 100, cmt = 1), ev(amt = 200, cmt = 2), 
+         ev(amt = 300, cmt = 3, time = 10))
+  expect_identical(a$time, b$time)
+  expect_identical(a$amt, b$amt)
+  expect_identical(a$cmt, b$cmt)
+})


### PR DESCRIPTION
# Summary 

- Use `&` to indicate that multiple events should be done at the same time
- `perl = TRUE` not required; I just like perl
