### PR TITLE
All records get a different draw from EPS

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 - Data set records at the same time within individual will receive different 
   `EPS` draws; this is a change from previous behavior where records with the 
-  same time received the same value for `EPS` (#).
+  same time received the same value for `EPS` (#1110).
 
 # mrgsolve 1.1.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # mrgsolve (development version)
 
+- Data set records at the same time within individual will receive different 
+  `EPS` draws; this is a change from previous behavior where records with the 
+  same time received the same value for `EPS` (#).
+
 # mrgsolve 1.1.1
 
 - Remove `.x` from `matlist` documentation object per new NOTE output from 

--- a/inst/maintenance/unit/test-mread.R
+++ b/inst/maintenance/unit/test-mread.R
@@ -122,6 +122,12 @@ test_that("EPS values have proper variance", {
   expect_equal(round(var(out$EPS1),2),0.55)
 })
 
+test_that("New EPS draws for records at the same time", {
+  data <- data.frame(ID = 1, TIME = c(0, 1, 1, 2), EVID = 0, CMT = 1)  
+  out <- mrgsim(mod, data)
+  expect_length(unique(out$EPS1), nrow(data))
+})
+
 test_that("Error when code is passed as project", {
   expect_error(suppressWarnings(mread("hey",code)))
 })

--- a/src/devtran.cpp
+++ b/src/devtran.cpp
@@ -286,7 +286,7 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
   const unsigned int NN = obsonly ? obscount : (obscount + evcount);
   int precol = 2 + int(tad);
   const unsigned int n_out_col  = precol + n_tran_carry
-    + n_data_carry + n_idata_carry + nreq + n_capture;
+  + n_data_carry + n_idata_carry + nreq + n_capture;
   Rcpp::NumericMatrix ans(NN,n_out_col);
   const unsigned int tran_carry_start = precol;
   const unsigned int data_carry_start = tran_carry_start + n_tran_carry;
@@ -312,11 +312,11 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
     } else {
       std::string msg = 
         R"(`etasrc` must be either:
-           "omega"     = ETAs simulated from OMEGA
-           "data"      = ETAs imported from the data set
-           "idata"     = ETAs imported from the idata set
-           "data.all"  = strict ETA import from data set
-           "idata.all" = strict ETA import from idata set)";
+              "omega"     = ETAs simulated from OMEGA
+              "data"      = ETAs imported from the data set
+              "idata"     = ETAs imported from the idata set
+              "data.all"  = strict ETA import from data set
+              "idata.all" = strict ETA import from idata set)";
       CRUMP(msg.c_str());  
     }
   }
@@ -501,10 +501,8 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
         tto = tfrom;
       }
       
-      if(tto > tfrom) {
-        for(int k = 0; k < neps; ++k) {
-          prob.eps(k,eps(crow,k));
-        }
+      for(int k = 0; k < neps; ++k) {
+        prob.eps(k,eps(crow,k));
       }
       
       if(j != 0) {


### PR DESCRIPTION
Previous behavior was to assign a new `EPS` only when time was advancing in the data set within individual. Now, we assign a new `EPS` every record.

There was some linting that happened too ... not sure if this came from Rstudio or not. But let's leave it as is.