### PR TITLE
Intelligent insertion of records for lagged doses and infusion stop events

### DIFF
--- a/inst/include/datarecord.h
+++ b/inst/include/datarecord.h
@@ -160,4 +160,6 @@ struct CompRec {
   }
 };
 
+void insert_record(std::vector<rec_ptr>& thisi, const int start, rec_ptr& rec);
+
 #endif

--- a/inst/include/datarecord.h
+++ b/inst/include/datarecord.h
@@ -160,6 +160,7 @@ struct CompRec {
   }
 };
 
-void insert_record(std::vector<rec_ptr>& thisi, const int start, rec_ptr& rec);
+void insert_record(std::vector<rec_ptr>& thisi, const int start, rec_ptr& rec, 
+                   const bool put_ev_first);
 
 #endif

--- a/inst/include/datarecord.h
+++ b/inst/include/datarecord.h
@@ -24,11 +24,12 @@
 //#include <boost/shared_ptr.hpp>
 #include "mrgsolv.h"
 #include "LSODA.h"
+#include <deque>
 
 class odeproblem;
 class datarecord;
 typedef std::shared_ptr<datarecord> rec_ptr;
-typedef std::vector<rec_ptr> reclist;
+typedef std::deque<rec_ptr> reclist;
 
 #define NEWREC std::make_shared<datarecord>
 
@@ -86,11 +87,11 @@ public:
   
   void ii(double ii_){Ii = ii_;}
   double ii(){return Ii;}
-
+  
   double fn(){return Fn;}
   void fn(double fn_){Fn = fn_;}
-
-  void schedule(std::vector<rec_ptr>& thisi, double maxtime, bool put_ev_first, 
+  
+  void schedule(reclist& thisi, double maxtime, bool put_ev_first, 
                 const unsigned int maxpos, double lagt);
   void implement(odeproblem* prob);
   void steady_zero(odeproblem* prob, LSODA& solver);
@@ -117,13 +118,13 @@ public:
   bool is_phantom() {return !Output && !Fromdata;}
   bool is_lagged() {return Lagged;}
   void lagged() {Lagged = true;}
-
+  
   int Pos; ///< record position number
   unsigned short int Evid; ///< record event ID
   unsigned short int Ss; ///< record steady-state indicator
   short int Cmt; ///< record compartment number
   unsigned int Addl; ///< number of additional doses
-
+  
   double Time; ///< record time
   double Id; ///< record ID value
   double Amt; ///< record dosing amount value
@@ -160,7 +161,7 @@ struct CompRec {
   }
 };
 
