### PR TITLE
Refactor interrupt interval checking

### DIFF
--- a/src/devtran.cpp
+++ b/src/devtran.cpp
@@ -435,7 +435,7 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
     
     for(size_t j=0; j < a[i].size(); ++j) {
       
-      if(do_interrupt && !(--ic)) {
+      if(do_interrupt && (!(--ic))) {
         Rcpp::checkUserInterrupt();
         ic = prob.interrupt;
       }

--- a/src/devtran.cpp
+++ b/src/devtran.cpp
@@ -374,6 +374,7 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
   
   crow = 0; // current output row
   int crec = 0; // current record number
+  int ic = prob.interrupt; // interrupt counter
   
   prob.nid(dat.nid());
   prob.nrow(NN);
@@ -436,8 +437,10 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
     for(size_t j=0; j < a[i].size(); ++j) {
       
       ++crec;
-      if(do_interrupt && ((crec % prob.interrupt)==0)) {
+      
+      if(do_interrupt && !(--ic)) {
         Rcpp::checkUserInterrupt();
+        ic = prob.interrupt;
       }
       
       if(crow == NN) continue;

--- a/src/devtran.cpp
+++ b/src/devtran.cpp
@@ -373,7 +373,6 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
   }
   
   crow = 0; // current output row
-  int crec = 0; // current record number
   int ic = prob.interrupt; // interrupt counter
   
   prob.nid(dat.nid());
@@ -435,8 +434,6 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
     prob.init_call(tfrom);
     
     for(size_t j=0; j < a[i].size(); ++j) {
-      
-      ++crec;
       
       if(do_interrupt && !(--ic)) {
         Rcpp::checkUserInterrupt();


### PR DESCRIPTION
This PR refactors how we tell when to check for interrupt signal. Previously, it used modulus; the refactor implements a clever trick that has recently been adopted in a bunch of R code. 

For example here: 
https://github.com/wch/r-source/commit/b5e5f267a6a16c679a1d186391b7d67b5ae76968

and here:
https://github.com/wch/r-source/commit/1ca6c6c6246629c6a98a526a2906595e5cfcd45e

Thread on R-devel
https://stat.ethz.ch/pipermail/r-devel/2023-May/082607.html