### PR TITLE
allow parameter_list objects to be passed to param

### DIFF
--- a/R/param.R
+++ b/R/param.R
@@ -100,7 +100,7 @@ setGeneric("param", function(.x, ...) {
 #' @export
 #' @rdname param
 setMethod("param", "mrgmod", function(.x, .y = NULL, ..., .pat="*", .strict=FALSE) {
-  
+
   .dots <- list(...)
   
   has_dots <- length(.dots) > 0
@@ -113,8 +113,8 @@ setMethod("param", "mrgmod", function(.x, .y = NULL, ..., .pat="*", .strict=FALS
   if(missing(.strict) && has_dots) {
     .strict <- TRUE 
   }
-  
-  if(!inherits(.y, c("NULL", "list", "data.frame", "numeric"))) {
+
+  if(!inherits(.y, c("NULL", "list", "data.frame", "numeric", "parameter_list"))) {
     wstop("[param-update] invalid object to update parameter list.")
   }
   

--- a/R/param.R
+++ b/R/param.R
@@ -25,10 +25,10 @@
 #'
 #' @param .x the model object.
 #' @param .y an object to be merged into parameter list; non-`NULL` values 
-#' must be named list, data.frame, or numeric vector; named items that do 
-#' not exist in the parameter list are allowed and will be silently ignored; 
-#' use the `.strict` argument to require that all names in `.y` exist already
-#' in the parameter list.
+#' must be named `list`, `data.frame`, `numeric` vector, or `parameter_list` 
+#' object; named items that do not exist in the parameter list are allowed and 
+#' will be silently ignored; use the `.strict` argument to require that all 
+#' names in `.y` exist already in the parameter list.
 #' @param .pat a regular expression (character) to be applied as a filter 
 #' for which parameters to show when printing.
 #' @param .strict if `TRUE`, all names to be updated must be found 
@@ -42,7 +42,7 @@
 #' Can be used to either get a parameter list object from a `mrgmod` 
 #' model object or to update the parameters in a model object.  
 #' For both uses, the return value is a `parameter_list` object. For the 
-#' former use, `param` is usually called to print the parameters to the 
+#' former use, `param()` is usually called to print the parameters to the 
 #' screen, but the `parameter_list` object can also be coerced to a list 
 #' or numeric R object.
 #' 

--- a/man/param.Rd
+++ b/man/param.Rd
@@ -33,10 +33,10 @@ must be numeric and all all names must exist in the parameter list
 for \code{.x}.}
 
 \item{.y}{an object to be merged into parameter list; non-\code{NULL} values
-must be named list, data.frame, or numeric vector; named items that do
-not exist in the parameter list are allowed and will be silently ignored;
-use the \code{.strict} argument to require that all names in \code{.y} exist already
-in the parameter list.}
+must be named \code{list}, \code{data.frame}, \code{numeric} vector, or \code{parameter_list}
+object; named items that do not exist in the parameter list are allowed and
+will be silently ignored; use the \code{.strict} argument to require that all
+names in \code{.y} exist already in the parameter list.}
 
 \item{.pat}{a regular expression (character) to be applied as a filter
 for which parameters to show when printing.}
@@ -54,7 +54,7 @@ See \link{numericlist} for methods to deal with \code{parameter_list} objects.
 Can be used to either get a parameter list object from a \code{mrgmod}
 model object or to update the parameters in a model object.
 For both uses, the return value is a \code{parameter_list} object. For the
-former use, \code{param} is usually called to print the parameters to the
+former use, \code{param()} is usually called to print the parameters to the
 screen, but the \code{parameter_list} object can also be coerced to a list
 or numeric R object.
 

--- a/tests/testthat/test-param.R
+++ b/tests/testthat/test-param.R
@@ -119,7 +119,7 @@ test_that("params are shown", {
   expect_match(x[2], "Model parameters")
 })
 
-test_that("parameter-list passed to param", {
+test_that("parameter_list object passed to param", {
   mod <- house()
   mod <- param(mod, param(CL = 10))
   expect_is(mod, "mrgmod")

--- a/tests/testthat/test-param.R
+++ b/tests/testthat/test-param.R
@@ -118,3 +118,10 @@ test_that("params are shown", {
   x <- capture.output(param(mod))
   expect_match(x[2], "Model parameters")
 })
+
+test_that("parameter-list passed to param", {
+  mod <- house()
+  mod <- param(mod, param(CL = 10))
+  expect_is(mod, "mrgmod")
+  expect_equal(mod$CL, 10)
+})


### PR DESCRIPTION
See discussion in #1075 : a user tried to do this in code and it didn't work; no reason why it shouldn't work.

This PR enables the user to pass a `parameter_list` object  to update parameters in a model object via `param()`

```r
library(dplyr)
library(mrgsolve)

mod <- house()

mod %>% param(param(CL = 5)) %>% param()
```


