### PR TITLE
Release/1.4.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: mrgsolve
 Title: Simulate from ODE-Based Models
-Version: 1.4.1.9000
+Version: 1.4.2
 Authors@R: 
     c(person(given = "Kyle T", family = "Baron",
              role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# mrgsolve (development version)
+# mrgsolve 1.4.2
 
 # mrgsolve 1.4.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,15 @@
 # mrgsolve 1.4.2
 
+- An error will now be issued at simulation time when simulation data sets 
+  (data and idata) contain non-numeric data in columns sharing names with
+  parameters; non-numeric data in columns with certain reserved names 
+  (like `AMT`, `RATE`, `II`, `ADDL`, etc.) will also result in an error
+  (#1193).
+  
+- Internal refactoring to improve performance when simulating infusions or 
+  doses with lag times when those doses are coded explicitly in the data
+  set (#1186, #1187).
+
 # mrgsolve 1.4.1
 
 - Fix bug in `evt::regimen.ii(double)` where timing of next dose 


### PR DESCRIPTION
# mrgsolve 1.4.2

- An error will now be issued at simulation time when simulation data sets 
  (data and idata) contain non-numeric data in columns sharing names with
  parameters; non-numeric data in columns with certain reserved names 
  (like `AMT`, `RATE`, `II`, `ADDL`, etc.) will also result in an error
  (#1193).
  
- Internal refactoring to improve performance when simulating infusions or 
  doses with lag times when those doses are coded explicitly in the data
  set (#1186, #1187).