### PR TITLE
Fix NOTE from r-devel for .x in matlist documentation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: mrgsolve
 Title: Simulate from ODE-Based Models
-Version: 1.1.0
+Version: 1.1.0.9000
 Authors@R: 
     c(person(given = "Kyle T", family = "Baron",
              role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# mrgsolve (development version)
+
 # mrgsolve 1.1.0
 
 - Add new functionality for assessing consistency between names on input data

--- a/R/matlist.R
+++ b/R/matlist.R
@@ -244,7 +244,6 @@ setMethod("zero_re", "mrgmod", function(.x, ...) {
 
 #' Methods for working with matrix-list objects
 #'
-#' @param .x a matlist object
 #' @param x a matlist object
 #' @param ... passed through to other methods
 #'

--- a/man/matlist.Rd
+++ b/man/matlist.Rd
@@ -39,8 +39,6 @@ as the \code{names} of the matrices}
 \item{...}{passed through to other methods}
 
 \item{object}{passed to showmatlist}
-
-\item{.x}{a matlist object}
 }
 \description{
 Methods for working with matrix-list objects


### PR DESCRIPTION
This is new with r-devel. I don't know exactly when, but let's reference `r84939` when I first noticed. I can't install r-devel right now and can only reproduce this via winbuilder. 

mrgsolve on cran: https://cran.r-project.org/web/checks/check_results_mrgsolve.html

Other packages are getting hit too: https://cran.r-project.org/web/checks/check_results_dplyr.html

See #1103 for before / after check results. 