### PR TITLE
Fix until calculation when time not equal to 0

### DIFF
--- a/R/class_ev.R
+++ b/R/class_ev.R
@@ -256,7 +256,7 @@ finalize_ev_data <- function(data) {
     data[["until"]] <- NULL
     i <- data[["ii"]] > 0
     data[["addl"]] <- 0
-    data[["addl"]][i] <- ceiling((data[["time"]][i] + until[i])/data[["ii"]][i]) - 1
+    data[["addl"]][i] <- floor((until[i] - data[["time"]][i] + data["ii"][i])/data[["ii"]][i]) - 1
   }
   ev_cols <- c("ID", "time", "amt", "rate", "ii", "addl", "cmt", "evid", "ss")
   match_cols <- intersect(ev_cols,names(data))

--- a/R/class_ev.R
+++ b/R/class_ev.R
@@ -256,7 +256,8 @@ finalize_ev_data <- function(data) {
     data[["until"]] <- NULL
     i <- data[["ii"]] > 0
     data[["addl"]] <- 0
-    data[["addl"]][i] <- floor((until[i] - data[["time"]][i] + data["ii"][i])/data[["ii"]][i]) - 1
+    data[["addl"]][i] <- ceiling((until[i] - data[["time"]][i])/data[["ii"]][i]) - 1
+    data[["addl"]] <- unlist(data[["addl"]])
   }
   ev_cols <- c("ID", "time", "amt", "rate", "ii", "addl", "cmt", "evid", "ss")
   match_cols <- intersect(ev_cols,names(data))

--- a/R/events.R
+++ b/R/events.R
@@ -1,4 +1,4 @@
-# Copyright (C) 2013 - 2022  Metrum Research Group
+# Copyright (C) 2013 - 2024  Metrum Research Group
 #
 # This file is part of mrgsolve.
 #
@@ -19,50 +19,48 @@
 #' Event objects for simulating PK and other interventions
 #' 
 #' An event object specifies dosing or other interventions that get implemented
-#' during simulation. Event objects do similar things as \code{\link{data_set}}, 
+#' during simulation. Event objects do similar things as [data_set], 
 #' but simpler and quicker.
 #'
-#' @param x a model object
-#' @param time event time
-#' @param amt dose amount
-#' @param evid event ID
-#' @param cmt compartment
-#' @param ID subject ID
-#' @param replicate logical; if \code{TRUE}, events will be replicated for 
-#' each individual in \code{ID}
-#' @param until the expected maximum \bold{observation} time for this regimen
-#' @param tinf infusion time; if greater than zero, then the \code{rate} item 
-#' will be derived as \code{amt/tinf}
-#' @param realize_addl if \code{FALSE} (default), no change to \code{addl} 
-#' doses.  If \code{TRUE}, \code{addl} doses are made explicit with 
-#' \code{\link{realize_addl}}
-#' @param object passed to show
+#' @param x a model object.
+#' @param time event time.
+#' @param amt dose amount.
+#' @param evid event ID.
+#' @param cmt compartment.
+#' @param ID subject ID.
+#' @param replicate logical; if `TRUE`, events will be replicated for 
+#' each individual in `ID`.
+#' @param until the expected maximum **observation** time for this regimen; 
+#' doses will be scheduled up to, but not including, the `until` time; 
+#' see `Examples`.
+#' @param tinf infusion time; if greater than zero, then the `rate` item 
+#' will be derived as `amt/tinf`.
+#' @param realize_addl if `FALSE` (default), no change to `addl` 
+#' doses.  If `TRUE`, `addl` doses are made explicit with [realize_addl()].
+#' @param object passed to show.
 #' @param ... other items to be incorporated into the event object; see 
-#' details
+#' Details.
 #' 
 #' @details
