### PR TITLE
Drop specialized comment character in articles

### DIFF
--- a/vignettes/extra/global.R
+++ b/vignettes/extra/global.R
@@ -1,2 +1,2 @@
-knitr::opts_chunk$set(message = FALSE, warning = FALSE, comment='.')
+knitr::opts_chunk$set(message = FALSE, warning = FALSE)
 options(mrgsolve.soloc = "mrgsolve-builds", mrgsolve.mread.quiet = TRUE)

--- a/vignettes/extra/modeled-event-time.Rmd
+++ b/vignettes/extra/modeled-event-time.Rmd
@@ -36,7 +36,7 @@ that is not found in a record in the input data set.  We can make this happen
 from the model code itself using `mtime()`. 
 
 Let's make KA change at 2.1 hours (`change_t` parameter in the example below).
-```{r, comment = '.', eval=FALSE, code = readLines("mtime-model.txt")}
+```{r, eval=FALSE, code = readLines("mtime-model.txt")}
 
 ```
 


### PR DESCRIPTION
Merging this out-of-package documentation fix; code base is not affected. 