### PR TITLE
Fix as_data_set with data.frame

### DIFF
--- a/R/class_ev.R
+++ b/R/class_ev.R
@@ -276,3 +276,15 @@ finalize_ev <- function(x,...) {
   }
   x
 }
+
+lc_tran_names <- function(x) {
+  if(is.data.frame(x)) {
+    nlower <- sum(names(x) %in% GLOBALS$TRAN_LOWER)
+    nupper <- sum(names(x) %in% GLOBALS$TRAN_UPPER)
+    return(nlower >= nupper)
+  } else {
+    if(is.evd(x)) return(FALSE)  
+    if(is.ev(x)) return(TRUE)
+  }
+  stop("object is neither data.frame, ev, nor evd.")
+}

--- a/R/class_ev.R
+++ b/R/class_ev.R
@@ -259,8 +259,8 @@ finalize_ev_data <- function(data) {
     data[["addl"]][i] <- ceiling((until[i] - data[["time"]][i])/data[["ii"]][i]) - 1
     data[["addl"]] <- unlist(data[["addl"]])
   }
-  ev_cols <- c("ID", "time", "amt", "rate", "ii", "addl", "cmt", "evid", "ss")
-  match_cols <- intersect(ev_cols,names(data))
+  ev_cols <- c("ID", "time", "amt", "rate", "ii", "ss", "addl", "cmt", "evid")
+  match_cols <- intersect(ev_cols, names(data))
   other_cols <- setdiff(names(data),match_cols)
   data <- data[,c(match_cols,other_cols)]
   data

--- a/R/class_evd.R
+++ b/R/class_evd.R
@@ -60,6 +60,10 @@ as.evd <- function(x) {
   x
 }
 
