### PR TITLE
Don't ignore NEWS.md when building package

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -34,7 +34,6 @@ src/.*[.]tar.gz$
 img
 README.Rmd
 README.md
-NEWS.md
 .git
 .gitignore
 .travis.yml
@@ -54,5 +53,3 @@ vignettes/extra
 vignettes/build
 vignettes/mrgsolve-builds
 vignettes/extra/mrgsolve-builds/
-
-


### PR DESCRIPTION
I don't think there is any reason to ignore it now; maybe there was at some point? Not sure. 