### PR TITLE
Release/1.4.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: mrgsolve
 Title: Simulate from ODE-Based Models
-Version: 1.3.0.9000
+Version: 1.4.0
 Authors@R: 
     c(person(given = "Kyle T", family = "Baron",
              role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -27,9 +27,9 @@
 
 ## Bugs Fixed
 
-- Fixed a bug where modeled doses scheduled to happen `now` were ignored based
-  if the `time` attribute was set to a value prior to the current simulation
-  time (#1152).
+- Fixed a bug where modeled doses scheduled to happen `now` were ignored if the 
+  `time` attribute was set to a value prior to the current simulation time 
+  (#1152).
 
 - Fixed a bug in how doses were computed using the `until` argument to `ev()`
   (#1154).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,38 @@
 # mrgsolve 1.4.0
 
+- `evtools` is a new plugin providing api for dynamic dosing from within the 
+  model; functions and classes are in the `evt` namespace (#1149).
+  
+- `regimen` is a new class located in the `evt` namespace via the `evtools` 
+  plugin; `regimen` objects can execute doses in a regular regimen (#1156).
+  
+- `mread()` and `mcode()` no longer print a message before the required 
+  waiting period on model recompile (#1145).
+
+- `ev_rep()` output rownames are cleaned up before returning (#1158).
+
+- C++ model code blocks (GLOBAL, PREAMBLE, MAIN/PK, ODE/DES, TABLE/ERROR) are 
+  now checked for `<object>.<attribute>` syntax; if found, symbols on both sides
+  of the dot become reserved words when loading and compiling that model; 
+  specifically, an error will be generated if either side of the dot (`<object>`
+  or `<attribute>`) is found in parameter names, compartment names, ETA labels, 
+  or EPS labels (#1159).
+  
+- ETA values are always simulated from OMEGA, even when the user requests they
+  get scraped from `data` or `idata` via `etasrc` argument to `mrgsim()`; this 
+  ensures `EPS` are reproducible for model runs where `etasrc = "omega"` 
+  (default, ETA are simulated) or, for example, where `etaasrc = "data.all"` 
+  (scrape ETA from the data set) (#1163).
 
 
+## Bugs Fixed
+
+- Fixed a bug where modeled doses scheduled to happen `now` were ignored based
+  if the `time` attribute was set to a value prior to the current simulation
+  time (#1152).
+
+- Fixed a bug in how doses were computed using the `until` argument to `ev()`
+  (#1154).
 
 # mrgsolve 1.3.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # mrgsolve 1.4.0
 
-- `evtools` is a new plugin providing api for dynamic dosing from within the 
+- `evtools` is a new plugin providing API for dynamic dosing from within the 
   model; functions and classes are in the `evt` namespace (#1149).
   
 - `regimen` is a new class located in the `evt` namespace via the `evtools` 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,7 @@
-# mrgsolve (development version)
+# mrgsolve 1.4.0
+
+
+
 
 # mrgsolve 1.3.0
 

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -4,6 +4,7 @@ NMEXT
 nmxml
 NMXML
 THETAs
+DES
 dll
 evid
 fortran


### PR DESCRIPTION
# mrgsolve 1.4.0

- `evtools` is a new plugin providing API for dynamic dosing from within the 
  model; functions and classes are in the `evt` namespace (#1149).
  
- `regimen` is a new class located in the `evt` namespace via the `evtools` 
  plugin; `regimen` objects can execute doses in a regular regimen (#1156).
  
- `mread()` and `mcode()` no longer print a message before the required 
  waiting period on model recompile (#1145).

- `ev_rep()` output rownames are cleaned up before returning (#1158).

- C++ model code blocks (GLOBAL, PREAMBLE, MAIN/PK, ODE/DES, TABLE/ERROR) are 
  now checked for `<object>.<attribute>` syntax; if found, symbols on both sides
  of the dot become reserved words when loading and compiling that model; 
  specifically, an error will be generated if either side of the dot (`<object>`
  or `<attribute>`) is found in parameter names, compartment names, ETA labels, 
  or EPS labels (#1159).
  
- ETA values are always simulated from OMEGA, even when the user requests they
  get scraped from `data` or `idata` via `etasrc` argument to `mrgsim()`; this 
  ensures `EPS` are reproducible for model runs where `etasrc = "omega"` 
  (default, ETA are simulated) or, for example, where `etaasrc = "data.all"` 
  (scrape ETA from the data set) (#1163).


## Bugs Fixed

- Fixed a bug where modeled doses scheduled to happen `now` were ignored if the 
  `time` attribute was set to a value prior to the current simulation time 
  (#1152).

- Fixed a bug in how doses were computed using the `until` argument to `ev()`
  (#1154).