+is.evd <- function(x) {
+  inherits(x, "ev") && x@case == 1
+}
+
 set_ev_case <- function(x, case) {
   if(!is.ev(x)) return(x)
   x@case <- case

--- a/R/data_set.R
+++ b/R/data_set.R
@@ -285,7 +285,8 @@ data_hooks <- function(data, object, envir, param = list(), ...) {
 #' To get a data frame with one row (event) per `ID`, look at [expand.ev()].
 #' 
 #' @return 
-#' A data frame suitable for passing into [data_set()].
+#' A data frame suitable for passing into [data_set()]. The columns will appear
+#' in a standardized order. 
 #'
 #' @examples
 #' a <- ev(amt = c(100,200), cmt=1, ID = seq(3))

--- a/R/data_set.R
+++ b/R/data_set.R
@@ -314,8 +314,17 @@ setMethod("as_data_set", "ev", function(x, ...) {
 })
 
 #' @rdname as_data_set
-setMethod("as_data_set","data.frame", function(x, ...) {
-  as_data_set(as.ev(x) ,...)
+setMethod("as_data_set", "data.frame", function(x, ...) {
+  lc <- lc_tran_names(x)
+  if(lc) {
+    x <- lctran(x)
+    x <- as.ev(x)
+  } else {
+    x <- uctran(x)
+    x <- as.ev(x)
+    x <- as.evd(x)
+  }
+  do.call(as_data_set, c(list(x), list(...)))
 })
 
 ##' Replicate a list of events into a data set

--- a/R/data_set.R
+++ b/R/data_set.R
@@ -315,6 +315,7 @@ setMethod("as_data_set", "ev", function(x, ...) {
 
 #' @rdname as_data_set
 setMethod("as_data_set", "data.frame", function(x, ...) {
+  # Coerce the first object, then call the ev method
   lc <- lc_tran_names(x)
   if(lc) {
     x <- lctran(x)

--- a/R/data_set.R
+++ b/R/data_set.R
@@ -260,23 +260,27 @@ data_hooks <- function(data, object, envir, param = list(), ...) {
   return(data)
 }
 
-#' Create a simulation data set from ev objects
+#' Create a simulation data set from ev objects or data frames
 #' 
-#' The goal is to take a series of event objects and combine them 
-#' into a single data set that can be passed to [data_set()]. 
+#' The goal is to take a series of event objects or data frames and combine them 
+#' into a single data frame that can be passed to [data_set()]. 
 #'
-#' @param x ev objects
-#' @param ... more ev objects
+#' @param x an ev object or data frame. 
+#' @param ... additional ev objects or data frames.
 #' 
 #' @details
-#' Each event object is added to the data frame as an `ID` or set of `ID`s  
-#' that are distinct from the `ID`s in the other event objects. Note that 
-#' including `ID` argument to the [ev()] call where `length(ID)` is greater 
-#' than one will render that set of events for all of `ID`s that are requested.
+#' Each event object or data frame is added to the data frame as an `ID` or 
+#' set of `ID`s  that are distinct from the `ID`s in the other event objects. 
+#' Note that including `ID` argument to the [ev()] call where `length(ID)` is 
+#' greater than one will render that set of events for all of `ID`s that are 
+#' requested.
 #' 
 #' When determining the case for output names, the `case` attribute for
 #' the first `ev` object passed will be used to set the case for the output
-#' data.frame.
+#' data.frame. In the event `x` is a data frame, the case of special column 
+#' names (like `amt/AMT` or `cmt/CMT`) in the first data frame will be assessed 
+#' and the case in the output data frame will be determined based on the 
+#' relative numbers of lower or upper names. 
 #'
 #' To get a data frame with one row (event) per `ID`, look at [expand.ev()].
 #' 
@@ -293,11 +297,18 @@ data_hooks <- function(data, object, envir, param = list(), ...) {
 #' d <- evd(amt = 500)
 #' 
 #' as_data_set(d, a)
-#'             
+#' 
+#' # Output will have upper case nmtran names
+#' as_data_set(
+#'   data.frame(AMT = 100, ID = 1:2), 
+#'   data.frame(amt = 200, rate = 5, cmt = 2)
+#' )
+#' 
 #' # Instead of this, use expand.ev
 #' as_data_set(ev(amt = 100), ev(amt = 200), ev(amt = 300))
 #' 
-#' @seealso [expand.ev()], [ev()]
+#' @seealso [expand.ev()], [expand.evd()], [ev()], [evd()], [uctran()], 
+#' [lctran()] 
 #'
 #' @md
 #' @rdname as_data_set

--- a/R/data_set.R
+++ b/R/data_set.R
@@ -318,12 +318,7 @@ setGeneric("as_data_set", function(x,...) standardGeneric("as_data_set"))
 
 #' @rdname as_data_set
 setMethod("as_data_set", "ev", function(x, ...) {
-  other_ev <- list(...)
-  if(length(other_ev)==0) {
-    ans <- finalize_ev(ev_to_ds(x))
-    return(ans) 
-  }
-  do.call(collect_ev, c(list(x), other_ev))
+  collect_ev(x, ...)
 })
 
 #' @rdname as_data_set

--- a/R/data_set.R
+++ b/R/data_set.R
@@ -320,7 +320,8 @@ setGeneric("as_data_set", function(x,...) standardGeneric("as_data_set"))
 setMethod("as_data_set", "ev", function(x, ...) {
   other_ev <- list(...)
   if(length(other_ev)==0) {
-    return(ev_to_ds(x)) 
+    ans <- finalize_ev(ev_to_ds(x))
+    return(ans) 
   }
   do.call(collect_ev, c(list(x), other_ev))
 })

--- a/R/data_set.R
+++ b/R/data_set.R
@@ -333,7 +333,7 @@ setMethod("as_data_set", "data.frame", function(x, ...) {
     x <- as.ev(x)
     x <- as.evd(x)
   }
-  do.call(as_data_set, c(list(x), list(...)))
+  as_data_set(x, ...)
 })
 
 ##' Replicate a list of events into a data set

--- a/R/events.R
+++ b/R/events.R
@@ -328,6 +328,7 @@ collect_ev <- function(...) {
   if(!"ID" %in% names(x)) {
     wstop("no ID column in the data set")
   }
+  x <- finalize_ev(x)
   if(case > 0) {
     x <- recase_ev(x, case)  
   }

--- a/R/events.R
+++ b/R/events.R
@@ -287,13 +287,15 @@ check_ev <- function(x) {
 
 collect_ev <- function(...) {
   x <- list(...)
-  tran <- c("ID","time", "cmt", "evid", "amt", "ii", "addl", "rate", "ss")
-  is_evnt <- vapply(x, is.ev, TRUE)
-  if(any(is_evnt)) {
-    w <- which(is_evnt)[1]
-    case <- x[[w]]@case
+  tran <- c("ID", GLOBALS$TRAN_LOWER)
+  case <- x[[1]]@case
+  if(case==0) {
+    x <- lapply(x, lctran) 
+    x <- lapply(x, as.ev)
   } else {
-    case <- 0  
+    x <- lapply(x, uctran) 
+    x <- lapply(x, as.ev)
+    x <- lapply(x, as.evd)
   }
   x <- lapply(x, check_ev)
   ids <- lapply(x, "[[", "ID")

--- a/R/events.R
+++ b/R/events.R
@@ -288,6 +288,8 @@ check_ev <- function(x) {
 collect_ev <- function(...) {
   x <- list(...)
   tran <- c("ID", GLOBALS$TRAN_LOWER)
+  # The case of the first object will determine 
+  # the case of the output
   case <- x[[1]]@case
   if(case==0) {
     x <- lapply(x, lctran) 

--- a/R/events.R
+++ b/R/events.R
@@ -276,20 +276,20 @@ setMethod("as.ev", "ev", function(x, ...) {
   x
 })
 
-check_ev <- function(x) {
+f_collect_prep <- function(x) {
   if(!inherits(x, c("ev", "data.frame"))) {
-    stop("All items must have class ev or data.frame.")  
+    wstop("all objects must have class ev or data.frame.")  
   }
   x <- to_data_frame(x)
   if(!"ID" %in% names(x)) x[["ID"]] <- 1
-  return(x)
+  x
 }
 
 collect_ev <- function(...) {
   x <- list(...)
   tran <- c("ID", GLOBALS$TRAN_LOWER)
   # The case of the first object will determine 
-  # the case of the output
+  # the case of the output; 0 = lc, 1 = uc
   case <- x[[1]]@case
   if(case==0) {
     x <- lapply(x, lctran) 
@@ -299,7 +299,7 @@ collect_ev <- function(...) {
     x <- lapply(x, as.ev)
     x <- lapply(x, as.evd)
   }
-  x <- lapply(x, check_ev)
+  x <- lapply(x, f_collect_prep)
   ids <- lapply(x, "[[", "ID")
   nid <- sapply(ids, function(tid) length(unique(tid)))
   idn <- cumsum(c(0, nid[-length(nid)]))

--- a/man/as_data_set.Rd
+++ b/man/as_data_set.Rd
@@ -4,7 +4,7 @@
 \alias{as_data_set}
 \alias{as_data_set,ev-method}
 \alias{as_data_set,data.frame-method}
-\title{Create a simulation data set from ev objects}
+\title{Create a simulation data set from ev objects or data frames}
 \usage{
 as_data_set(x, ...)
 
@@ -13,26 +13,30 @@ as_data_set(x, ...)
 \S4method{as_data_set}{data.frame}(x, ...)
 }
 \arguments{
-\item{x}{ev objects}
+\item{x}{an ev object or data frame.}
 
-\item{...}{more ev objects}
+\item{...}{additional ev objects or data frames.}
 }
 \value{
 A data frame suitable for passing into \code{\link[=data_set]{data_set()}}.
 }
 \description{
-The goal is to take a series of event objects and combine them
-into a single data set that can be passed to \code{\link[=data_set]{data_set()}}.
+The goal is to take a series of event objects or data frames and combine them
+into a single data frame that can be passed to \code{\link[=data_set]{data_set()}}.
 }
 \details{
-Each event object is added to the data frame as an \code{ID} or set of \code{ID}s
-that are distinct from the \code{ID}s in the other event objects. Note that
-including \code{ID} argument to the \code{\link[=ev]{ev()}} call where \code{length(ID)} is greater
-than one will render that set of events for all of \code{ID}s that are requested.
+Each event object or data frame is added to the data frame as an \code{ID} or
+set of \code{ID}s  that are distinct from the \code{ID}s in the other event objects.
+Note that including \code{ID} argument to the \code{\link[=ev]{ev()}} call where \code{length(ID)} is
+greater than one will render that set of events for all of \code{ID}s that are
+requested.
 
 When determining the case for output names, the \code{case} attribute for
 the first \code{ev} object passed will be used to set the case for the output
-data.frame.
+data.frame. In the event \code{x} is a data frame, the case of special column
+names (like \code{amt/AMT} or \code{cmt/CMT}) in the first data frame will be assessed
+and the case in the output data frame will be determined based on the
+relative numbers of lower or upper names.
 
 To get a data frame with one row (event) per \code{ID}, look at \code{\link[=expand.ev]{expand.ev()}}.
 }
@@ -46,11 +50,18 @@ as_data_set(a, b, c)
 d <- evd(amt = 500)
 
 as_data_set(d, a)
-            
+
+# Output will have upper case nmtran names
+as_data_set(
+  data.frame(AMT = 100, ID = 1:2), 
+  data.frame(amt = 200, rate = 5, cmt = 2)
+)
+
 # Instead of this, use expand.ev
 as_data_set(ev(amt = 100), ev(amt = 200), ev(amt = 300))
 
 }
 \seealso{
-\code{\link[=expand.ev]{expand.ev()}}, \code{\link[=ev]{ev()}}
+\code{\link[=expand.ev]{expand.ev()}}, \code{\link[=expand.evd]{expand.evd()}}, \code{\link[=ev]{ev()}}, \code{\link[=evd]{evd()}}, \code{\link[=uctran]{uctran()}},
+\code{\link[=lctran]{lctran()}}
 }

--- a/man/as_data_set.Rd
+++ b/man/as_data_set.Rd
@@ -18,7 +18,8 @@ as_data_set(x, ...)
 \item{...}{additional ev objects or data frames.}
 }
 \value{
-A data frame suitable for passing into \code{\link[=data_set]{data_set()}}.
+A data frame suitable for passing into \code{\link[=data_set]{data_set()}}. The columns will appear
+in a standardized order.
 }
 \description{
 The goal is to take a series of event objects or data frames and combine them

--- a/tests/testthat/test-as_data_set.R
+++ b/tests/testthat/test-as_data_set.R
@@ -125,3 +125,12 @@ test_that("as_data_set with event then data frame", {
   expect_identical(data$amt, c(100,100,200,200))
   expect_false(anyNA(data))
 })
+
+test_that("warning if both upper and lower case names", {
+  # the warning comes from lctran in this case
+  d1 <- data.frame(amt = 100, CMT = 5, RATE = 1, rate = 2, ii = 12)
+  e1 <- ev(amt = 100)
+  expect_warning(as_data_set(d1), "both upper and lower")
+  expect_warning(as_data_set(d1,e1), "both upper and lower")
+  expect_warning(as_data_set(d1,e1), "missing values")
+})

--- a/tests/testthat/test-as_data_set.R
+++ b/tests/testthat/test-as_data_set.R
@@ -55,7 +55,7 @@ test_that("as_data_set with leading data frame", {
   e1 <- as.data.frame(evd(amt = 100, ID = 1:2))
   e2 <- as.data.frame(ev(amt = 200, ID = 1:2))
   data <- as_data_set(e1,e2)
-  expect_identical(sort(names(data)), sort_uower)
+  expect_identical(sort(names(data)), sort_upper)
   expect_identical(data$AMT, c(100,100,200,200))
   expect_false(anyNA(data))
   
@@ -100,6 +100,7 @@ test_that("as_data_set with data frame then event", {
 test_that("as_data_set with event then data frame", {
   sort_lower <- sort(c("ID", "time", "amt", "cmt", "evid"))
   sort_upper <- sort(toupper(sort_lower))
+  
   # both lower case
   e1 <- ev(amt = 100, ID = 1:2)
   e2 <- as.data.frame(ev(amt = 200, ID = 1:2))
@@ -112,7 +113,7 @@ test_that("as_data_set with event then data frame", {
   e1 <- as.data.frame(evd(amt = 100, ID = 1:2))
   e2 <- ev(amt = 200, ID = 1:2)
   data <- as_data_set(e1,e2)
-  expect_identical(sort(names(data)), sort_uower)
+  expect_identical(sort(names(data)), sort_upper)
   expect_identical(data$AMT, c(100,100,200,200))
   expect_false(anyNA(data))
   

--- a/tests/testthat/test-as_data_set.R
+++ b/tests/testthat/test-as_data_set.R
@@ -1,4 +1,4 @@
-# Copyright (C) 2013 - 2019  Metrum Research Group, LLC
+# Copyright (C) 2013 - 2024  Metrum Research Group, LLC
 #
 # This file is part of mrgsolve.
 #
@@ -37,8 +37,82 @@ test_that("as_data_set basic", {
   data <- as_data_set(as.data.frame(e1),as.data.frame(e2))
   expect_equal(data$ID, c(1,2,3,4,5))
   expect_equal(data$amt, c(rep(100,2),rep(200,3)))
-  
 })
 
+test_that("as_data_set with leading data frame", {
+  # both lower case
+  e1 <- as.data.frame(ev(amt = 100, ID = 1:2))
+  e2 <- as.data.frame(ev(amt = 200, ID = 1:2))
+  data <- as_data_set(e1,e2)
+  expect_identical(names(data), c("ID", "time", "amt", "cmt", "evid"))
+  expect_identical(data$amt, c(100,100,200,200))
+  expect_false(anyNA(data))
 
+  # leading upper case
+  e1 <- as.data.frame(evd(amt = 100, ID = 1:2))
+  e2 <- as.data.frame(ev(amt = 200, ID = 1:2))
+  data <- as_data_set(e1,e2)
+  expect_identical(names(data), c("ID", "TIME", "AMT", "CMT", "EVID"))
+  expect_identical(data$AMT, c(100,100,200,200))
+  expect_false(anyNA(data))
+  
+  # leading lower case
+  e1 <- as.data.frame(ev(amt = 100, ID = 1:2))
+  e2 <- as.data.frame(evd(amt = 200, ID = 1:2))
+  data <- as_data_set(e1,e2)
+  expect_identical(names(data), c("ID", "time", "amt", "cmt", "evid"))
+  expect_identical(data$amt, c(100,100,200,200))
+  expect_false(anyNA(data))
+})
 
+test_that("as_data_set with data frame then event", {
+  # both lower case
+  e1 <- as.data.frame(ev(amt = 100, ID = 1:2))
+  e2 <- ev(amt = 200, ID = 1:2)
+  data <- as_data_set(e1,e2)
+  expect_identical(names(data), c("ID", "time", "amt", "cmt", "evid"))
+  expect_identical(data$amt, c(100,100,200,200))
+  expect_false(anyNA(data))
+  
+  # leading upper case
+  e1 <- as.data.frame(evd(amt = 100, ID = 1:2))
+  e2 <- ev(amt = 200, ID = 1:2)
+  data <- as_data_set(e1,e2)
+  expect_identical(names(data), c("ID", "TIME", "AMT", "CMT", "EVID"))
+  expect_identical(data$AMT, c(100,100,200,200))
+  expect_false(anyNA(data))
+  
+  # leading lower case
+  e1 <- as.data.frame(ev(amt = 100, ID = 1:2))
+  e2 <- evd(amt = 200, ID = 1:2)
+  data <- as_data_set(e1,e2)
+  expect_identical(names(data), c("ID", "time", "amt", "cmt", "evid"))
+  expect_identical(data$amt, c(100,100,200,200))
+  expect_false(anyNA(data))
+})
+
+test_that("as_data_set with event then data frame", {
+  # both lower case
+  e1 <- ev(amt = 100, ID = 1:2)
+  e2 <- as.data.frame(ev(amt = 200, ID = 1:2))
+  data <- as_data_set(e1,e2)
+  expect_identical(names(data), c("ID", "time", "amt", "cmt", "evid"))
+  expect_identical(data$amt, c(100,100,200,200))
+  expect_false(anyNA(data))
+  
+  # leading upper case
+  e1 <- as.data.frame(evd(amt = 100, ID = 1:2))
+  e2 <- ev(amt = 200, ID = 1:2)
+  data <- as_data_set(e1,e2)
+  expect_identical(names(data), c("ID", "TIME", "AMT", "CMT", "EVID"))
+  expect_identical(data$AMT, c(100,100,200,200))
+  expect_false(anyNA(data))
+  
+  # leading lower case
+  e1 <- ev(amt = 100, ID = 1:2)
+  e2 <- as.data.frame(evd(amt = 200, ID = 1:2))
+  data <- as_data_set(e1,e2)
+  expect_identical(names(data), c("ID", "time", "amt", "cmt", "evid"))
+  expect_identical(data$amt, c(100,100,200,200))
+  expect_false(anyNA(data))
+})

--- a/tests/testthat/test-as_data_set.R
+++ b/tests/testthat/test-as_data_set.R
@@ -40,11 +40,14 @@ test_that("as_data_set basic", {
 })
 
 test_that("as_data_set with leading data frame", {
+  sort_lower <- sort(c("ID", "time", "amt", "cmt", "evid"))
+  sort_upper <- sort(toupper(sort_lower))
+  
   # both lower case
   e1 <- as.data.frame(ev(amt = 100, ID = 1:2))
   e2 <- as.data.frame(ev(amt = 200, ID = 1:2))
   data <- as_data_set(e1,e2)
-  expect_identical(names(data), c("ID", "time", "amt", "cmt", "evid"))
+  expect_identical(sort(names(data)), sort_lower)
   expect_identical(data$amt, c(100,100,200,200))
   expect_false(anyNA(data))
 
@@ -52,7 +55,7 @@ test_that("as_data_set with leading data frame", {
   e1 <- as.data.frame(evd(amt = 100, ID = 1:2))
   e2 <- as.data.frame(ev(amt = 200, ID = 1:2))
   data <- as_data_set(e1,e2)
-  expect_identical(names(data), c("ID", "TIME", "AMT", "CMT", "EVID"))
+  expect_identical(sort(names(data)), sort_uower)
   expect_identical(data$AMT, c(100,100,200,200))
   expect_false(anyNA(data))
   
@@ -60,17 +63,20 @@ test_that("as_data_set with leading data frame", {
   e1 <- as.data.frame(ev(amt = 100, ID = 1:2))
   e2 <- as.data.frame(evd(amt = 200, ID = 1:2))
   data <- as_data_set(e1,e2)
-  expect_identical(names(data), c("ID", "time", "amt", "cmt", "evid"))
+  expect_identical(sort(names(data)), sort_lower)
   expect_identical(data$amt, c(100,100,200,200))
   expect_false(anyNA(data))
 })
 
 test_that("as_data_set with data frame then event", {
+  sort_lower <- sort(c("ID", "time", "amt", "cmt", "evid"))
+  sort_upper <- sort(toupper(sort_lower))
+  
   # both lower case
   e1 <- as.data.frame(ev(amt = 100, ID = 1:2))
   e2 <- ev(amt = 200, ID = 1:2)
   data <- as_data_set(e1,e2)
-  expect_identical(names(data), c("ID", "time", "amt", "cmt", "evid"))
+  expect_identical(sort(names(data)), sort_lower)
   expect_identical(data$amt, c(100,100,200,200))
   expect_false(anyNA(data))
   
@@ -78,7 +84,7 @@ test_that("as_data_set with data frame then event", {
   e1 <- as.data.frame(evd(amt = 100, ID = 1:2))
   e2 <- ev(amt = 200, ID = 1:2)
   data <- as_data_set(e1,e2)
-  expect_identical(names(data), c("ID", "TIME", "AMT", "CMT", "EVID"))
+  expect_identical(sort(names(data)), sort_upper)
   expect_identical(data$AMT, c(100,100,200,200))
   expect_false(anyNA(data))
   
@@ -86,17 +92,19 @@ test_that("as_data_set with data frame then event", {
   e1 <- as.data.frame(ev(amt = 100, ID = 1:2))
   e2 <- evd(amt = 200, ID = 1:2)
   data <- as_data_set(e1,e2)
-  expect_identical(names(data), c("ID", "time", "amt", "cmt", "evid"))
+  expect_identical(sort(names(data)), sort_lower)
   expect_identical(data$amt, c(100,100,200,200))
   expect_false(anyNA(data))
 })
 
 test_that("as_data_set with event then data frame", {
+  sort_lower <- sort(c("ID", "time", "amt", "cmt", "evid"))
+  sort_upper <- sort(toupper(sort_lower))
   # both lower case
   e1 <- ev(amt = 100, ID = 1:2)
   e2 <- as.data.frame(ev(amt = 200, ID = 1:2))
   data <- as_data_set(e1,e2)
-  expect_identical(names(data), c("ID", "time", "amt", "cmt", "evid"))
+  expect_identical(sort(names(data)), sort_lower)
   expect_identical(data$amt, c(100,100,200,200))
   expect_false(anyNA(data))
   
@@ -104,7 +112,7 @@ test_that("as_data_set with event then data frame", {
   e1 <- as.data.frame(evd(amt = 100, ID = 1:2))
   e2 <- ev(amt = 200, ID = 1:2)
   data <- as_data_set(e1,e2)
-  expect_identical(names(data), c("ID", "TIME", "AMT", "CMT", "EVID"))
+  expect_identical(sort(names(data)), sort_uower)
   expect_identical(data$AMT, c(100,100,200,200))
   expect_false(anyNA(data))
   
@@ -112,7 +120,7 @@ test_that("as_data_set with event then data frame", {
   e1 <- ev(amt = 100, ID = 1:2)
   e2 <- as.data.frame(evd(amt = 200, ID = 1:2))
   data <- as_data_set(e1,e2)
-  expect_identical(names(data), c("ID", "time", "amt", "cmt", "evid"))
+  expect_identical(sort(names(data)), sort_lower)
   expect_identical(data$amt, c(100,100,200,200))
   expect_false(anyNA(data))
 })


### PR DESCRIPTION
# Summary 

`as_data_set()` takes event objects or data frames and combines them in to a single data frame / data set. The key moving parts are 

1. We can potentially combine objects with upper or lower case naming 
2. We can combine either data frames or event objects
3. All subjects get unique IDs

There are methods for handling either data frames or event objects with upper or lower case naming. The data frame method was recently found to be broken in #1115. 

The refactor in the PR for the data frame method includes coercing the first object into  an event object and then calling the event object method. The worker function for handing events assesses that first object and then makes sure that all the other objects follow the setup discovered for the first object.

There is a function (`lc_tran_names`) that assess `data.frame` or event objects and reports if the naming scheme is lower case or not. 

I also started calling `finalize_ev()` which does some checks and puts output columns in a standardized order. 

