### PR TITLE
Check for clashes between model names and cpp dot syntax

### DIFF
--- a/R/class_mrgmod.R
+++ b/R/class_mrgmod.R
@@ -100,14 +100,18 @@ check_globals <- function(x,cmt) {
   return(invisible(NULL))
 }
 
-check_cpp_objects <- function(env, x) {
-  if(is.null(env[["cpp_objects"]])) return(NULL)
+check_cpp_dot <- function(env, x) {
+  # Vast majority of models will just return
+  if(is.null(env[["cpp_dot"]])) return(NULL)
+  cpp_dot <- setdiff(
+    env[["cpp_dot"]], 
+    x@envir[["MRGSOLVE_CPP_DOT_SKIP"]]
+  )
+  if(!length(cpp_dot)) return(NULL)
   mod_names <- names(x)
   mod_names <- mod_names[c("param", "init", "omega_labels", "sigma_labels")]
   mod_labels <- unlist(mod_names, use.names = FALSE)
-  cpp_objects <- env[["cpp_objects"]]
-  bad <- cpp_objects[cpp_objects %in% mod_labels]
-  if(!length(bad)) return(NULL)
+  bad <- cpp_dot[cpp_dot %in% mod_labels]
   bad <- setdiff(bad, Reserved)  
   if(!length(bad)) return(NULL)
   mod_names$sigma_labels <- unlist(mod_names$sigma_labels, use.names = FALSE)
@@ -115,8 +119,8 @@ check_cpp_objects <- function(env, x) {
   for(i in seq_along(bad)) {
     if(bad[i] %in% mod_names$param) bad[i] <- paste(bad[i], "(parameter)")
     if(bad[i] %in% mod_names$init) bad[i] <- paste(bad[i], "(compartment)")
-    if(bad[i] %in% mod_names$omega_labels) bad[i] <- paste(bad[i], "(eta name)")
-    if(bad[i] %in% mod_names$sigma_labels) bad[i] <- paste(bad[i], "(eps name)")
+    if(bad[i] %in% mod_names$omega_labels) bad[i] <- paste(bad[i], "(eta label)")
+    if(bad[i] %in% mod_names$sigma_labels) bad[i] <- paste(bad[i], "(eps label)")
   }
   if(length(bad) > 1) {
     msg <- "Reserved symbols cannot be used as model names:"

--- a/R/class_mrgmod.R
+++ b/R/class_mrgmod.R
@@ -117,10 +117,18 @@ check_cpp_dot <- function(env, x) {
   mod_names$sigma_labels <- unlist(mod_names$sigma_labels, use.names = FALSE)
   mod_names$omega_labels <- unlist(mod_names$omega_labels, use.names = FALSE)
   for(i in seq_along(bad)) {
-    if(bad[i] %in% mod_names$param) bad[i] <- paste(bad[i], "(parameter)")
-    if(bad[i] %in% mod_names$init) bad[i] <- paste(bad[i], "(compartment)")
-    if(bad[i] %in% mod_names$omega_labels) bad[i] <- paste(bad[i], "(eta label)")
-    if(bad[i] %in% mod_names$sigma_labels) bad[i] <- paste(bad[i], "(eps label)")
+    if(bad[i] %in% mod_names$param) {
+      bad[i] <- paste(bad[i], "(parameter)")
+    }
+    if(bad[i] %in% mod_names$init) {
+      bad[i] <- paste(bad[i], "(compartment)")
+    }
+    if(bad[i] %in% mod_names$omega_labels) {
+      bad[i] <- paste(bad[i], "(eta label)")
+    }
+    if(bad[i] %in% mod_names$sigma_labels) {
+      bad[i] <- paste(bad[i], "(eps label)")
+    }
   }
   if(length(bad) > 1) {
     msg <- "Reserved symbols cannot be used as model names:"
@@ -130,7 +138,7 @@ check_cpp_dot <- function(env, x) {
     foot <- "This symbol became reserved because it was detected in C++ model code."
   }
   names(bad) <- rep("x", length(bad))
-  abort(c(msg, bad), footer=foot)
+  abort(c(msg, bad), footer = foot)
 }
 
 protomod <- list(model=character(0),

--- a/R/class_mrgmod.R
+++ b/R/class_mrgmod.R
@@ -103,8 +103,12 @@ check_globals <- function(x,cmt) {
 check_cpp_dot <- function(env, x) {
   # Vast majority of models will just return
   if(is.null(env[["cpp_dot"]])) return(NULL)
-  dont_check <- cvec_cs(x@envir[["MRGSOLVE_CPP_DOT_SKIP"]])
-  cpp_dot <- setdiff(env[["cpp_dot"]], dont_check)
+  cpp_dot <- env[["cpp_dot"]]
+  dont_check <- x@envir[["MRGSOLVE_CPP_DOT_SKIP"]]
+  if(is.character(dont_check)) {
+    dont_check <- cvec_cs(dont_check)
+    cpp_dot <- setdiff(cpp_dot, dont_check)
+  } 
   if(!length(cpp_dot)) return(NULL)
   mod_names <- names(x)
   mod_names <- mod_names[c("param", "init", "omega_labels", "sigma_labels")]

--- a/R/class_mrgmod.R
+++ b/R/class_mrgmod.R
@@ -103,10 +103,8 @@ check_globals <- function(x,cmt) {
 check_cpp_dot <- function(env, x) {
   # Vast majority of models will just return
   if(is.null(env[["cpp_dot"]])) return(NULL)
-  cpp_dot <- setdiff(
-    env[["cpp_dot"]], 
-    x@envir[["MRGSOLVE_CPP_DOT_SKIP"]]
-  )
+  dont_check <- cvec_cs(x@envir[["MRGSOLVE_CPP_DOT_SKIP"]])
+  cpp_dot <- setdiff(env[["cpp_dot"]], dont_check)
   if(!length(cpp_dot)) return(NULL)
   mod_names <- names(x)
   mod_names <- mod_names[c("param", "init", "omega_labels", "sigma_labels")]

--- a/R/class_mrgmod.R
+++ b/R/class_mrgmod.R
@@ -100,6 +100,35 @@ check_globals <- function(x,cmt) {
   return(invisible(NULL))
 }
 
+check_cpp_objects <- function(env, x) {
+  if(is.null(env[["cpp_objects"]])) return(NULL)
+  mod_names <- names(x)
+  mod_names <- mod_names[c("param", "init", "omega_labels", "sigma_labels")]
+  mod_labels <- unlist(mod_names, use.names = FALSE)
+  cpp_objects <- env[["cpp_objects"]]
+  bad <- cpp_objects[cpp_objects %in% mod_labels]
+  if(!length(bad)) return(NULL)
+  bad <- setdiff(bad, Reserved)  
+  if(!length(bad)) return(NULL)
+  mod_names$sigma_labels <- unlist(mod_names$sigma_labels, use.names = FALSE)
+  mod_names$omega_labels <- unlist(mod_names$omega_labels, use.names = FALSE)
+  for(i in seq_along(bad)) {
+    if(bad[i] %in% mod_names$param) bad[i] <- paste(bad[i], "(parameter)")
+    if(bad[i] %in% mod_names$init) bad[i] <- paste(bad[i], "(compartment)")
+    if(bad[i] %in% mod_names$omega_labels) bad[i] <- paste(bad[i], "(eta name)")
+    if(bad[i] %in% mod_names$sigma_labels) bad[i] <- paste(bad[i], "(eps name)")
+  }
+  if(length(bad) > 1) {
+    msg <- "Reserved symbols cannot be used as model names:"
+    foot <- "These symbols became reserved because they were detected in C++ model code."
+  } else {
+    msg <- "Reserved symbol cannot be used as model name:"
+    foot <- "This symbol became reserved because it was detected in C++ model code."
+  }
+  names(bad) <- rep("x", length(bad))
+  abort(c(msg, bad), footer=foot)
+}
+
 protomod <- list(model=character(0),
                  modfile = character(0),
                  package=character(0),

--- a/R/modspec.R
+++ b/R/modspec.R
@@ -539,9 +539,11 @@ find_cpp_dot <- function(spec, env) {
   to_check <- c("PREAMBLE", "MAIN", "PRED", "ODE", "TABLE", "GLOBAL")
   x <- spec[names(spec) %in% to_check]
   x <- unlist(x, use.names = FALSE)
+  # Narrow the search first; 10x speed up when searching for `pattern`
+  x <- x[grepl(".", x, fixed = TRUE)]
   if(!length(x)) return(NULL)
   pattern <- "\\b[a-zA-Z][a-zA-Z0-9_]*\\.[a-zA-Z][a-zA-Z0-9_]*\\b"
-  m <- gregexpr(pattern, x)
+  m <- gregexpr(pattern, x, perl = TRUE)
   mm <- regmatches(x, m)
   mm <- unlist(mm, use.names = FALSE)
   if(!length(mm)) return(NULL)

--- a/R/modspec.R
+++ b/R/modspec.R
@@ -542,11 +542,12 @@ find_cpp_dot <- function(spec, env) {
   if(!length(x)) return(NULL)
   pattern <- "\\b[a-zA-Z][a-zA-Z0-9_]*\\.[a-zA-Z][a-zA-Z0-9_]*\\b"
   m <- gregexpr(pattern, x)
-  mm <- unlist(regmatches(x, m))
+  mm <- regmatches(x, m)
+  mm <- unlist(mm, use.names = FALSE)
   if(!length(mm)) return(NULL)
-  mm <- strsplit(mm, ".", fixed = TRUE)
-  mm <- unique(unlist(mm), use.names = FALSE)
-  env[["cpp_dot"]] <- mm
+  cpp_dot <- strsplit(mm, ".", fixed = TRUE)
+  cpp_dot <- unlist(cpp_dot, use.names = FALSE)
+  env[["cpp_dot"]] <- unique(cpp_dot)
   return(NULL)
 }
 

--- a/R/modspec.R
+++ b/R/modspec.R
@@ -535,6 +535,22 @@ move_global2 <- function(spec, env, build) {
   spec
 }
 
+find_cpp_objects <- function(spec, env) {
+  to_check <- c("PREAMBLE", "MAIN", "PK", "ODE", "TABLE", 
+                "ERROR", "GLOBAL", "PRED")
+  x <- spec[names(spec) %in% to_check]
+  x <- unlist(x, use.names = FALSE)
+  if(length(x)==0) return(NULL)
+  pat <- "\\b[a-zA-Z][a-zA-Z0-9_]*\\.[a-zA-Z][a-zA-Z0-9_]*\\b"
+  m <- gregexpr(pat, x)
+  mm <- unlist(regmatches(x, m))
+  if(length(mm)==0) return(NULL)
+  mm <- strsplit(mm, ".", fixed = TRUE)
+  mm <- unique(unlist(mm), use.names = FALSE)
+  env[["cpp_objects"]] <- mm
+  return(NULL)
+}
+
 # nocov start
 get_rcpp_vars <- function(y) {
   m <- gregexpr(move_global_rcpp_re_find,y,perl=TRUE)
@@ -736,6 +752,7 @@ parse_env <- function(spec, incoming_names = names(spec),build,ENV=new.env()) {
   mread.env$blocks <- names(spec)
   mread.env$incoming_names <- incoming_names
   mread.env$capture_etas <- NULL
+  mread.env$cpp_objects <- NULL
   mread.env
 }
 

--- a/R/modspec.R
+++ b/R/modspec.R
@@ -535,19 +535,18 @@ move_global2 <- function(spec, env, build) {
   spec
 }
 
-find_cpp_objects <- function(spec, env) {
-  to_check <- c("PREAMBLE", "MAIN", "PK", "ODE", "TABLE", 
-                "ERROR", "GLOBAL", "PRED")
+find_cpp_dot <- function(spec, env) {
+  to_check <- c("PREAMBLE", "MAIN", "PRED", "ODE", "TABLE", "GLOBAL")
   x <- spec[names(spec) %in% to_check]
   x <- unlist(x, use.names = FALSE)
-  if(length(x)==0) return(NULL)
-  pat <- "\\b[a-zA-Z][a-zA-Z0-9_]*\\.[a-zA-Z][a-zA-Z0-9_]*\\b"
-  m <- gregexpr(pat, x)
+  if(!length(x)) return(NULL)
+  pattern <- "\\b[a-zA-Z][a-zA-Z0-9_]*\\.[a-zA-Z][a-zA-Z0-9_]*\\b"
+  m <- gregexpr(pattern, x)
   mm <- unlist(regmatches(x, m))
-  if(length(mm)==0) return(NULL)
+  if(!length(mm)) return(NULL)
   mm <- strsplit(mm, ".", fixed = TRUE)
   mm <- unique(unlist(mm), use.names = FALSE)
-  env[["cpp_objects"]] <- mm
+  env[["cpp_dot"]] <- mm
   return(NULL)
 }
 
@@ -752,7 +751,7 @@ parse_env <- function(spec, incoming_names = names(spec),build,ENV=new.env()) {
   mread.env$blocks <- names(spec)
   mread.env$incoming_names <- incoming_names
   mread.env$capture_etas <- NULL
-  mread.env$cpp_objects <- NULL
+  mread.env$cpp_dot <- NULL
   mread.env
 }
 

--- a/R/mread.R
+++ b/R/mread.R
@@ -231,7 +231,6 @@ mread <- function(model, project = getOption("mrgsolve.project", getwd()),
   
   # Find cpp objects with dot syntax; saved to mread.env$cpp_dot ----
   find_cpp_dot(spec, mread.env)
-  return(spec)
   
   # Parse blocks ----
   # Each block gets assigned a class to dispatch the handler function

--- a/R/mread.R
+++ b/R/mread.R
@@ -229,7 +229,7 @@ mread <- function(model, project = getOption("mrgsolve.project", getwd()),
     build
   )
   
-  # Find cpp objects with dot syntax ----
+  # Find cpp objects with dot syntax; saved to mread.env$cpp_dot ----
   find_cpp_dot(spec, mread.env)
   
   # Parse blocks ----

--- a/R/mread.R
+++ b/R/mread.R
@@ -229,8 +229,8 @@ mread <- function(model, project = getOption("mrgsolve.project", getwd()),
     build
   )
   
-  # Find cpp objects ----
-  find_cpp_objects(spec, mread.env)
+  # Find cpp objects with dot syntax ----
+  find_cpp_dot(spec, mread.env)
   
   # Parse blocks ----
   # Each block gets assigned a class to dispatch the handler function
@@ -435,7 +435,7 @@ mread <- function(model, project = getOption("mrgsolve.project", getwd()),
   # Check mod ----
   check_pkmodel(x, subr, spec)
   check_globals(mread.env[["move_global"]], Cmt(x))
-  check_cpp_objects(mread.env, x)
+  check_cpp_dot(mread.env, x)
   check_sim_eta_eps_n(x, spec)
   
   # This must come after audit

--- a/R/mread.R
+++ b/R/mread.R
@@ -231,6 +231,7 @@ mread <- function(model, project = getOption("mrgsolve.project", getwd()),
   
   # Find cpp objects with dot syntax; saved to mread.env$cpp_dot ----
   find_cpp_dot(spec, mread.env)
+  return(spec)
   
   # Parse blocks ----
   # Each block gets assigned a class to dispatch the handler function

--- a/R/mread.R
+++ b/R/mread.R
@@ -229,6 +229,9 @@ mread <- function(model, project = getOption("mrgsolve.project", getwd()),
     build
   )
   
+  # Find cpp objects ----
+  find_cpp_objects(spec, mread.env)
+  
   # Parse blocks ----
   # Each block gets assigned a class to dispatch the handler function
   # Also, we use a position attribute so we know 
@@ -432,6 +435,7 @@ mread <- function(model, project = getOption("mrgsolve.project", getwd()),
   # Check mod ----
   check_pkmodel(x, subr, spec)
   check_globals(mread.env[["move_global"]], Cmt(x))
+  check_cpp_objects(mread.env, x)
   check_sim_eta_eps_n(x, spec)
   
   # This must come after audit

--- a/tests/testthat/test-modspec.R
+++ b/tests/testthat/test-modspec.R
@@ -629,10 +629,10 @@ test_that("Skip cpp dot check gh-1159", {
   table <- "true;"
   code <- glue::glue(temp)
   
-  expect_is(mcode("cpp-dot-skip-1", code, compile = FALSE), "mrgmod")
+  expect_s4_class(mcode("cpp-dot-skip-1", code, compile = FALSE), "mrgmod")
   
-  temp <- '$param {param}\n$main\n{main};\n$env MRGSOLVE_CPP_DOT_SKIP="foo,bar"'
-  param <- "cl = 1, bar = 2, vc = 5"
+  temp <- '$param {param}\n$main\n{main};\n$env MRGSOLVE_CPP_DOT_SKIP="foo"'
+  param <- "cl = 1, foo = 3, bar = 2, vc = 5"
   main <- "double b = 5;\nfoo.bar = true;"
   table <- "true;"
   code <- glue::glue(temp)
@@ -647,4 +647,12 @@ test_that("Skip cpp dot check gh-1159", {
   
   expect_match(check, "bar (parameter)", fixed = TRUE)
   expect_no_match(check, "foo (parameter)", fixed = TRUE)
+  
+  temp <- '$param {param}\n$main\n{main};\n$env MRGSOLVE_CPP_DOT_SKIP="foo,bar"'
+  param <- "cl = 1, foo = 3, bar = 2, vc = 5"
+  main <- "double b = 5;\nfoo.bar = true;"
+  table <- "true;"
+  code <- glue::glue(temp)
+  
+  expect_s4_class(mcode("cpp-dot-skip-4", code, compile = FALSE), "mrgmod")
 })

--- a/tests/testthat/test-modspec.R
+++ b/tests/testthat/test-modspec.R
@@ -587,3 +587,10 @@ test_that("INPUT block", {
   expect_equal(tagdf$name, c("CL", "V2"))
   expect_equal(tagdf$tag, rep("input", 2))
 })
+
+test_that("Reserve names in cpp dot gh-1159", {
+  temp <- '$param {param}\n$main {main};\n$table {table}'
+  param <- "cl = 1, bar = 2, vc = 5"
+  main <- "double b = 5;\nfoo.bar = true;"
+  table <- ""
+})


### PR DESCRIPTION
# Summary

I referred to this in #1156; original issue in #1143


# Example of what happens currently

Two examples below. In the first example, we have written some C++ code that clashes with parameter names; the model won't compile. 

Several of these names that we _might_ use are known and we have already reserved them. 

What I want to do in the PR is to find names of the first case and give them reserved status at the time of model load and prevent parameters or compartments or other model labels from using those names.


``` r
library(mrgsolve)
#> 
#> Attaching package: 'mrgsolve'
#> The following object is masked from 'package:stats':
#> 
#>     filter

code <- '
$PARAM check_unique = 2
$MAIN 
mrg::evdata ev(0, 2);
ev.check_unique = true;
'

mod <- mcode("verify", code)
#> Building verify ...
#> error.
#> 
#> ---:: stderr ::---------------------------------------------
#> using C++ compiler: ‘Apple clang version 14.0.3 (clang-1403.0.22.14.1)’
#> using SDK: ‘MacOSX13.3.sdk’
#> 12:4: error: no member named '_THETA_' in 'mrgsolve::evdata'
#> ev.check_unique = true;
#> ~~ ^
#> ./verify-mread-header.h:38:22: note: expanded from macro 'check_unique'
#> #define check_unique _THETA_[0]
#>                      ^
#> 1 error generated.
#> make: *** [verify-mread-source.o] Error 1
#> 
#> ------------------------------------------------------------
#> Error: the model build step failed.

code <- '
$PARAM check_unique = 2, amt = 5
$MAIN 
mrg::evdata ev(0, 2);
ev.amt = 100;
'

mod <- mcode("verify2", code)
#> Error in validObject(.Object): invalid class "mrgmod" object: Reserved words in model names: amt
```

<sup>Created on 2024-02-02 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
