### PR TITLE
Patch for evt::regimen.ii(double) bug

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: mrgsolve
 Title: Simulate from ODE-Based Models
-Version: 1.4.0.9000
+Version: 1.4.1
 Authors@R: 
     c(person(given = "Kyle T", family = "Baron",
              role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,7 @@
-# mrgsolve (development version)
+# mrgsolve 1.4.1
+
+- Fix bug in `evt::regimen.ii(double)` where timing of next dose 
+  was not as expected (#1170).
 
 # mrgsolve 1.4.0
 


### PR DESCRIPTION
Submitted 1.4.0 to CRAN on Feb 7, 2024. Shortly thereafter, found bug in `evt::regimen(double)`. This PR patches that bug. 

See #1170 #1169 


```
scores:
{
  "testing": {
    "check": 0.9,
    "covr": 0.7131
  },
  "documentation": {
    "has_vignettes": 0,
    "has_website": 1,
    "has_news": 1
  },
  "maintenance": {
    "has_maintainer": 1,
    "news_current": 1
  },
  "transparency": {
    "has_source_control": 1,
    "has_bug_reports_url": 1
  }
}
```