### PR TITLE
Fix behavior for regimen::ii()

### DIFF
--- a/inst/base/mrgsolve-evtools-regimen.h
+++ b/inst/base/mrgsolve-evtools-regimen.h
@@ -73,9 +73,6 @@ void regimen::cmt(int cmt_) {
 
 void regimen::ii(double ii_) {
   Ii = ii_;
-  if(prev_dose_time > -1e9) {
-    dose_time = prev_dose_time + Ii;  
-  }
   return;
 }
 

--- a/inst/maintenance/unit-cpp/test-evtools-regimen.R
+++ b/inst/maintenance/unit-cpp/test-evtools-regimen.R
@@ -81,3 +81,77 @@ test_that("flag_next stops the simulation", {
   out2 <- filter(out2, time %in% pick)
   expect_equal(out1$CP, out2$CP, tolerance = 1e-10)
 })
+
+
+
+code <- ' // gh-1169
+$PARAM CL = 1, V = 10, KA = 1
+
+$PKMODEL cmt = "GUT,CENT", depot = TRUE
+
+$PLUGIN evtools
+
+$GLOBAL
+evt::regimen reg;
+
+$PK
+if(NEWIND <= 1) {
+  reg.init(self);
+  reg.amt(100);
+  reg.ii(24);
+  reg.cmt(2);
+}
+
+$ERROR
+if(TIME==168 && EVID==0) {
+  reg.ii(12);
+  reg.amt(reg.amt()/2);
+}
+
+if(TIME==300 && EVID==0) {
+  reg.ii(6);
+  reg.amt(reg.amt()/2);
+}
+
+if(TIME==400 && EVID==0) {
+  reg.ii(24);
+  reg.amt(reg.amt()*4);
+}
+
+reg.execute();
+'
+mod <- mcode("fix-gh-1169", code)
+
+test_that("regimen::ii() gives expected result gh-1169", {
+  
+  out <- mrgsim(mod, end = 840, output = "df")
+  out <- mutate(out, DAY = 1+floor(time/24)) 
+  
+  summ <-
+    out %>% 
+    group_by(DAY) %>% 
+    summarise(Cmax = max(CENT), Cmin = min(CENT)) %>% 
+    ungroup()
+  
+  # ggplot(as.data.frame(out), aes(time,CENT)) + geom_line() + geom_vline(xintercept = c(168, 300, 400))
+  
+  #' The exact values for the cutoffs aren't obvious; but looking for 
+  #' steady-state Cmax that starts high, goes down in the next two periods and 
+  #' then comes back up to the original; Cmin will will start low, increase x2 
+  #' and then return to original values; changing dose interval and dose as 
+  #' suggested in the code will fit this pattern
+  summ1 <- filter(summ, DAY >  2 & DAY <=  7)
+  summ2 <- filter(summ, DAY >  8 & DAY <= 13) 
+  summ3 <- filter(summ, DAY > 14 & DAY <  17)
+  summ4 <- filter(summ, DAY > 19 & DAY <  35)
+  
+  expect_true(all(summ1$Cmax > 109 & summ1$Cmax < 110))
+  expect_true(all(summ2$Cmax >  71 & summ2$Cmax <  72))
+  expect_true(all(summ3$Cmax >  54 & summ3$Cmax <  56))
+  expect_true(all(summ4$Cmax > 109 & summ4$Cmax < 110))
+  
+  expect_true(all(summ1$Cmin > 11 & summ1$Cmin < 12))
+  expect_true(all(summ2$Cmin > 23 & summ2$Cmin < 24))
+  expect_true(all(summ3$Cmin > 33 & summ3$Cmin < 34))
+  expect_true(all(summ4$Cmin > 11 & summ4$Cmin < 12))
+})


### PR DESCRIPTION
See #1169 for details. This PR changes `regimen::ii()` to just just update the dose interval, with no other fancy tricks. Look at the working example in #1169; I think that's what we want. 

I put a note in the tests that I took the cutoffs for those tests from looking at a plot of the profile. The plot looks right to me. The tests check that the pattern we get is what we'd expect from the model code. But the exact cutoffs aren't obvious. 

@kyleam I'd like to send this through as a hotfix if possible. As for general reliability, I've been kicking the tires for several hours on this working up a blog post and no other surprises found. 