### PR TITLE
Always simulate from OMEGA so EPS is reproducible

### DIFF
--- a/inst/maintenance/unit/test-simeta.R
+++ b/inst/maintenance/unit/test-simeta.R
@@ -314,7 +314,7 @@ test_that("pass ETA on the idata set", {
     ETA1 = rev(ID)/10,
     ETA3 = ETA1
   )[, c("ID", "ETA1", "ETA3")]
-
+  
   data <- expand_observations(data, times = seq(5))
   data <- mutate(data, cmt = 0)
   data2 <- merge(data, idata, by = "ID")
@@ -330,7 +330,7 @@ test_that("pass ETA on the idata set", {
     mrgsim(mod, data, idata, etasrc = "idata.all"), 
     "all 11 ETAs must"
   )
-
+  
   expect_error(
     mrgsim(mod, data, idata = data[, "ID"], etasrc = "idata"), 
     "at least one"
@@ -355,4 +355,16 @@ test_that("pass ETA on the idata set", {
   expect_identical(out$c, idata$ETA3)
   expect_identical(out$b, rep(0, nrow(idata)))
   expect_identical(out$d, rep(0, nrow(idata)))
+})
+
+
+test_that("Reproducible EPS with etasrc=data gh-1138", { 
+  data <- expand.ev(amt = 0, ETA1 = 0.1)
+  mod <- modlib("popex", capture = "EPS(1)", end = 300)
+  mod <- smat(mod, matrix(1))
+  set.seed(11211)
+  out1 <- mrgsim(mod, data)
+  set.seed(11211)
+  out2 <- mrgsim(mod, data, etasrc = "data")
+  expect_identical(out1$EPS_1, out2$EPS_1)
 })

--- a/src/devtran.cpp
+++ b/src/devtran.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2013 - 2023  Metrum Research Group
+// Copyright (C) 2013 - 2024  Metrum Research Group
 //
 // This file is part of mrgsolve.
 //
@@ -299,8 +299,10 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
   if(neta > 0) {
     const std::string etasrc = Rcpp::as<std::string> (parin["etasrc"]);
     prob.set_eta();
+    eta = prob.mv_omega(NID); 
     if(etasrc=="omega") {
-      eta = prob.mv_omega(NID); 
+      // Nothing else to do; we always simulate
+      // from omega if neta > 0
     } else if(etasrc=="data") {
       eta = dat.get_etas(neta, false, etasrc);
     } else if(etasrc=="data.all") {


### PR DESCRIPTION
See examples in #1138

The PR changes behavior so that we always simulate from OMEGA, even when requesting ETA to come from an input data set. This will make EPS reproducible between a run that uses simulated ETA and a run that pulls ETA from the data set. 

This change will change certain simulations involving RUV and ETAs pulled from the input data. I don't expect many people to be affected at this point in the game. 