### PR TITLE
Fixing false file.access() errors on windows machines

### DIFF
--- a/R/class_build.R
+++ b/R/class_build.R
@@ -69,7 +69,9 @@ new_build <- function(file=NULL, model, project, soloc=getwd(), code = NULL,
   env$soloc <- as.character(create_soloc(soloc,new_model,preclean))
   
   if(!file_readable(project)) {
-    stop("project directory '", project, "' must exist and be readable.",call.=FALSE) 
+    warning("The file.access function indicates that project directory '", project,
+            "' might not exist or is not readable. However, file.access is unreliable on Windows.",
+            " Thus, existance and readability of the project directory should be ensured by the user. ",call.=FALSE) 
   }
   
   env$project <- normalizePath(project, mustWork=TRUE, winslash="/")  


### PR DESCRIPTION
## What?
I've provided a little bugfix for windows machines where `file.access()` falsely indicates readability issues. This can happen e.g., when working on mounted / mapped network drives. Please refer to issue #1100.

## Why?
The `new_build()` function checks via `file_readable()` (helper function for `file.access()`) if the directory is readable. `file.access()` however seems to be unreliable and throws errors even when the directory is readable. Thus, it is not justified to force a stop based on output from `file.access()`.

## How?
Minor change: changed the stop into a warning. Instead of forcing a stop, the user will be informed that the directory might be non-readable or non-existent.

## Testing
Tested the modified function on my local machine when working on a mapped network drive and now the model is correctly being read in plus throws a warning 

> Warning message:
> The file.access function indicates that project directory 'G:/Projekte/xxx/models' might not exist or is not readable. However, file.access is unreliable on Windows. Thus, existance and readability of the project directory should be ensured by the user.

 The change is not expected to affect any of the existing tests. devtools::check() passes without issues. 