### PR TITLE
fix show output when no captures

### DIFF
--- a/R/print.R
+++ b/R/print.R
@@ -93,7 +93,7 @@ print.mrgmod <- function(x,verbose=FALSE,...) {
     capttext <- paste0(captheader[1:length(capttext)],capttext)
     
   } else {
-    capttext <- paste(captheader[1],"<none>")  
+    capttext <- paste0(captheader[1],"<none>")  
   }
   
   maxs <- paste0(floor(x@maxsteps/1000), "k")


### PR DESCRIPTION


# Before

``` r
library(mrgsolve); mcode("foo", "$PARAM a = 1")
#> 
#> Attaching package: 'mrgsolve'
#> The following object is masked from 'package:stats':
#> 
#>     filter
#> Building foo ... done.
#> 
#> 
#> -----------------  source: foo.cpp  -----------------
#> 
#>   project: /private/var/fol.../T/Rtmpx1oc8D
#>   shared object: foo-so-112005ee5d935 
#> 
#>   time:          start: 0 end: 24 delta: 1
#>                  add: <none>
#> 
#>   compartments:  <none>
#>   parameters:    a [1]
#>   captures:       <none>
#>   omega:         0x0 
#>   sigma:         0x0 
#> 
#>   solver:        atol: 1e-08 rtol: 1e-08 maxsteps: 20k
#> ------------------------------------------------------
```

<sup>Created on 2024-02-03 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

# After

``` r
library(mrgsolve); mcode("foo", "$PARAM a = 1")
#> 
#> Attaching package: 'mrgsolve'
#> The following object is masked from 'package:stats':
#> 
#>     filter
#> Building foo ... done.
#> 
#> 
#> -----------------  source: foo.cpp  -----------------
#> 
#>   project: /private/var/fol.../T/Rtmp2Ei8vw
#>   shared object: foo-so-11387219d62d3 
#> 
#>   time:          start: 0 end: 24 delta: 1
#>                  add: <none>
#> 
#>   compartments:  <none>
#>   parameters:    a [1]
#>   captures:      <none>
#>   omega:         0x0 
#>   sigma:         0x0 
#> 
#>   solver:        atol: 1e-08 rtol: 1e-08 maxsteps: 20k
#> ------------------------------------------------------
```

<sup>Created on 2024-02-03 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>