### PR TITLE
Never ignore .now doses based on .time

### DIFF
--- a/inst/maintenance/unit-cpp/test-cpp.R
+++ b/inst/maintenance/unit-cpp/test-cpp.R
@@ -157,3 +157,23 @@ test_that("mev lag times with F are respected", {
   a <- filter_sims(a, A==max(A))
   expect_identical(a$time, param(a)$t + param(a)$l + 0.5*mod$dose/param(a)$r)
 })
+
+code <- '
+$CMT A
+$MAIN
+if(TIME==1) {
+  mrgsolve::evdata ev(0, 1); 
+  ev.time = 0;
+  ev.now = true;
+  ev.amt = 100;
+  self.mevector.push_back(ev);
+}
+'
+
+test_that("now doses are given even when time is past", {
+  mod <- mcode("gh-1151", code)
+  out <- mrgsim(mod)
+  expect_false(all(out$A==0))
+  expect_equal(out$A[1], 0)
+  expect_equal(out$A[2], 100)
+})

--- a/inst/maintenance/unit-cpp/test-cpp.R
+++ b/inst/maintenance/unit-cpp/test-cpp.R
@@ -161,16 +161,15 @@ test_that("mev lag times with F are respected", {
 code <- '
 $CMT A
 $MAIN
-if(TIME==1) {
-  mrgsolve::evdata ev(0, 1); 
-  ev.time = 0;
-  ev.now = true;
+if(TIME==1) {                // Give dose at TIME==1
+  mrgsolve::evdata ev(0, 1); // Set time to 0
+  ev.now = true;             // Also set now to true
   ev.amt = 100;
   self.mevector.push_back(ev);
 }
 '
 
-test_that("now doses are given even when time is past", {
+test_that("now doses are given even when time is past #1151", {
   mod <- mcode("gh-1151", code)
   out <- mrgsim(mod)
   expect_false(all(out$A==0))

--- a/src/devtran.cpp
+++ b/src/devtran.cpp
@@ -624,7 +624,7 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
         for(size_t mti = 0; mti < mt.size(); ++mti) {
           // Unpack and check
           double this_time = (mt[mti]).time;
-          if(this_time < tto) continue;
+          if(this_time < tto && !mt[mti].now) continue;
           unsigned int this_evid = (mt[mti]).evid;
           if(this_evid==0) continue;
           double this_amt = mt[mti].amt;


### PR DESCRIPTION
- Doses that are requested with time before the current time are ignored. 
- When doses are scheduled to happen `now`, it shouldn't matter what the value of `time` is in the object passed back to mrgsolve
- That is to say, we want `now` status to override whatever is in `time`

This PR corrects some of the implementation logic so we don't ignore them when the dose is to be given `now`.

See #1151 