### PR TITLE
Fix regex for detecting dosing compartments

### DIFF
--- a/R/handle_spec_block.R
+++ b/R/handle_spec_block.R
@@ -833,7 +833,7 @@ dosing_cmts <- function(x, what) {
   x <- unlist(strsplit(x,"\n",fixed=TRUE),use.names=FALSE)
   m <- regexpr("(ALAG|F|R|D)\\_[^= ]+", x, perl=TRUE)
   m <- regmatches(x,m)
-  m <- unique(gsub("(ALAG|F|R|D)\\_", "",m))
+  m <- unique(sub("^(ALAG|F|R|D)\\_", "",m))
   m <- intersect(m,what)
   return(m)
 }

--- a/inst/maintenance/unit/test-D-R-F.R
+++ b/inst/maintenance/unit/test-D-R-F.R
@@ -267,3 +267,23 @@ test_that("tad is correctly calculated for addl doses with lag", {
   
 })
 
+test_that("Detect dosing compartments", {
+  cmts <- c("GUT", "CENT", "ABS_RAPID_FORM2")
+  code <- c("CL = THETA(1);", "F_ABS_RAPID_FORM2 = 1.2;", "S2 = V2;")
+  ans <- mrgsolve:::dosing_cmts(code, cmts)
+  expect_identical(ans, cmts[3])
+  
+  code <- '
+  $CMT ABS_RAPID_FORM2 CENT
+  $PK
+    F_ABS_RAPID_FORM2 = 0.2;
+  '
+  mod <- mcode("test-detect-dosing", code, compile = FALSE)
+  f <- list.files(
+    dirname(mod@shlib$source), 
+    pattern = "header", 
+    full.names = TRUE
+  )
+  txt <- readLines(f)
+  expect_match(txt, "define F_ABS_RAPID_FORM2", all = FALSE)
+})

--- a/inst/maintenance/unit/test-D-R-F.R
+++ b/inst/maintenance/unit/test-D-R-F.R
@@ -275,8 +275,7 @@ test_that("Detect dosing compartments", {
   
   code <- '
   $CMT ABS_RAPID_FORM2 CENT
-  $PK
-    F_ABS_RAPID_FORM2 = 0.2;
+  $PK F_ABS_RAPID_FORM2 = 0.2;
   '
   mod <- mcode("test-detect-dosing", code, compile = FALSE)
   f <- list.files(


### PR DESCRIPTION
See #1112 reported by @rfaelens


No need to look for leading whitespace

``` r
x <- "    F_ABS_RAPID_FORM2"
regmatches(x, regexpr("(ALAG|F|R|D)\\_[^= ]+", x, perl=TRUE))
#> [1] "F_ABS_RAPID_FORM2"
```

<sup>Created on 2023-08-24 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>