-void insert_record(std::vector<rec_ptr>& thisi, const int start, rec_ptr& rec, 
+void insert_record(reclist& thisi, const int start, rec_ptr& rec, 
                    const bool put_ev_first);
 
 #endif

--- a/inst/include/odeproblem.h
+++ b/inst/include/odeproblem.h
@@ -24,6 +24,7 @@
 #define ODEPROBLEM_H
 #include <math.h>
 #include <vector>
+#include <deque>
 #include "RcppInclude.h"
 #include "mrgsolv.h"
 #include "datarecord.h"
@@ -38,7 +39,7 @@
 class odeproblem;
 
 //! vector of <code>datarecord</code> objects for one <code>ID</code>
-typedef std::vector<rec_ptr> reclist;
+typedef std::deque<rec_ptr> reclist;
 
 //! vector of <code>reclist</code> vectors comprising  a data set
 typedef std::vector<reclist> recstack;

--- a/src/dataobject.cpp
+++ b/src/dataobject.cpp
@@ -247,7 +247,7 @@ void dataobject:: get_records_pred(recstack& a, int NID, int neq,
   }
   for(int h=0; h < NID; ++h) {
     lastime = Data(this->start(h),col[_COL_time_]);
-    a[h].reserve(this->end(h) - this->start(h) + 5);
+    //a[h].reserve(this->end(h) - this->start(h) + 5); // TODO: remove
     
     for(j=this->start(h); j <= this->end(h); ++j) {
       if(Data(j,col[_COL_time_]) < lastime) {
@@ -320,7 +320,7 @@ void dataobject::get_records(recstack& a, int NID, int neq,
     
     lastime = Data(this->start(h),col[_COL_time_]);
     
-    a[h].reserve(this->end(h) - this->start(h) + 5);
+    //a[h].reserve(this->end(h) - this->start(h) + 5); // TODO: remove
     
     for(j = this->start(h); j <= this->end(h); ++j) {
       

--- a/src/datarecord.cpp
+++ b/src/datarecord.cpp
@@ -582,3 +582,19 @@ void datarecord::schedule(std::vector<rec_ptr>& thisi, double maxtime,
     thisi.push_back(evon);
   }
 }  
+
+void insert_record(std::vector<rec_ptr>& thisi, const int start, rec_ptr& rec) {
+  double time = rec->time();
+  int i = start;
+  for(i = start; i < thisi.size(); ++i) {
+    if(thisi.at(i)->time() >= time) {
+      break;  
+    }
+  }
+  // Rcpp::Rcout << " start " << start << std::endl;
+  // Rcpp::Rcout << " i " << i << std::endl;
+  // Rcpp::Rcout << " size " << thisi.size() << std::endl;
+  
+  reclist::iterator alagit = thisi.begin() + i;
+  thisi.insert(alagit, rec);
+}

--- a/src/datarecord.cpp
+++ b/src/datarecord.cpp
@@ -584,9 +584,12 @@ void datarecord::schedule(std::vector<rec_ptr>& thisi, double maxtime,
 }  
 
 /* 
- * Inserts a record at the first opportunity based on time. Boolean flag
- * indicates if the record should get inserted before or after all other 
- * records at the time of that event. 
+ * Inserts a record at the earliest or latest opportunity based on time. 
+ * Boolean flag indicates if the record should get inserted before or after all 
+ * other records at the time of that event. 
+ * 
+ * This is currently being used to insert records for lag times as well as
+ * infusion end. 
  * 
  */
 void insert_record(std::vector<rec_ptr>& thisi, const int start, rec_ptr& rec, 

--- a/src/datarecord.cpp
+++ b/src/datarecord.cpp
@@ -245,7 +245,7 @@ void datarecord::steady_bolus(odeproblem* prob, LSODA& solver) {
   double diff = 0, err = 0;
   bool made_it = false;
   size_t n_cmt = prob->Ss_cmt.size();
-
+  
   prob->lsoda_init();
   
   rec_ptr evon = NEWREC(Cmt, 1, Amt, Time, Rate, Fn);
@@ -341,7 +341,7 @@ void datarecord::steady_infusion(odeproblem* prob, reclist& thisi, LSODA& solver
   double tfrom = 0.0;
   
   int i;
-
+  
   bool warn = !prob->ss_fixed;
   int N_SS = prob->ss_n;  
   size_t n_cmt = prob->Ss_cmt.size();
@@ -556,7 +556,7 @@ void datarecord::schedule(std::vector<rec_ptr>& thisi, double maxtime,
   }
   
   thisi.reserve(thisi.size() + n_dose); 
-
+  
   double ontime = 0;
   
   int mp = 1000000000;
@@ -583,18 +583,28 @@ void datarecord::schedule(std::vector<rec_ptr>& thisi, double maxtime,
   }
 }  
 
-void insert_record(std::vector<rec_ptr>& thisi, const int start, rec_ptr& rec) {
+/* 
+ * Inserts a record at the first opportunity based on time. Boolean flag
+ * indicates if the record should get inserted before or after all other 
+ * records at the time of that event. 
+ * 
+ */
+void insert_record(std::vector<rec_ptr>& thisi, const int start, rec_ptr& rec, 
+                   const bool put_ev_first) {
   double time = rec->time();
   int i = start;
-  for(i = start; i < thisi.size(); ++i) {
-    if(thisi.at(i)->time() >= time) {
-      break;  
+  if(put_ev_first) {
+    for(i = start + 1; i < thisi.size(); ++i) {
+      if(thisi[i]->time() >= time) {
+        break;  
+      }
+    }
+  } else {
+    for(i = start + 1; i < thisi.size(); ++i) {
+      if(thisi[i]->time() > time) {
+        break;  
+      }
     }
   }
-  // Rcpp::Rcout << " start " << start << std::endl;
-  // Rcpp::Rcout << " i " << i << std::endl;
-  // Rcpp::Rcout << " size " << thisi.size() << std::endl;
-  
-  reclist::iterator alagit = thisi.begin() + i;
-  thisi.insert(alagit, rec);
+  thisi.insert(thisi.begin() + i, rec);
 }

--- a/src/datarecord.cpp
+++ b/src/datarecord.cpp
@@ -534,7 +534,7 @@ void datarecord::steady_zero(odeproblem* prob, LSODA& solver) {
   prob->ss_flag = false;
 }
 
-void datarecord::schedule(std::vector<rec_ptr>& thisi, double maxtime, 
+void datarecord::schedule(reclist& thisi, double maxtime, 
                           bool addl_ev_first, 
                           const unsigned int maxpos, 
                           double lagt) {
@@ -555,7 +555,7 @@ void datarecord::schedule(std::vector<rec_ptr>& thisi, double maxtime,
     this_evid = Rate > 0 ? 5 : 1;
   }
   
-  thisi.reserve(thisi.size() + n_dose); 
+  //thisi.reserve(thisi.size() + n_dose); // TODO: remove 
   
   double ontime = 0;
   
@@ -592,7 +592,7 @@ void datarecord::schedule(std::vector<rec_ptr>& thisi, double maxtime,
  * infusion end. 
  * 
  */
-void insert_record(std::vector<rec_ptr>& thisi, const int start, rec_ptr& rec, 
+void insert_record(reclist& thisi, const int start, rec_ptr& rec, 
                    const bool put_ev_first) {
   double time = rec->time();
   int i = start;

--- a/src/devtran.cpp
+++ b/src/devtran.cpp
@@ -21,6 +21,7 @@
  *
  */
 
+#include <deque>
 #include <string>
 #include "mrgsolve.h"
 #include "odeproblem.h"
@@ -243,13 +244,13 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
     // Vector of vectors
     // Outer vector: length = number of designs
     // Inner vector: length = number of times in that design
-    std::vector<std::vector<rec_ptr> > designs;
+    recstack designs;
     
     for(size_t i = 0; i < tgridn.size(); ++i) {
       
-      std::vector<rec_ptr> z;
+      reclist z;
       
-      z.reserve(tgridn[i]);
+      //z.reserve(tgridn[i]); // TODO: remove
       
       for(int j = 0; j < tgridn[i]; ++j) {
         rec_ptr obs = NEWREC(tgrid(j,i),nextpos,true);
@@ -271,7 +272,7 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
         n = tgridn.at(0);
       } 
       
-      it->reserve((it->size() + n));
+      //it->reserve((it->size() + n)); // TODO: remove
       for(int h=0; h < n; ++h) {
         it->push_back(designs[tgridi[j]][h]);
         ++obscount;

--- a/src/devtran.cpp
+++ b/src/devtran.cpp
@@ -559,12 +559,13 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
             newev->lagged();
             newev->time(this_rec->time() + prob.alag(this_cmtn));
             newev->ss(0);
-            reclist::iterator alagit = a[i].begin()+j;
-            advance(alagit,1);
-            a[i].insert(alagit,newev);
+            //reclist::iterator alagit = a[i].begin()+j;
+            //advance(alagit,1);
+            //a[i].insert(alagit,newev);
+            insert_record(a[i], j, newev);
             newev->schedule(a[i], maxtime, put_ev_first, NN, prob.alag(this_cmtn));
             this_rec->unarm();
-            sort_recs = true;
+            sort_recs = false;
           } else { // no valid lagtime
             this_rec->schedule(a[i], maxtime, addl_ev_first, NN, 0.0);
             sort_recs = this_rec->needs_sorting();

--- a/src/devtran.cpp
+++ b/src/devtran.cpp
@@ -562,10 +562,10 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
             //reclist::iterator alagit = a[i].begin()+j;
             //advance(alagit,1);
             //a[i].insert(alagit,newev);
-            insert_record(a[i], j, newev);
+            insert_record(a[i], j, newev, put_ev_first);
             newev->schedule(a[i], maxtime, put_ev_first, NN, prob.alag(this_cmtn));
             this_rec->unarm();
-            sort_recs = false;
+            sort_recs = newev->needs_sorting();
           } else { // no valid lagtime
             this_rec->schedule(a[i], maxtime, addl_ev_first, NN, 0.0);
             sort_recs = this_rec->needs_sorting();
@@ -586,9 +586,12 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
           
           if(this_rec->from_data()) {
             evoff->time(evoff->time() + prob.alag(this_cmtn));
-          }
-          a[i].push_back(evoff);
-          sort_recs = true;
+          } 
+          // TODO: drop when ready
+          //a[i].push_back(evoff);
+          //sort_recs = true;
+          // Infusion off always happens first
+          insert_record(a[i], j, evoff, true);
         }
         
         // SORT

--- a/src/mrgsolve.cpp
+++ b/src/mrgsolve.cpp
@@ -382,7 +382,7 @@ Rcpp::List EXPAND_OBSERVATIONS(
   obscount = 0;
   
   int n_time = int(times.size());
-  std::vector<rec_ptr> z(n_time);
+  reclist z(n_time);
   for(int j = 0; j < n_time; ++j) {
     rec_ptr obs = NEWREC(times[j],nextpos,true);
     z[j] = obs;
@@ -391,7 +391,7 @@ Rcpp::List EXPAND_OBSERVATIONS(
   size_t n = z.size();
   
   for(recstack::iterator it = a.begin(); it != a.end(); ++it) {
-    it->reserve((it->size() + n));
+    //it->reserve((it->size() + n)); // TODO: remove
     for(size_t h=0; h < n; h++) {
       it->push_back(z[h]);
       ++obscount;


### PR DESCRIPTION

# Summary 

Every time we start an infusion, we need to figure out when it ends and insert a record for that to happen. This is complicated by the fact that we aren't guaranteed to know the infusion duration for any given dose until we actually give that dose. 

Current behavior is to push this dose record on the back of the `vector` / `deque` and then re-sort the records. This is fine when the data set is set up to dose in bulk, but really slows down when doses are explicit in the data set and have to be processed one at a time. 

By controlled or intelligent insert, I mean we know when the infusion end record happens, so we iterate through the next records until we find the correct insertion point and insert there. With this approach, there is no need to sort. This, along with the `deque` speeds things up a lot in specific circumstances. 

It's a similar story with doses involving lag time: once we know the lag time, we have to insert a record a the time of the original dose plus the lag time. So it's the same problem. 