-#' \itemize{
-#' \item Required items in events objects include 
-#' \code{time}, \code{amt}, \code{evid} and \code{cmt}.
-#' \item If not supplied, \code{evid} is assumed to be 1.
-#' \item If not supplied, \code{cmt}  is assumed to be 1.
-#' \item If not supplied, \code{time} is assumed to be 0.
-#' \item If \code{amt} is not supplied, an error will be generated.
-#' \item If \code{total} is supplied, then \code{addl} will be set 
-#' to \code{total} - 1.
-#' \item Other items can include \code{ii}, \code{ss}, and \code{addl}
-#' (see \code{\link{data_set}} for details on all of these items).
-#' \item \code{ID} may be specified as a vector.
-#' \item If replicate is \code{TRUE} (default), then the events 
-#' regimen is replicated for each \code{ID}; otherwise, the number of
-#' event rows must match the number of \code{ID}s entered
-#' }
-#' @return events object
+#' - Required items in events objects include 
+#'   `time`, `amt`, `evid` and `cmt`.
+#' - If not supplied, `evid` is assumed to be 1.
+#' - If not supplied, `cmt`  is assumed to be 1.
+#' - If not supplied, `time` is assumed to be 0.
+#' - If `amt` is not supplied, an error will be generated.
+#' - If `total` is supplied, then `addl` will be set to `total` - 1.
+#' - Other items can include `ii`, `ss`, and `addl`
+#'   (see [data_set] for details on all of these items).
+#' - `ID` may be specified as a vector.
+#' - If replicate is `TRUE` (default), then the events 
+#'   regimen is replicated for each `ID`; otherwise, the number of
+#'   event rows must match the number of `ID`s entered.
 #' 
-#' @seealso \code{\link{evd}}, \code{\link{ev_rep}}, \code{\link{ev_days}}, 
-#' \code{\link{ev_repeat}}, \code{\link{ev_assign}},
-#' \code{\link{ev_seq}}, \code{\link{mutate.ev}},
-#' \code{\link{as.ev}}, \code{\link{ev_methods}}
+#' @return `ev()` returns an event object. 
+#' 
+#' @seealso [evd()], [ev_rep()], [ev_days()], [ev_repeat()], [ev_assign()], 
+#' [ev_seq()], [mutate.ev()], [as.ev()], [as.evd()], [ev_methods].
+#' 
 #' 
 #' @examples
 #' mod <- mrgsolve::house()
@@ -77,6 +75,17 @@
 #' 
 #' reduced_load <- dplyr::mutate(loading, amt = 750)
 #' 
