### PR TITLE
Release 1.2.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: mrgsolve
 Title: Simulate from ODE-Based Models
-Version: 1.1.1.9000
+Version: 1.2.0
 Authors@R: 
     c(person(given = "Kyle T", family = "Baron",
              role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# mrgsolve (development version)
+# mrgsolve 1.2.0
 
 - Data set records at the same time within individual will receive different 
   `EPS` draws; this is a change from previous behavior where records with the 


### PR DESCRIPTION
# mrgsolve 1.2.0

- Data set records at the same time within individual will receive different 
  `EPS` draws; this is a change from previous behavior where records with the 
  same time received the same value for `EPS` (#1110).
