### PR TITLE
Check TIME and time when looking for mixed upper/lower case names in data

### DIFF
--- a/R/mrgindata.R
+++ b/R/mrgindata.R
@@ -192,8 +192,8 @@ valid_data_set <- function(x, m = NULL, verbose = FALSE, quiet = FALSE) {
                          dimnames=list(NULL, "..zeros..")))
   
   # Look for both upper and lower case column names
-  uc <- any(dimnames(dm)[[2]] %in% GLOBALS[["CARRY_TRAN_UC"]])
-  lc <- any(dimnames(dm)[[2]] %in% GLOBALS[["CARRY_TRAN_LC"]])
+  uc <- any(dimnames(dm)[[2]] %in% GLOBALS[["TRAN_UPPER"]])
+  lc <- any(dimnames(dm)[[2]] %in% GLOBALS[["TRAN_LOWER"]])
   
   if(uc & lc) {
     warning("Both lower- & upper-case names found in the data set.\n",

--- a/tests/testthat/test-data_set.R
+++ b/tests/testthat/test-data_set.R
@@ -58,6 +58,19 @@ test_that("Warning is generated when mixed upper/lower names", {
   expect_warning(mrgsim(data_set(mod,mix)))
 })
 
+test_that("Include TIME and time when checking for mixed upper/lower case", {
+  expect_warning(
+    mrgsim(house(), data = data.frame(ID = 1, TIME = 0, amt = 0, cmt = 1)), 
+    "Both lower- & upper-case", 
+    fixed = TRUE
+  )
+  expect_warning(
+    mrgsim(house(), data = data.frame(ID = 1, time = 0, AMT = 0, cmt = 1)), 
+    "Both lower- & upper-case", 
+    fixed = TRUE
+  )
+})
+
 test_that("Filter out ID", {
   out <- mod %>% data_set(up, ID > 4) %>% mrgsim
   expect_true(all(out$ID > 4))

--- a/tests/testthat/test-data_set.R
+++ b/tests/testthat/test-data_set.R
@@ -65,7 +65,7 @@ test_that("Include TIME and time when checking for mixed upper/lower case", {
     fixed = TRUE
   )
   expect_warning(
-    mrgsim(house(), data = data.frame(ID = 1, time = 0, AMT = 0, cmt = 1)), 
+    mrgsim(house(), data = data.frame(ID = 1, time = 0, AMT = 0, CMT = 1)), 
     "Both lower- & upper-case", 
     fixed = TRUE
   )


### PR DESCRIPTION
We'll warn if an incoming data set has both lower- and upper-case versions of some recognized names (like AMT, CMT, etc).  TIME / time should also be in that check, but it hasn't been and we just realized it when helping a user in #1098. 

We already have the right names to check in this `GLOBALS` list
```r
> mrgsolve:::GLOBALS[["TRAN_UPPER"]]
[1] "AMT"  "II"   "SS"   "CMT"  "ADDL" "RATE" "EVID" "TIME"
> mrgsolve:::GLOBALS[["TRAN_LOWER"]]
[1] "amt"  "ii"   "ss"   "cmt"  "addl" "rate" "evid" "time"
> mrgsolve:::GLOBALS[["CARRY_TRAN_UC"]]
[1] "AMT"  "CMT"  "EVID" "II"   "ADDL" "RATE" "SS"  
> mrgsolve:::GLOBALS[["CARRY_TRAN_LC"]]
[1] "amt"  "cmt"  "evid" "ii"   "addl" "rate" "ss"  
```