+#' # Three additional doses in this case
+#' e <- ev(amt = 100, ii = 4*7, until = 16*7)
+#' e
+#' # Last dose is given at 84
+#' realize_addl(e)
+#' 
+#' # Four additional doses with last at 112 in this case
+#' e <- ev(amt = 100, ii = 4*7, until = 16*7 + 0.001)
+#' realize_addl(e)
+#' 
+#' @md
 #' @export
 setGeneric("ev", function(x, ...) {
   standardGeneric("ev")

--- a/R/events.R
+++ b/R/events.R
@@ -20,7 +20,7 @@
 #' 
 #' An event object specifies dosing or other interventions that get implemented
 #' during simulation. Event objects do similar things as [data_set], 
-#' but simpler and quicker.
+#' but simpler and easier to create.
 #'
 #' @param x a model object.
 #' @param time event time.

--- a/R/events.R
+++ b/R/events.R
@@ -26,7 +26,7 @@
 #' @param time event time.
 #' @param amt dose amount.
 #' @param evid event ID.
-#' @param cmt compartment.
+#' @param cmt compartment number or name.
 #' @param ID subject ID.
 #' @param replicate logical; if `TRUE`, events will be replicated for 
 #' each individual in `ID`.
@@ -37,7 +37,7 @@
 #' will be derived as `amt/tinf`.
 #' @param realize_addl if `FALSE` (default), no change to `addl` 
 #' doses.  If `TRUE`, `addl` doses are made explicit with [realize_addl()].
-#' @param object passed to show.
+#' @param object an event object to be added to a model object.
 #' @param ... other items to be incorporated into the event object; see 
 #' **Details**.
 #' 
@@ -48,7 +48,7 @@
 #' - If not supplied, `cmt`  is assumed to be 1.
 #' - If not supplied, `time` is assumed to be 0.
 #' - If `amt` is not supplied, an error will be generated.
-#' - If `total` is supplied, then `addl` will be set to `total` - 1.
+#' - If `total` is supplied, then `addl` will be set to `total-1`.
 #' - Other items can include `ii`, `ss`, and `addl`
 #'   (see [data_set] for details on all of these items).
 #' - `ID` may be specified as a vector.

--- a/R/events.R
+++ b/R/events.R
@@ -32,14 +32,14 @@
 #' each individual in `ID`.
 #' @param until the expected maximum **observation** time for this regimen; 
 #' doses will be scheduled up to, but not including, the `until` time; 
-#' see `Examples`.
+#' see **Examples**.
 #' @param tinf infusion time; if greater than zero, then the `rate` item 
 #' will be derived as `amt/tinf`.
 #' @param realize_addl if `FALSE` (default), no change to `addl` 
 #' doses.  If `TRUE`, `addl` doses are made explicit with [realize_addl()].
 #' @param object passed to show.
 #' @param ... other items to be incorporated into the event object; see 
-#' Details.
+#' **Details**.
 #' 
 #' @details
 #' - Required items in events objects include 

--- a/man/ev.Rd
+++ b/man/ev.Rd
@@ -63,7 +63,7 @@ doses.  If \code{TRUE}, \code{addl} doses are made explicit with \code{\link[=re
 \description{
 An event object specifies dosing or other interventions that get implemented
 during simulation. Event objects do similar things as \link{data_set},
-but simpler and quicker.
+but simpler and easier to create.
 }
 \details{
 \itemize{

--- a/man/ev.Rd
+++ b/man/ev.Rd
@@ -30,7 +30,7 @@ ev(x, ...)
 \item{x}{a model object.}
 
 \item{...}{other items to be incorporated into the event object; see
-Details.}
+\strong{Details}.}
 
 \item{object}{passed to show.}
 
@@ -49,7 +49,7 @@ each individual in \code{ID}.}
 
 \item{until}{the expected maximum \strong{observation} time for this regimen;
 doses will be scheduled up to, but not including, the \code{until} time;
-see \code{Examples}.}
+see \strong{Examples}.}
 
 \item{tinf}{infusion time; if greater than zero, then the \code{rate} item
 will be derived as \code{amt/tinf}.}

--- a/man/ev.Rd
+++ b/man/ev.Rd
@@ -27,59 +27,59 @@ ev(x, ...)
 \S4method{ev}{ev}(x, realize_addl = FALSE, ...)
 }
 \arguments{
-\item{x}{a model object}
+\item{x}{a model object.}
 
-\item{...}{other items to be incorporated into the event object; see 
-details}
+\item{...}{other items to be incorporated into the event object; see
+Details.}
 
-\item{object}{passed to show}
+\item{object}{passed to show.}
 
-\item{time}{event time}
+\item{time}{event time.}
 
-\item{amt}{dose amount}
+\item{amt}{dose amount.}
 
-\item{evid}{event ID}
+\item{evid}{event ID.}
 
-\item{cmt}{compartment}
+\item{cmt}{compartment.}
 
-\item{ID}{subject ID}
+\item{ID}{subject ID.}
 
-\item{replicate}{logical; if \code{TRUE}, events will be replicated for 
-each individual in \code{ID}}
+\item{replicate}{logical; if \code{TRUE}, events will be replicated for
+each individual in \code{ID}.}
 
-\item{until}{the expected maximum \bold{observation} time for this regimen}
+\item{until}{the expected maximum \strong{observation} time for this regimen;
+doses will be scheduled up to, but not including, the \code{until} time;
+see \code{Examples}.}
 
-\item{tinf}{infusion time; if greater than zero, then the \code{rate} item 
-will be derived as \code{amt/tinf}}
+\item{tinf}{infusion time; if greater than zero, then the \code{rate} item
+will be derived as \code{amt/tinf}.}
 
-\item{realize_addl}{if \code{FALSE} (default), no change to \code{addl} 
-doses.  If \code{TRUE}, \code{addl} doses are made explicit with 
-\code{\link{realize_addl}}}
+\item{realize_addl}{if \code{FALSE} (default), no change to \code{addl}
+doses.  If \code{TRUE}, \code{addl} doses are made explicit with \code{\link[=realize_addl]{realize_addl()}}.}
 }
 \value{
-events object
+\code{ev()} returns an event object.
 }
 \description{
 An event object specifies dosing or other interventions that get implemented
-during simulation. Event objects do similar things as \code{\link{data_set}}, 
+during simulation. Event objects do similar things as \link{data_set},
 but simpler and quicker.
 }
 \details{
 \itemize{
-\item Required items in events objects include 
+\item Required items in events objects include
 \code{time}, \code{amt}, \code{evid} and \code{cmt}.
 \item If not supplied, \code{evid} is assumed to be 1.
 \item If not supplied, \code{cmt}  is assumed to be 1.
 \item If not supplied, \code{time} is assumed to be 0.
 \item If \code{amt} is not supplied, an error will be generated.
-\item If \code{total} is supplied, then \code{addl} will be set 
-to \code{total} - 1.
+\item If \code{total} is supplied, then \code{addl} will be set to \code{total} - 1.
 \item Other items can include \code{ii}, \code{ss}, and \code{addl}
-(see \code{\link{data_set}} for details on all of these items).
+(see \link{data_set} for details on all of these items).
 \item \code{ID} may be specified as a vector.
-\item If replicate is \code{TRUE} (default), then the events 
+\item If replicate is \code{TRUE} (default), then the events
 regimen is replicated for each \code{ID}; otherwise, the number of
-event rows must match the number of \code{ID}s entered
+event rows must match the number of \code{ID}s entered.
 }
 }
 \examples{
@@ -95,10 +95,18 @@ c(loading, maint)
 
 reduced_load <- dplyr::mutate(loading, amt = 750)
 
+# Three additional doses in this case
+e <- ev(amt = 100, ii = 4*7, until = 16*7)
+e
+# Last dose is given at 84
+realize_addl(e)
+
+# Four additional doses with last at 112 in this case
+e <- ev(amt = 100, ii = 4*7, until = 16*7 + 0.001)
+realize_addl(e)
+
 }
 \seealso{
-\code{\link{evd}}, \code{\link{ev_rep}}, \code{\link{ev_days}}, 
-\code{\link{ev_repeat}}, \code{\link{ev_assign}},
-\code{\link{ev_seq}}, \code{\link{mutate.ev}},
-\code{\link{as.ev}}, \code{\link{ev_methods}}
+\code{\link[=evd]{evd()}}, \code{\link[=ev_rep]{ev_rep()}}, \code{\link[=ev_days]{ev_days()}}, \code{\link[=ev_repeat]{ev_repeat()}}, \code{\link[=ev_assign]{ev_assign()}},
+\code{\link[=ev_seq]{ev_seq()}}, \code{\link[=mutate.ev]{mutate.ev()}}, \code{\link[=as.ev]{as.ev()}}, \code{\link[=as.evd]{as.evd()}}, \link{ev_methods}.
 }

--- a/tests/testthat/test-ev.R
+++ b/tests/testthat/test-ev.R
@@ -261,6 +261,7 @@ test_that("until  issue-513", {
   expect_silent(mutate(ev(amt=100,ii=2,until=168),until=NULL,addl=5))
 })
 
+# See also examples given in `ev()` help topic.
 test_that("until with non-zero dose time gh-1144", {
   # Every 4 weeks to 16 weeks; four total doses
   e <- ev(amt = 100, ii = 4*7, until = 16*7)

--- a/tests/testthat/test-ev.R
+++ b/tests/testthat/test-ev.R
@@ -260,3 +260,15 @@ test_that("until  issue-513", {
   expect_error(ev(amt=100,addl=5,until=100), "input can include either")
   expect_silent(mutate(ev(amt=100,ii=2,until=168),until=NULL,addl=5))
 })
+
+test_that("until with non-zero dose time gh-1144", {
+  # Every 4 weeks to 16 weeks; four total doses
+  e <- ev(amt = 100, ii = 4*7, until = 16*7)
+  expect_equal(e$addl, 3)
+  # Every 4 weeks to just under 16 weeks; three total doses
+  e <- ev(amt = 100, ii = 4*7, until = 16*7-0.01)
+  expect_equal(e$addl, 2)
+  # Every 4 weeks to 16 weeks, starting at 28 days; three total doses
+  e <- ev(amt = 100, ii = 4*7, until = 16*7, time = 4*7)
+  expect_equal(e$addl, 2)
+})

--- a/tests/testthat/test-ev.R
+++ b/tests/testthat/test-ev.R
@@ -1,4 +1,4 @@
-# Copyright (C) 2013 - 2019  Metrum Research Group
+# Copyright (C) 2013 - 2024  Metrum Research Group
 #
 # This file is part of mrgsolve.
 #
@@ -264,11 +264,18 @@ test_that("until  issue-513", {
 test_that("until with non-zero dose time gh-1144", {
   # Every 4 weeks to 16 weeks; four total doses
   e <- ev(amt = 100, ii = 4*7, until = 16*7)
-  expect_equal(e$addl, 3)
-  # Every 4 weeks to just under 16 weeks; three total doses
-  e <- ev(amt = 100, ii = 4*7, until = 16*7-0.01)
-  expect_equal(e$addl, 2)
+  expect_equal(e$addl, 4-1)
+  r <- realize_addl(e)
+  expect_equal(max(r$time), 16*7 - 4*7)
+  # Every 4 weeks to just under 16 weeks; four total doses
+  eu <- ev(amt = 100, ii = 4*7, until = 16*7-0.01)
+  expect_identical(eu, e)
+  # Every 4 weeks to just over 16 weeks; five total doses
+  e <- ev(amt = 100, ii = 4*7, until = 16*7+0.01)
+  expect_equal(e$addl, 5-1)
   # Every 4 weeks to 16 weeks, starting at 28 days; three total doses
   e <- ev(amt = 100, ii = 4*7, until = 16*7, time = 4*7)
-  expect_equal(e$addl, 2)
+  expect_equal(e$addl, 3-1)
+  r <- realize_addl(e)
+  expect_equal(max(r$time), 16*7 - 4*7)
 })


### PR DESCRIPTION
@dpastoor reported bad behavior of `until` when constructing event objects #1144

The primary problem was that the logic inadvertently assumed the dose was given at time = 0. This PR fixes that logic. 

One legit question raised in the issue was when should dosing end when this works properly?  For example, `Q28d` dosing that runs `until` 168` hours. The dosing regimen ends at 168 hours; should there be a dose given at 168 hours or not?

As I was working on this issue, I was thinking there _should_ be a dose there. But it looks like up to this point, we have been assuming that there isn't a dose at that time. So I'm going to code this fix to respect that behavior even though I'm thinking about it a little different now. 

To be clear: the `until` argument is the expected last `observation` time covered by that dose sequence; so we keep you dosing to cover the `until` time. If a dose might be given at the same time as the last observation, `until` won't cover that. 

Using @dpastoor 's example, the dosing runs to 84 hours, not 112. But I agree it might be reasonable to run it to 112 too. 

``` r
library(mrgsolve)
#> 
#> Attaching package: 'mrgsolve'
#> The following object is masked from 'package:stats':
#> 
#>     filter

realize_addl(ev(amt = 300, time = 4*7, ii = 4*7, until = 16*7-0.001))
#> Events:
#>   time amt ii addl cmt evid
#> 1   28 300  0    0   1    1
#> 2   56 300  0    0   1    1
#> 3   84 300  0    0   1    1
realize_addl(ev(amt = 300, time = 4*7, ii = 4*7, until = 16*7))
#> Events:
#>   time amt ii addl cmt evid
#> 1   28 300  0    0   1    1
#> 2   56 300  0    0   1    1
#> 3   84 300  0    0   1    1
realize_addl(ev(amt = 300, time = 4*7, ii = 4*7, until = 16*7+0.001))
#> Events:
#>   time amt ii addl cmt evid
#> 1   28 300  0    0   1    1
#> 2   56 300  0    0   1    1
#> 3   84 300  0    0   1    1
#> 4  112 300  0    0   1    1
```

<sup>Created on 2024-01-16 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>


**EDIT**: this PR also modernizes the `ev()` help topic and adds some text and examples for what to expect for `until` behavior. There are some other modifications that I'd like to make, but this will require modifying some other help topics as well (e.g. documenting evid/EVID in data_set). I will do this as another PR. 
