### PR TITLE
Release 1.1.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: mrgsolve
 Title: Simulate from ODE-Based Models
-Version: 1.1.0.9000
+Version: 1.1.1
 Authors@R: 
     c(person(given = "Kyle T", family = "Baron",
              role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,7 @@
-# mrgsolve (development version)
+# mrgsolve 1.1.1
+
+- Remove `.x` from `matlist` documentation object per new NOTE output from 
+  rdevel (#1103, #1104).
 
 # mrgsolve 1.1.0
 


### PR DESCRIPTION
# mrgsolve 1.1.1

- Remove `.x` from `matlist` documentation object per new NOTE output from 
  rdevel (#1103, #1104).
