### PR TITLE
Fix bug when ETA in first column when using etasrc="data"

### DIFF
--- a/inst/maintenance/unit/test-simeta.R
+++ b/inst/maintenance/unit/test-simeta.R
@@ -209,6 +209,22 @@ test_that("warn when simeps(n) is called with off diagonals", {
   expect_silent(mcode("simeps-n-nowarn-2", code, compile = FALSE))
 })
 
+# Fixes issue discovered in #1092
+test_that("etasrc works with ETA in first column", {
+  mod <- param(mod, mode = 0)
+  
+  data <- expand.ev(amt = 100, ID = seq(4), cmt = 1)
+  data <- mutate(data, ETA1 = rev(ID) / 10)
+  data <- expand_observations(data, times = seq(5))
+  data <- mutate(data, cmt = 0)
+  
+  set.seed(9812)
+  expect_identical(
+    mrgsim(mod, data, etasrc = "data"),
+    mrgsim(mod, select(data, "ETA1", everything()), etasrc = "data")
+  )
+})
+
 test_that("pass ETA on the data set", {
   mod <- param(mod, mode = 0)
   data <- expand.ev(amt = 100, ID = seq(4), cmt = 1)

--- a/inst/maintenance/unit/test-simeta.R
+++ b/inst/maintenance/unit/test-simeta.R
@@ -214,14 +214,15 @@ test_that("etasrc works with ETA in first column", {
   mod <- param(mod, mode = 0)
   
   data <- expand.ev(amt = 100, ID = seq(4), cmt = 1)
-  data <- mutate(data, ETA1 = rev(ID) / 10)
+  data <- dplyr::mutate(data, ETA1 = rev(ID) / 10)
   data <- expand_observations(data, times = seq(5))
-  data <- mutate(data, cmt = 0)
+  data <- dplyr::mutate(data, cmt = 0)
   
   set.seed(9812)
   expect_identical(
     mrgsim(mod, data, etasrc = "data"),
-    mrgsim(mod, select(data, "ETA1", everything()), etasrc = "data")
+    mrgsim(mod, dplyr::select(data, "ETA1", tidyselect::everything()), 
+           etasrc = "data")
   )
 })
 

--- a/src/dataobject.cpp
+++ b/src/dataobject.cpp
@@ -635,7 +635,7 @@ arma::mat dataobject::get_etas(const int n_eta, const bool strict,
   for(size_t i = 0; i < Uid.size(); ++i) {
     int start_row = Startrow[i];
     for(int j = 0; j < n_eta; ++j) {
-      if(eta_location[j] > 0) {
+      if(eta_location[j] >= 0) {
         ans(i, j) = Data(start_row, eta_location[j]);
       }
     }


### PR DESCRIPTION
This bug was discovered when implementing #1092 ; when there is an ETA in the first column, it is not detected by `get_etas()`.

See #1094 and #1092 for discussion 