### PR TITLE
Refactor default value for `check_unique`

### DIFF
--- a/inst/base/databox_cpp.h
+++ b/inst/base/databox_cpp.h
@@ -21,11 +21,13 @@
 
 void databox::mevent(double time, int evid) {
   mrgsolve::evdata ev(time,evid);
+  ev.check_unique = true;
   mevector.push_back(ev);
 }
 
 double databox::mtime(double time) {
   mrgsolve::evdata ev(time,2);
+  ev.check_unique = true;
   mevector.push_back(ev);
   return time;
 }

--- a/inst/base/mrgsolv.h
+++ b/inst/base/mrgsolv.h
@@ -54,7 +54,7 @@ struct evdata {
     amt = 0.0;
     rate = 0.0;
     now = false;
-    check_unique = true;
+    check_unique = false;
   } 
   double time; 
   int evid;

--- a/inst/maintenance/unit-cpp/test-cpp.R
+++ b/inst/maintenance/unit-cpp/test-cpp.R
@@ -92,7 +92,7 @@ $PARAM r = 0, l = 0, d = 5, n = 0, t = 0, dose = 100
 $MAIN
 ALAG_A = l;
 D_A = d;
-if(TIME==0) {
+if(TIME==0 && EVID==0) {
   mrg::evdata ev(t, 1); 
   ev.amt = dose; 
   ev.now = n==1;


### PR DESCRIPTION
When an `evdata` object is constructed, lets set `check_unique` to `false` instead of the current default of `true`. This is what we want most of the time when users are constructing these objects themselves (for doses). 

For `mevent()` and `mtime()` we set `check_unique` to `true`; it was these functions that originally motivated this check  for duplicates and we can now control the check behavior when we calling these functions through `check_unique`. 

This is technically a breaking change but I think negative impact should be minimal; there just aren't many people using it. But we'll draw attention to this in the news. 