### PR TITLE
Remove start and end; not used

### DIFF
--- a/src/datarecord.cpp
+++ b/src/datarecord.cpp
@@ -348,8 +348,6 @@ void datarecord::steady_infusion(odeproblem* prob, reclist& thisi, LSODA& solver
   
   reclist offs;
   
-  int start = 0;
-  int end = 0;
   bool made_it = false;  
   double diff = 0, err = 0;
   double nexti = 0.0, toff = 0.0;
@@ -360,7 +358,6 @@ void datarecord::steady_infusion(odeproblem* prob, reclist& thisi, LSODA& solver
   
   for(i=1; i < N_SS ; ++i) {
     evon->time(tfrom);
-    ++start;
     evon->implement(prob);
     prob->lsoda_init();
     toff = tfrom + duration;
@@ -377,7 +374,6 @@ void datarecord::steady_infusion(odeproblem* prob, reclist& thisi, LSODA& solver
     while((!offs.empty()) && (offs[0]->time()  <= nexti)) {
       toff = offs[0]->time();
       prob->advance(tfrom,toff,solver);
-      ++end;
       offs[0]->implement(prob);
       prob->lsoda_init();
       tfrom = toff;


### PR DESCRIPTION
I haven't seen this warning before; but it can tell that we initialize and increment `start` and `end`, but it makes no difference if we do it or not.

```c++
urces/include" -DNDEBUG -I../inst/include -I../inst/base -I. -I'/Users/kyleb/Rlibs/Rcpp/include' -I'/Users/kyleb/Rlibs/RcppArmadillo/include' -I'/Users/kyleb/Rlibs/BH/include' -I/opt/R/arm64/include  -arch arm64 -std=gnu++11 -fPIC  -falign-functions=64 -Wall -g -O2  -c datarecord.cpp -o datarecord.o
datarecord.cpp:351:7: warning: variable 'start' set but not used [-Wunused-but-set-variable]
  int start = 0;
      ^
datarecord.cpp:352:7: warning: variable 'end' set but not used [-Wunused-but-set-variable]
  int end = 0;
      ^
2 warnings generated.
ccache /usr/bin/clang++ -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -I"/Library/Frameworks/R.framework/Reso
```
