### PR TITLE
Clean up rownames after ev_rep

### DIFF
--- a/R/events.R
+++ b/R/events.R
@@ -467,6 +467,7 @@ ev_rep <- function(x, ID = 1, n = NULL, wait = 0, as.ev = FALSE, id = NULL) {
       data <- ev_repeat(data, n = n, wait = wait)
     }
   }
+  rownames(data) <- NULL
   if(isTRUE(as.ev)) {
     set_ev_case(as.ev(data), case)
   } else {

--- a/tests/testthat/test-ev.R
+++ b/tests/testthat/test-ev.R
@@ -137,7 +137,7 @@ test_that("clean up row names gh-1116", {
     ev_rep(ev(amt = 100), ID = 1:2), 
     ev_rep(ev(amt = 200), ID = 1:3)
   )
-  expect_identical(rownames(a), as.character(seq(5)))
+  expect_identical(rownames(a), as.character(seq(nrow(a))))
 })
 
 test_that("events with without rate" , {

--- a/tests/testthat/test-ev.R
+++ b/tests/testthat/test-ev.R
@@ -132,6 +132,14 @@ test_that("replicate an event object", {
   expect_equal(df$ID, 11:14)
 })
 
+test_that("clean up row names gh-1116", {
+  a <- as_data_set(
+    ev_rep(ev(amt = 100), ID = 1:2), 
+    ev_rep(ev(amt = 200), ID = 1:3)
+  )
+  expect_identical(rownames(a), as.character(seq(5)))
+})
+
 test_that("events with without rate" , {
   e1 <- ev(amt=1, ii=12)
   e2 <- ev(amt=2, ii=24, rate=1)


### PR DESCRIPTION
Fix up row names when expanding event object in a population. See #1116.


