### PR TITLE
Refactor mrgsim_nid

### DIFF
--- a/R/mrgsims.R
+++ b/R/mrgsims.R
@@ -532,3 +532,8 @@ plot_sims <- function(.data, ..., .f = NULL, .dots = list()) {
   }
   return(do.call(plot, .dots))
 }
+
+#' Carry model parameters into simulated output
+#' 
+#' 
+#' @param x mrgsims object.

--- a/R/mrgsims.R
+++ b/R/mrgsims.R
@@ -532,8 +532,3 @@ plot_sims <- function(.data, ..., .f = NULL, .dots = list()) {
   }
   return(do.call(plot, .dots))
 }
-
-#' Carry model parameters into simulated output
-#' 
-#' 
-#' @param x mrgsims object.

--- a/R/mrgsolve.R
+++ b/R/mrgsolve.R
@@ -259,7 +259,7 @@ mrgsim <-  function(x, data=NULL, idata=NULL, events=NULL, nid=NULL, ...) {
   x@args$data <- NULL
   x@args$events <- NULL
   
-  if(is.numeric(nid) && !have_idata) {
+  if(is.numeric(nid) && !have_idata && !have_data) {
     return(mrgsim_nid(x, nid, events, ...))
   } 
   

--- a/R/mrgsolve.R
+++ b/R/mrgsolve.R
@@ -238,7 +238,7 @@ tgrid_id <- function(col,idata) {
 #' out
 #' @md
 #' @export
-mrgsim <-  function(x, data=NULL, idata=NULL, events=NULL, nid=1, ...) {
+mrgsim <-  function(x, data=NULL, idata=NULL, events=NULL, nid=NULL, ...) {
   if(!is.mrgmod(x)) mod_first()
   if(is.null(data)) {
     data <- x@args$data
@@ -259,7 +259,7 @@ mrgsim <-  function(x, data=NULL, idata=NULL, events=NULL, nid=1, ...) {
   x@args$data <- NULL
   x@args$events <- NULL
   
-  if(nid > 1) {
+  if(is.numeric(nid)) {
     return(mrgsim_nid(x, nid, events, ...))
   } 
   

--- a/R/mrgsolve.R
+++ b/R/mrgsolve.R
@@ -259,7 +259,7 @@ mrgsim <-  function(x, data=NULL, idata=NULL, events=NULL, nid=NULL, ...) {
   x@args$data <- NULL
   x@args$events <- NULL
   
-  if(is.numeric(nid)) {
+  if(is.numeric(nid) && !have_idata) {
     return(mrgsim_nid(x, nid, events, ...))
   } 
   

--- a/man/mrgsim.Rd
+++ b/man/mrgsim.Rd
@@ -6,7 +6,7 @@
 \alias{do_mrgsim}
 \title{Simulate from a model object}
 \usage{
-mrgsim(x, data = NULL, idata = NULL, events = NULL, nid = 1, ...)
+mrgsim(x, data = NULL, idata = NULL, events = NULL, nid = NULL, ...)
 
 mrgsim_df(..., output = "df")
 


### PR DESCRIPTION
# Summary

`mrgsim_nid()` is a convenience variant to simulate a number of IDs. The `nid` simulation has been around since way back when this was sort of useful. Now just keeping it around for continuity.

A user called out inaccurate documentation around what happens when `nid` is set to 1. Rather than changing the documentation, I refactored how it works. The bottom line is no meaningful change in function.

See #1080 

1. Change default `nid`  from 1 to `NULL`
2. Always call `mrgsim_nid()` when `nid` is numeric
