### PR TITLE
Add support for etas attached to idata

### DIFF
--- a/R/mrgsim_q.R
+++ b/R/mrgsim_q.R
@@ -40,7 +40,8 @@
 ##' object is returned; if \code{"df"} then a data frame is returned.
 ##' @param simcall not used; only the default value of 0 is allowed. 
 ##' @param etasrc source for ETA() values in the model; values can include: 
-##' "omega", "data" or "data.all"; see 'Details' in [mrgsim()]. 
+##' "omega", `"data"`, `"data.all"`, `"idata"`, or `"idata.all"`; see 
+##' 'Details' in [mrgsim()]. 
 ##' 
 ##' @details
 ##' 

--- a/R/mrgsolve.R
+++ b/R/mrgsolve.R
@@ -480,7 +480,8 @@ mrgsim_nid <- function(x, nid, events = ev(), ...) {
 #' @param tgrid a tgrid object; or a numeric vector of simulation times
 #' or another object with an `stime` method. 
 #' @param etasrc source for `ETA()` values in the model; values can include: 
-#' `"omega"`, `"data"` or `"data.all"`; see 'Details'. 
+#' `"omega"`, `"data"`, `"data.all"`, `"idata"`, or `"idata.all"`; see 
+#' 'Details'. 
 #' @param recsort record sorting flag.  Default value is 1.  Possible values 
 #' are 1,2,3,4: 1 and 2 put doses in a data set after padded observations at 
 #' the same time; 3 and 4 put those doses before padded observations at the 

--- a/R/mrgsolve.R
+++ b/R/mrgsolve.R
@@ -167,7 +167,9 @@ tgrid_id <- function(col,idata) {
 #' - `etasrc`: this argument lets you control where `ETA(n)` come from in the 
 #' model. When `etasrc` is set to `"omega"` (the default), `ETAs` will be 
 #' simulated from a multivariate normal distribution defined by the `$OMEGA`
-#' blocks in the model. When `etasrc` is set to `"data"` or `"data.all"`, 
+#' blocks in the model. Alternatively, input `data` or `idata` sets can be used
+#' to pass in fixed `ETA(n)` by setting `etasrc` to `"data"`, `"idata"`, 
+#' `"data.all"` or `"idata.all"`. When `etasrc` is set to `"data"` or `"data.all"`, 
 #' the input data set will be scanned for columns called `ETA1`, `ETA2`, ..., 
 #' `ETAn` and those values will be copied into the appropriate slot in the 
 #' `ETA()` vector. Only the first record for each individual will be copied into 
@@ -189,7 +191,9 @@ tgrid_id <- function(col,idata) {
 #' can pass `etasrc = "data.all"` which causes an error to be generated if any 
 #' `ETAn` is missing from the data set. Use this option when you intend to have 
 #' _all_ `ETAs` attached to the data set and want an error generated if mrgsolve 
-#' finds one or more of them is missing.
+#' finds one or more of them is missing. Using `etasrc ="idata"` or 
+#' `"idata.all"`, the behavior is identical to `"data"` (or `"data.all"`), 
+#' except mrgsolve will look at the idata set rather than data set.
 #' 
 #' 
 #' @seealso [mrgsim_variants], [mrgsim_q()]

--- a/inst/maintenance/unit/test-simeta.R
+++ b/inst/maintenance/unit/test-simeta.R
@@ -288,22 +288,6 @@ test_that("pass ETA on the data set", {
   expect_identical(out@data, outq@data)
 })
 
-# Bug discovered with #1092
-test_that("etasrc works with ETA in first column", {
-  mod <- param(mod, mode = 0)
-  
-  data <- expand.ev(amt = 100, ID = seq(4), cmt = 1)
-  data <- mutate(data, ETA1 = rev(ID) / 10)
-  data <- expand_observations(data, times = seq(5))
-  data <- mutate(data, cmt = 0)
-  
-  set.seed(9812)
-  expect_identical(
-    mrgsim(mod, data, etasrc = "data"),
-    mrgsim(mod, select(data, "ETA1", everything()), etasrc = "data")
-  )
-})
-
 # Keeping tests simpler here since there is shared code
 test_that("pass ETA on the idata set", {
   mod <- param(mod, mode = 0)

--- a/inst/maintenance/unit/test-simeta.R
+++ b/inst/maintenance/unit/test-simeta.R
@@ -315,7 +315,7 @@ test_that("pass ETA on the idata set", {
   )
 
   expect_error(
-    mrgsim(mod, data, etasrc = "idata"), 
+    mrgsim(mod, data, idata = data[, "ID"], etasrc = "idata"), 
     "at least one"
   )
   

--- a/inst/maintenance/unit/test-simeta.R
+++ b/inst/maintenance/unit/test-simeta.R
@@ -288,6 +288,22 @@ test_that("pass ETA on the data set", {
   expect_identical(out@data, outq@data)
 })
 
+# Bug discovered with #1092
+test_that("etasrc works with ETA in first column", {
+  mod <- param(mod, mode = 0)
+  
+  data <- expand.ev(amt = 100, ID = seq(4), cmt = 1)
+  data <- mutate(data, ETA1 = rev(ID) / 10)
+  data <- expand_observations(data, times = seq(5))
+  data <- mutate(data, cmt = 0)
+  
+  set.seed(9812)
+  expect_identical(
+    mrgsim(mod, data, etasrc = "data"),
+    mrgsim(mod, select(data, "ETA1", everything()), etasrc = "data")
+  )
+})
+
 # Keeping tests simpler here since there is shared code
 test_that("pass ETA on the idata set", {
   mod <- param(mod, mode = 0)

--- a/man/mrgsim.Rd
+++ b/man/mrgsim.Rd
@@ -186,7 +186,9 @@ counts.
 \item \code{etasrc}: this argument lets you control where \code{ETA(n)} come from in the
 model. When \code{etasrc} is set to \code{"omega"} (the default), \code{ETAs} will be
 simulated from a multivariate normal distribution defined by the \verb{$OMEGA}
-blocks in the model. When \code{etasrc} is set to \code{"data"} or \code{"data.all"},
+blocks in the model. Alternatively, input \code{data} or \code{idata} sets can be used
+to pass in fixed \code{ETA(n)} by setting \code{etasrc} to \code{"data"}, \code{"idata"},
+\code{"data.all"} or \code{"idata.all"}. When \code{etasrc} is set to \code{"data"} or \code{"data.all"},
 the input data set will be scanned for columns called \code{ETA1}, \code{ETA2}, ...,
 \code{ETAn} and those values will be copied into the appropriate slot in the
 \code{ETA()} vector. Only the first record for each individual will be copied into
@@ -208,7 +210,9 @@ data set, the missing \code{ETA()} will be set to \code{0}.  Alternatively, the 
 can pass \code{etasrc = "data.all"} which causes an error to be generated if any
 \code{ETAn} is missing from the data set. Use this option when you intend to have
 \emph{all} \code{ETAs} attached to the data set and want an error generated if mrgsolve
-finds one or more of them is missing.
+finds one or more of them is missing. Using \code{etasrc ="idata"} or
+\code{"idata.all"}, the behavior is identical to \code{"data"} (or \code{"data.all"}),
+except mrgsolve will look at the idata set rather than data set.
 }
 }
 \examples{

--- a/man/mrgsim.Rd
+++ b/man/mrgsim.Rd
@@ -88,7 +88,8 @@ including \code{a.u.g} in  \code{carry_out}.}
 or another object with an \code{stime} method.}
 
 \item{etasrc}{source for \code{ETA()} values in the model; values can include:
-\code{"omega"}, \code{"data"} or \code{"data.all"}; see 'Details'.}
+\code{"omega"}, \code{"data"}, \code{"data.all"}, \code{"idata"}, or \code{"idata.all"}; see
+'Details'.}
 
 \item{recsort}{record sorting flag.  Default value is 1.  Possible values
 are 1,2,3,4: 1 and 2 put doses in a data set after padded observations at

--- a/man/mrgsim_q.Rd
+++ b/man/mrgsim_q.Rd
@@ -34,7 +34,8 @@ object is returned; if \code{"df"} then a data frame is returned.}
 \item{simcall}{not used; only the default value of 0 is allowed.}
 
 \item{etasrc}{source for ETA() values in the model; values can include: 
-"omega", "data" or "data.all"; see 'Details' in [mrgsim()].}
+"omega", `"data"`, `"data.all"`, `"idata"`, or `"idata.all"`; see 
+'Details' in [mrgsim()].}
 }
 \value{
 By default, an object of class `mrgsims`. Use `output = "df"` to return 

--- a/src/dataobject.cpp
+++ b/src/dataobject.cpp
@@ -634,7 +634,7 @@ arma::mat dataobject::get_etas(const int n_eta, const bool strict,
   
   arma::mat ans(Uid.size(), n_eta); 
   for(size_t i = 0; i < Uid.size(); ++i) {
-    int start_row = Startrow[i];
+    int start_row = this->start(i);
     for(int j = 0; j < n_eta; ++j) {
       if(eta_location[j] >= 0) {
         ans(i, j) = Data(start_row, eta_location[j]);

--- a/src/dataobject.cpp
+++ b/src/dataobject.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2013 - 2019  Metrum Research Group
+// Copyright (C) 2013 - 2023  Metrum Research Group
 //
 // This file is part of mrgsolve.
 //
@@ -71,7 +71,6 @@ dataobject::dataobject(Rcpp::NumericMatrix _data,
   Data_names = Rcpp::as<Rcpp::CharacterVector>(dimnames[1]);
   
   Idcol = find_position("ID", Data_names);
-  
   if(Idcol < 0) {
     throw Rcpp::exception(
         "could not find ID column in data set.",false
@@ -178,9 +177,11 @@ void dataobject::locate_tran() {
 
 void dataobject::idata_row() {
   Uid.resize(Data.nrow());
+  Startrow.resize(Data.nrow());
   for(int i=0; i < Data.nrow(); ++i) {
     idmap[Data(i,Idcol)] = i;
     Uid[i] = Data(i,Idcol);
+    Startrow[i] = i;
   }
 }
 
@@ -635,12 +636,11 @@ arma::mat dataobject::get_etas(const int n_eta, const bool strict,
   for(size_t i = 0; i < Uid.size(); ++i) {
     int start_row = Startrow[i];
     for(int j = 0; j < n_eta; ++j) {
-      if(eta_location[j] > 0) {
+      if(eta_location[j] >= 0) {
         ans(i, j) = Data(start_row, eta_location[j]);
       }
     }
   }
-  
   return ans;
 }
 

--- a/src/dataobject.cpp
+++ b/src/dataobject.cpp
@@ -636,7 +636,7 @@ arma::mat dataobject::get_etas(const int n_eta, const bool strict,
   for(size_t i = 0; i < Uid.size(); ++i) {
     int start_row = this->start(i);
     for(int j = 0; j < n_eta; ++j) {
-      if(eta_location[j] >= 0) {
+      if(eta_location[j] > 0) {
         ans(i, j) = Data(start_row, eta_location[j]);
       }
     }

--- a/src/devtran.cpp
+++ b/src/devtran.cpp
@@ -305,12 +305,18 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
       eta = dat.get_etas(neta, false, etasrc);
     } else if(etasrc=="data.all") {
       eta = dat.get_etas(neta, true, etasrc);
+    } else if(etasrc=="idata") {
+      eta = idat.get_etas(neta, false, etasrc); 
+    } else if(etasrc=="idata.all") {
+      eta = idat.get_etas(neta, true, etasrc);
     } else {
       std::string msg = 
         R"(`etasrc` must be either:
-           "omega"    = ETAs simulated from OMEGA
-           "data"     = ETAs imported from the data set
-           "data.all" = strict ETA import from data set)";
+           "omega"     = ETAs simulated from OMEGA
+           "data"      = ETAs imported from the data set
+           "idata"     = ETAs imported from the idata set
+           "data.all"  = strict ETA import from data set
+           "idata.all" = strict ETA import from idata set)";
       CRUMP(msg.c_str());  
     }
   }


### PR DESCRIPTION
Add on to #1037 ; `etasrc` can now be
- `idata`
- `idata.all`

Re-using all of the `get_etas()` code. 

Checklist

- [x] Update devtran to accept `etasrc = "idata"` or `etasrc = "idata.all"`
- [x] Make sure `get_etas()` works with `idata` object; one minor change to fill out `Startrow` for idata sets.
- [x] Add tests
- [x] Documentation


 Discovered a bug when implementing #1092 where ETA was missed if it was in the first column of the data set. Please see #1095 for the fix. 
