### PR TITLE
Fix mevent hx reset

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: mrgsolve
 Title: Simulate from ODE-Based Models
-Version: 1.2.0
+Version: 1.2.0.9000
 Authors@R: 
     c(person(given = "Kyle T", family = "Baron",
              role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# mrgsolve (development version)
+
 # mrgsolve 1.2.0
 
 - Data set records at the same time within individual will receive different 

--- a/inst/maintenance/unit-cpp/test-cpp.R
+++ b/inst/maintenance/unit-cpp/test-cpp.R
@@ -29,52 +29,14 @@ $PK
 if(NEWIND <= 1) capture FLAG = 0;
 $CMT A
 $TABLE 
-if(TIME==2) {
-  self.mevent(2.001,33);
-  self.mevent(2.001,33);
-}
+if(TIME==2) self.mevent(2.001,33);
 if(EVID==33) ++FLAG;
 '
-
-mod <- mcode("test-cpp-re-event", code, end = -1, add = c(1,2,3))
-
-mrgsim(mod, ev(amt = 0, ID = 1:2, evid = 2)) %>% as.data.frame()
-
-
-
-code <- '
-
-$MAIN 
-if(NEWIND == 0) { 
-  int count = 0;
-}
-if(NEWIND <= 1) {
-  int dosen = 0;
-  double dose = 0;
-}
-
-$TABLE
-if(EVID> 30 && dosen < 11) {
-    if(dosen <= 1) dose = 100;
-    if(dosen==2)   dose = 200;  
-    if(dosen ==3)  dose = 300;
-    if(dosen > 3)  dose = 400;
-    if(dosen > 5)  dose =   0;
-    mrg::evdata ev(TIME,1);
-    ev.cmt = 1;
-    ev.amt = dose;
-    ev.now = true;
-    self.mevector.push_back(ev);
-    ++dosen;
-    self.mevent(TIME + 3, 33);
-}
-
-$CMT A
-$CAPTURE dosen dose
-'
-
-mod <- mcode("foo", code)
-
-data <- expand.ev(amt = 0, evid = 33, time = 0, ID = 1:2)
-
-mrgsim(mod, data = data, end = 33, delta = 0.1)  %>% plot()
+test_that("ev history is reset", {
+  mod <- mcode("test-cpp-re-event", code, end = -1, add = c(1,2,3))
+  out <- mrgsim_df(mod, ev(amt = 0, ID = 1:2, evid = 2)) 
+  expect_equal(sum(out$FLAG), 2)  
+  out3 <- subset(out, time==3)
+  expect_length(out3$FLAG, 2)
+  expect_true(all(out3$FLAG==1))
+})

--- a/inst/maintenance/unit-cpp/test-cpp.R
+++ b/inst/maintenance/unit-cpp/test-cpp.R
@@ -24,3 +24,57 @@ test_that("build a model with mrgx and nm-vars", {
   )
 })
 
+code <- '
+$PK
+if(NEWIND <= 1) capture FLAG = 0;
+$CMT A
+$TABLE 
+if(TIME==2) {
+  self.mevent(2.001,33);
+  self.mevent(2.001,33);
+}
+if(EVID==33) ++FLAG;
+'
+
+mod <- mcode("test-cpp-re-event", code, end = -1, add = c(1,2,3))
+
+mrgsim(mod, ev(amt = 0, ID = 1:2, evid = 2)) %>% as.data.frame()
+
+
+
+code <- '
+
+$MAIN 
+if(NEWIND == 0) { 
+  int count = 0;
+}
+if(NEWIND <= 1) {
+  int dosen = 0;
+  double dose = 0;
+}
+
+$TABLE
+if(EVID> 30 && dosen < 11) {
+    if(dosen <= 1) dose = 100;
+    if(dosen==2)   dose = 200;  
+    if(dosen ==3)  dose = 300;
+    if(dosen > 3)  dose = 400;
+    if(dosen > 5)  dose =   0;
+    mrg::evdata ev(TIME,1);
+    ev.cmt = 1;
+    ev.amt = dose;
+    ev.now = true;
+    self.mevector.push_back(ev);
+    ++dosen;
+    self.mevent(TIME + 3, 33);
+}
+
+$CMT A
+$CAPTURE dosen dose
+'
+
+mod <- mcode("foo", code)
+
+data <- expand.ev(amt = 0, evid = 33, time = 0, ID = 1:2)
+
+mrgsim(mod, data = data, end = 33, delta = 0.1)  %>% plot()

--- a/src/devtran.cpp
+++ b/src/devtran.cpp
@@ -388,6 +388,7 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
   
   prob.config_call();
   reclist mtimehx;
+  bool used_mtimehx = false;
   
   bool has_idata = idat.nrow() > 0;
   int this_idata_row = 0;
@@ -402,7 +403,7 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
     dat.next_id(i);
     prob.idn(i);
     prob.reset_newid(id);
-    mtimehx.clear();  
+    if(used_mtimehx) mtimehx.clear();  
     
     if(i==0) {
       prob.newind(0);
@@ -617,6 +618,7 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
       }
       
       if(prob.any_mtime()) {
+        // Will set used_mtimehx only if we push back
         std::vector<mrgsolve::evdata> mt  = prob.mtimes();
         for(size_t mti = 0; mti < mt.size(); ++mti) {
           double this_time = (mt[mti]).time;
@@ -643,6 +645,7 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
             } 
           }
         }
+        used_mtimehx = mtimehx.size() > 0;
         prob.clear_mtime();
       }
       if(this_rec->output()) {

--- a/src/devtran.cpp
+++ b/src/devtran.cpp
@@ -402,6 +402,7 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
     dat.next_id(i);
     prob.idn(i);
     prob.reset_newid(id);
+    mtimehx.clear();  
     
     if(i==0) {
       prob.newind(0);
@@ -616,7 +617,6 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
       }
       
       if(prob.any_mtime()) {
-        if(prob.newind() <=1) mtimehx.clear();  
         std::vector<mrgsolve::evdata> mt  = prob.mtimes();
         for(size_t mti = 0; mti < mt.size(); ++mti) {
           double this_time = (mt[mti]).time;


### PR DESCRIPTION
# Summary

We should clear the mtime event history with every subject but only if mtime is being used. Details in #1117 