### PR TITLE
Match data type with format in sprintf

### DIFF
--- a/src/LSODA.cpp
+++ b/src/LSODA.cpp
@@ -205,7 +205,7 @@ void LSODA::lsoda(LSODA_ODE_SYSTEM_TYPE f, const size_t neq, vector<double> &y,
     if (neq <= 0)
     {
       //cerr << "[lsoda] neq = " << neq << " is less than 1." << endl;
-      REprintf("[lsoda] neq = %i is less than 1.\n", neq);
+      REprintf("[lsoda] neq = %zi is less than 1.\n", neq);
       terminate(istate);
       return;
     }
@@ -246,14 +246,14 @@ void LSODA::lsoda(LSODA_ODE_SYSTEM_TYPE f, const size_t neq, vector<double> &y,
       if (ml >= n)
       {
         //cerr << "[lsoda] ml = " << ml << " not between 1 and neq" << endl;
-        REprintf("[lsoda] ml = %i not between 1 and neq.\n", ml);
+        REprintf("[lsoda] ml = %zi not between 1 and neq.\n", ml);
         terminate(istate);
         return;
       }
       if (mu >= n)
       {
         //cerr << "[lsoda] mu = " << mu << " not between 1 and neq" << endl;
-        REprintf("[lsoda] mu = %i not between 1 and neq.\n", mu);
+        REprintf("[lsoda] mu = %zi not between 1 and neq.\n", mu);
         terminate(istate);
         return;
       }
@@ -283,7 +283,7 @@ void LSODA::lsoda(LSODA_ODE_SYSTEM_TYPE f, const size_t neq, vector<double> &y,
       if (ixpr > 1)
       {
         //cerr << "[lsoda] ixpr = " << ixpr << " is illegal" << endl;
-        REprintf("[lsoda] ixpr =%i is illegal.\n", ixpr);
+        REprintf("[lsoda] ixpr =%zi is illegal.\n", ixpr);
         terminate(istate);
         return;
       }
@@ -466,7 +466,7 @@ void LSODA::lsoda(LSODA_ODE_SYSTEM_TYPE f, const size_t neq, vector<double> &y,
         if (ewt[i] <= 0.)
         {
           //cerr << "[lsoda] ewt[" << i << "] = " << ewt[i] << " <= 0.\n" << endl;
-          REprintf("[lsoda] ewt[%i] = %g <= 0.\n", i, ewt[i]);
+          REprintf("[lsoda] ewt[%zi] = %g <= 0.\n", i, ewt[i]);
           terminate2(y, t);
           return;
         }
@@ -671,7 +671,7 @@ void LSODA::lsoda(LSODA_ODE_SYSTEM_TYPE f, const size_t neq, vector<double> &y,
           {
             // cerr << "[lsoda] " << mxstep << " steps taken before reaching tout"
             //      << endl;
-            REprintf("[lsoda] %i steps taken before reaching tout; consider increasing maxsteps.\n", 
+            REprintf("[lsoda] %zi steps taken before reaching tout; consider increasing maxsteps.\n", 
                      mxstep);
             *istate = -1;
             terminate2(y, t);
@@ -684,7 +684,7 @@ void LSODA::lsoda(LSODA_ODE_SYSTEM_TYPE f, const size_t neq, vector<double> &y,
             if (ewt[i] <= 0.)
             {
               //cerr << "[lsoda] ewt[" << i << "] = " << ewt[i] << " <= 0." << endl;
-              REprintf("[lsoda] ewt[%i] = %g <= 0.\n", i, ewt[i]);
+              REprintf("[lsoda] ewt[%zi] = %g <= 0.\n", i, ewt[i]);
               *istate = -6;
               terminate2(y, t);
               return;
@@ -739,7 +739,7 @@ void LSODA::lsoda(LSODA_ODE_SYSTEM_TYPE f, const size_t neq, vector<double> &y,
               // cerr << "lsoda -- above warning has been issued " << nhnil
               //      << " times, " << endl
               //      << "       it will not be issued again for this problem" << endl;
-              REprintf("[lsoda] above warning has been issued %i times\n", nhnil);
+              REprintf("[lsoda] above warning has been issued %zi times\n", nhnil);
               REprintf("        it will not be issued again for this problem.\n");
             }
           }

--- a/src/LSODA.cpp
+++ b/src/LSODA.cpp
@@ -315,7 +315,7 @@ void LSODA::lsoda(LSODA_ODE_SYSTEM_TYPE f, const size_t neq, vector<double> &y,
         {
           // cerr << "[lsoda] tout = " << tout << " behind t = " << *t
           //      << ". integration direction is given by " << h0 << endl;
-          REprintf("[lsoda] tout = %.f behind t = %f. integration direction is given by %f.\n", 
+          REprintf("[lsoda] tout = %f behind t = %f integration direction is given by %f.\n", 
                    tout, *t, h0);
           terminate(istate);
           return;

--- a/src/LSODA.cpp
+++ b/src/LSODA.cpp
@@ -205,7 +205,7 @@ void LSODA::lsoda(LSODA_ODE_SYSTEM_TYPE f, const size_t neq, vector<double> &y,
     if (neq <= 0)
     {
       //cerr << "[lsoda] neq = " << neq << " is less than 1." << endl;
-      REprintf("[lsoda] neq = %i is less than 1.\n", (int)neq);
+      REprintf("[lsoda] neq = %zu is less than 1.\n", neq);
       terminate(istate);
       return;
     }
@@ -246,14 +246,14 @@ void LSODA::lsoda(LSODA_ODE_SYSTEM_TYPE f, const size_t neq, vector<double> &y,
       if (ml >= n)
       {
         //cerr << "[lsoda] ml = " << ml << " not between 1 and neq" << endl;
-        REprintf("[lsoda] ml = %i not between 1 and neq.\n", (int)ml);
+        REprintf("[lsoda] ml = %zu not between 1 and neq.\n", ml);
         terminate(istate);
         return;
       }
       if (mu >= n)
       {
         //cerr << "[lsoda] mu = " << mu << " not between 1 and neq" << endl;
-        REprintf("[lsoda] mu = %i not between 1 and neq.\n", (int)mu);
+        REprintf("[lsoda] mu = %zu not between 1 and neq.\n", mu);
         terminate(istate);
         return;
       }
@@ -283,7 +283,7 @@ void LSODA::lsoda(LSODA_ODE_SYSTEM_TYPE f, const size_t neq, vector<double> &y,
       if (ixpr > 1)
       {
         //cerr << "[lsoda] ixpr = " << ixpr << " is illegal" << endl;
-        REprintf("[lsoda] ixpr =%i is illegal.\n", (int)ixpr);
+        REprintf("[lsoda] ixpr =%zu is illegal.\n", ixpr);
         terminate(istate);
         return;
       }
@@ -466,7 +466,7 @@ void LSODA::lsoda(LSODA_ODE_SYSTEM_TYPE f, const size_t neq, vector<double> &y,
         if (ewt[i] <= 0.)
         {
           //cerr << "[lsoda] ewt[" << i << "] = " << ewt[i] << " <= 0.\n" << endl;
-          REprintf("[lsoda] ewt[%i] = %g <= 0.\n", (int)i, ewt[i]);
+          REprintf("[lsoda] ewt[%zu] = %g <= 0.\n", i, ewt[i]);
           terminate2(y, t);
           return;
         }
@@ -671,8 +671,8 @@ void LSODA::lsoda(LSODA_ODE_SYSTEM_TYPE f, const size_t neq, vector<double> &y,
           {
             // cerr << "[lsoda] " << mxstep << " steps taken before reaching tout"
             //      << endl;
-            REprintf("[lsoda] %i steps taken before reaching tout; consider increasing maxsteps.\n", 
-                     (int)mxstep);
+            REprintf("[lsoda] %zu steps taken before reaching tout; consider increasing maxsteps.\n", 
+                     mxstep);
             *istate = -1;
             terminate2(y, t);
             return;
@@ -684,7 +684,7 @@ void LSODA::lsoda(LSODA_ODE_SYSTEM_TYPE f, const size_t neq, vector<double> &y,
             if (ewt[i] <= 0.)
             {
               //cerr << "[lsoda] ewt[" << i << "] = " << ewt[i] << " <= 0." << endl;
-              REprintf("[lsoda] ewt[%i] = %g <= 0.\n", (int)i, ewt[i]);
+              REprintf("[lsoda] ewt[%zu] = %g <= 0.\n", i, ewt[i]);
               *istate = -6;
               terminate2(y, t);
               return;
@@ -739,7 +739,7 @@ void LSODA::lsoda(LSODA_ODE_SYSTEM_TYPE f, const size_t neq, vector<double> &y,
               // cerr << "lsoda -- above warning has been issued " << nhnil
               //      << " times, " << endl
               //      << "       it will not be issued again for this problem" << endl;
-              REprintf("[lsoda] above warning has been issued %i times\n", (int)nhnil);
+              REprintf("[lsoda] above warning has been issued %zu times\n", nhnil);
               REprintf("        it will not be issued again for this problem.\n");
             }
           }

--- a/src/LSODA.cpp
+++ b/src/LSODA.cpp
@@ -315,7 +315,7 @@ void LSODA::lsoda(LSODA_ODE_SYSTEM_TYPE f, const size_t neq, vector<double> &y,
         {
           // cerr << "[lsoda] tout = " << tout << " behind t = " << *t
           //      << ". integration direction is given by " << h0 << endl;
-          REprintf("[lsoda] tout = %d behind t = %d. integration direction is given by %d.\n", 
+          REprintf("[lsoda] tout = %.f behind t = %f. integration direction is given by %f.\n", 
                    tout, *t, h0);
           terminate(istate);
           return;

--- a/src/LSODA.cpp
+++ b/src/LSODA.cpp
@@ -205,7 +205,7 @@ void LSODA::lsoda(LSODA_ODE_SYSTEM_TYPE f, const size_t neq, vector<double> &y,
     if (neq <= 0)
     {
       //cerr << "[lsoda] neq = " << neq << " is less than 1." << endl;
-      REprintf("[lsoda] neq = %zu is less than 1.\n", neq);
+      REprintf("[lsoda] neq = %i is less than 1.\n", (int)neq);
       terminate(istate);
       return;
     }
@@ -246,14 +246,14 @@ void LSODA::lsoda(LSODA_ODE_SYSTEM_TYPE f, const size_t neq, vector<double> &y,
       if (ml >= n)
       {
         //cerr << "[lsoda] ml = " << ml << " not between 1 and neq" << endl;
-        REprintf("[lsoda] ml = %zu not between 1 and neq.\n", ml);
+        REprintf("[lsoda] ml = %i not between 1 and neq.\n", (int)ml);
         terminate(istate);
         return;
       }
       if (mu >= n)
       {
         //cerr << "[lsoda] mu = " << mu << " not between 1 and neq" << endl;
-        REprintf("[lsoda] mu = %zu not between 1 and neq.\n", mu);
+        REprintf("[lsoda] mu = %i not between 1 and neq.\n", (int)mu);
         terminate(istate);
         return;
       }

--- a/src/LSODA.cpp
+++ b/src/LSODA.cpp
@@ -205,7 +205,7 @@ void LSODA::lsoda(LSODA_ODE_SYSTEM_TYPE f, const size_t neq, vector<double> &y,
     if (neq <= 0)
     {
       //cerr << "[lsoda] neq = " << neq << " is less than 1." << endl;
-      REprintf("[lsoda] neq = %zi is less than 1.\n", neq);
+      REprintf("[lsoda] neq = %zu is less than 1.\n", neq);
       terminate(istate);
       return;
     }
@@ -246,14 +246,14 @@ void LSODA::lsoda(LSODA_ODE_SYSTEM_TYPE f, const size_t neq, vector<double> &y,
       if (ml >= n)
       {
         //cerr << "[lsoda] ml = " << ml << " not between 1 and neq" << endl;
-        REprintf("[lsoda] ml = %zi not between 1 and neq.\n", ml);
+        REprintf("[lsoda] ml = %zu not between 1 and neq.\n", ml);
         terminate(istate);
         return;
       }
       if (mu >= n)
       {
         //cerr << "[lsoda] mu = " << mu << " not between 1 and neq" << endl;
-        REprintf("[lsoda] mu = %zi not between 1 and neq.\n", mu);
+        REprintf("[lsoda] mu = %zu not between 1 and neq.\n", mu);
         terminate(istate);
         return;
       }
@@ -283,7 +283,7 @@ void LSODA::lsoda(LSODA_ODE_SYSTEM_TYPE f, const size_t neq, vector<double> &y,
       if (ixpr > 1)
       {
         //cerr << "[lsoda] ixpr = " << ixpr << " is illegal" << endl;
-        REprintf("[lsoda] ixpr =%zi is illegal.\n", ixpr);
+        REprintf("[lsoda] ixpr =%i is illegal.\n", (int)ixpr);
         terminate(istate);
         return;
       }
@@ -466,7 +466,7 @@ void LSODA::lsoda(LSODA_ODE_SYSTEM_TYPE f, const size_t neq, vector<double> &y,
         if (ewt[i] <= 0.)
         {
           //cerr << "[lsoda] ewt[" << i << "] = " << ewt[i] << " <= 0.\n" << endl;
-          REprintf("[lsoda] ewt[%zi] = %g <= 0.\n", i, ewt[i]);
+          REprintf("[lsoda] ewt[%i] = %g <= 0.\n", (int)i, ewt[i]);
           terminate2(y, t);
           return;
         }
@@ -671,8 +671,8 @@ void LSODA::lsoda(LSODA_ODE_SYSTEM_TYPE f, const size_t neq, vector<double> &y,
           {
             // cerr << "[lsoda] " << mxstep << " steps taken before reaching tout"
             //      << endl;
-            REprintf("[lsoda] %zi steps taken before reaching tout; consider increasing maxsteps.\n", 
-                     mxstep);
+            REprintf("[lsoda] %i steps taken before reaching tout; consider increasing maxsteps.\n", 
+                     (int)mxstep);
             *istate = -1;
             terminate2(y, t);
             return;
@@ -684,7 +684,7 @@ void LSODA::lsoda(LSODA_ODE_SYSTEM_TYPE f, const size_t neq, vector<double> &y,
             if (ewt[i] <= 0.)
             {
               //cerr << "[lsoda] ewt[" << i << "] = " << ewt[i] << " <= 0." << endl;
-              REprintf("[lsoda] ewt[%zi] = %g <= 0.\n", i, ewt[i]);
+              REprintf("[lsoda] ewt[%i] = %g <= 0.\n", (int)i, ewt[i]);
               *istate = -6;
               terminate2(y, t);
               return;
@@ -739,7 +739,7 @@ void LSODA::lsoda(LSODA_ODE_SYSTEM_TYPE f, const size_t neq, vector<double> &y,
               // cerr << "lsoda -- above warning has been issued " << nhnil
               //      << " times, " << endl
               //      << "       it will not be issued again for this problem" << endl;
-              REprintf("[lsoda] above warning has been issued %zi times\n", nhnil);
+              REprintf("[lsoda] above warning has been issued %i times\n", (int)nhnil);
               REprintf("        it will not be issued again for this problem.\n");
             }
           }

--- a/src/LSODA.cpp
+++ b/src/LSODA.cpp
@@ -204,8 +204,9 @@ void LSODA::lsoda(LSODA_ODE_SYSTEM_TYPE f, const size_t neq, vector<double> &y,
     ntrep = 0;
     if (neq <= 0)
     {
-      //cerr << "[lsoda] neq = " << neq << " is less than 1." << endl;
-      REprintf("[lsoda] neq = %zu is less than 1.\n", neq);
+      Rcpp::Rcerr << "[lsoda] neq = " << neq << " is less than 1." 
+                  << std::endl;
+      //REprintf("[lsoda] neq = %zu is less than 1.\n", neq);
       terminate(istate);
       return;
     }
@@ -245,15 +246,17 @@ void LSODA::lsoda(LSODA_ODE_SYSTEM_TYPE f, const size_t neq, vector<double> &y,
       mu = iworks[1];
       if (ml >= n)
       {
-        //cerr << "[lsoda] ml = " << ml << " not between 1 and neq" << endl;
-        REprintf("[lsoda] ml = %zu not between 1 and neq.\n", ml);
+        Rcpp::Rcerr << "[lsoda] ml = " << ml << " not between 1 and neq."
+                    << std::endl;
+        //REprintf("[lsoda] ml = %zu not between 1 and neq.\n", ml);
         terminate(istate);
         return;
       }
       if (mu >= n)
       {
-        //cerr << "[lsoda] mu = " << mu << " not between 1 and neq" << endl;
-        REprintf("[lsoda] mu = %zu not between 1 and neq.\n", mu);
+        Rcpp::Rcerr << "[lsoda] mu = " << mu << " not between 1 and neq." 
+                    << std::endl;
+        //REprintf("[lsoda] mu = %zu not between 1 and neq.\n", mu);
         terminate(istate);
         return;
       }
@@ -282,8 +285,8 @@ void LSODA::lsoda(LSODA_ODE_SYSTEM_TYPE f, const size_t neq, vector<double> &y,
       ixpr = iworks[2];
       if (ixpr > 1)
       {
-        //cerr << "[lsoda] ixpr = " << ixpr << " is illegal" << endl;
-        REprintf("[lsoda] ixpr =%zu is illegal.\n", ixpr);
+        Rcpp::Rcerr << "[lsoda] ixpr = " << ixpr << " is illegal." << std::endl;
+        //REprintf("[lsoda] ixpr =%zu is illegal.\n", ixpr);
         terminate(istate);
         return;
       }
@@ -465,8 +468,9 @@ void LSODA::lsoda(LSODA_ODE_SYSTEM_TYPE f, const size_t neq, vector<double> &y,
       {
         if (ewt[i] <= 0.)
         {
-          //cerr << "[lsoda] ewt[" << i << "] = " << ewt[i] << " <= 0.\n" << endl;
-          REprintf("[lsoda] ewt[%zu] = %g <= 0.\n", i, ewt[i]);
+          Rcpp::Rcerr << "[lsoda] ewt[" << i << "] = " << ewt[i] << " <= 0." 
+                      << std::endl;
+          //REprintf("[lsoda] ewt[%zu] = %g <= 0.\n", i, ewt[i]);
           terminate2(y, t);
           return;
         }
@@ -669,10 +673,12 @@ void LSODA::lsoda(LSODA_ODE_SYSTEM_TYPE f, const size_t neq, vector<double> &y,
         {
           if ((nst - nslast) >= mxstep)
           {
-            // cerr << "[lsoda] " << mxstep << " steps taken before reaching tout"
-            //      << endl;
-            REprintf("[lsoda] %zu steps taken before reaching tout; consider increasing maxsteps.\n", 
-                     mxstep);
+            Rcpp::Rcerr << "[lsoda] " << mxstep 
+                        << " steps taken before reaching tout;" 
+                        << " consider increasing maxsteps."
+                        << std::endl;
+            //REprintf("[lsoda] %zu steps taken before reaching tout; consider increasing maxsteps.\n", 
+            //         mxstep);
             *istate = -1;
             terminate2(y, t);
             return;
@@ -683,8 +689,9 @@ void LSODA::lsoda(LSODA_ODE_SYSTEM_TYPE f, const size_t neq, vector<double> &y,
           {
             if (ewt[i] <= 0.)
             {
-              //cerr << "[lsoda] ewt[" << i << "] = " << ewt[i] << " <= 0." << endl;
-              REprintf("[lsoda] ewt[%zu] = %g <= 0.\n", i, ewt[i]);
+              Rcpp::Rcerr << "[lsoda] ewt[" << i << "] = " << ewt[i] 
+                          << " <= 0." << std::endl;
+              //REprintf("[lsoda] ewt[%zu] = %g <= 0.\n", i, ewt[i]);
               *istate = -6;
               terminate2(y, t);
               return;
@@ -736,11 +743,12 @@ void LSODA::lsoda(LSODA_ODE_SYSTEM_TYPE f, const size_t neq, vector<double> &y,
             
             if (nhnil == mxhnil)
             {
-              // cerr << "lsoda -- above warning has been issued " << nhnil
-              //      << " times, " << endl
-              //      << "       it will not be issued again for this problem" << endl;
-              REprintf("[lsoda] above warning has been issued %zu times\n", nhnil);
-              REprintf("        it will not be issued again for this problem.\n");
+              Rcpp::Rcerr << "[lsoda] above warning has been issued " << nhnil
+                          << " times, " << std::endl
+                          << "        it will not be issued again for this problem." 
+                          << std::endl;
+              // REprintf("[lsoda] above warning has been issued %zu times\n", nhnil);
+              // REprintf("        it will not be issued again for this problem.\n");
             }
           }
         }


### PR DESCRIPTION
See #1132 ... apparently new gcc setup is generating warnings because `sprintf()` isn't getting the right type. Most of the warnings were from `size_t`. There _should_ be a "length modifier" that you can use with unsigned integer (`%zu`), but gcc doesn't seem to like the `z` length modifier. Tried with this `%zi` as well, but gcc complains about `z`. 

I ended up casting `size_t` (unsigned long int) to `int` with C-style casts. I don't think this should be a problem ...  we should always be able to cast to int. 

On one of the `sprintf()` calls, I was passing `double` and trying to format with `%d` which is just wrong; updated that to use `%f`. 

**UPDATE**

- Casting to `int` seems like it worked although `unsigned long long` might be better.
-  It's possible that `%zu` will work now, but likely to work only on newest R releases. 
- Discussing with @kyleam, he suggested using `Rcpp::Rcerr` to write to `stderr`; this was easy to implement since the original `C++` code used `cerr` and seems to be the safest route to go at this point. 