### PR TITLE
Error when k10 is equal to ka in one-compartment closed-form model

### DIFF
--- a/inst/include/odeproblem.h
+++ b/inst/include/odeproblem.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2013 - 2022  Metrum Research Group
+// Copyright (C) 2013 - 2024  Metrum Research Group
 //
 // This file is part of mrgsolve.
 //
@@ -28,8 +28,6 @@
 #include "RcppInclude.h"
 #include "mrgsolv.h"
 #include "datarecord.h"
-//#include "LSODA.h"
-
 
 // 
 // resim functor comes from mrgsolv.h

--- a/inst/maintenance/unit/test-pkmodel.R
+++ b/inst/maintenance/unit/test-pkmodel.R
@@ -208,5 +208,11 @@ test_that("Incorrect number of compartments causes error", {
   expect_error(mod <- mcode("a2error3",code))
 })
 
-
-
+test_that("Error when KA==K10 in 1 compartment model", {
+  mod <- param(pred1, KA = 1.5, CL = 1.5, V = 1)
+  expect_error(mrgsim(mod), "k10 is too close to ka")
+  mod <- param(mod, V = 1 + 5e-14)
+  expect_is(mrgsim(mod), "mrgsims")
+  mod <- param(mod, V = 1 + 1e-14)
+  expect_error(mrgsim(mod), "k10 is too close to ka")
+})

--- a/src/odeproblem.cpp
+++ b/src/odeproblem.cpp
@@ -380,8 +380,8 @@ void odeproblem::advan2(const double& tfrom, const double& tto) {
   
   if(k10 <= 0) Rcpp::stop("k10 has a 0 or negative value");
   // https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/
-  // Going for the simpler method
-  if(std::fabs(ka-k10) <= DBL_EPSILON*100.0) {
+  // Going for the simpler method; using epsilon of ~  100 * DBL_EPSILON
+  if(std::fabs(ka-k10) <= 2.22e-14) {
     Rcpp::stop("k10 is too close to ka for analytical solution to one-compartment model.");
   }
   

--- a/src/odeproblem.cpp
+++ b/src/odeproblem.cpp
@@ -379,8 +379,9 @@ void odeproblem::advan2(const double& tfrom, const double& tto) {
   double ka =  MRGSOLVE_GET_PRED_KA;
   
   if(k10 <= 0) Rcpp::stop("k10 has a 0 or negative value");
-  // https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/
+  
   // Going for the simpler method; using epsilon of ~  100 * DBL_EPSILON
+  // https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/
   if(std::fabs(ka-k10) < 2.22e-14) {
     Rcpp::stop("k10 is too close to ka for analytical solution to one-compartment model.");
   }

--- a/src/odeproblem.cpp
+++ b/src/odeproblem.cpp
@@ -381,7 +381,7 @@ void odeproblem::advan2(const double& tfrom, const double& tto) {
   if(k10 <= 0) Rcpp::stop("k10 has a 0 or negative value");
   // https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/
   // Going for the simpler method; using epsilon of ~  100 * DBL_EPSILON
-  if(std::fabs(ka-k10) <= 2.22e-14) {
+  if(std::fabs(ka-k10) < 2.22e-14) {
     Rcpp::stop("k10 is too close to ka for analytical solution to one-compartment model.");
   }
   

--- a/src/odeproblem.cpp
+++ b/src/odeproblem.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2013 - 2023  Metrum Research Group
+// Copyright (C) 2013 - 2024  Metrum Research Group
 //
 // This file is part of mrgsolve.
 //
@@ -380,7 +380,8 @@ void odeproblem::advan2(const double& tfrom, const double& tto) {
   
   if(k10 <= 0) Rcpp::stop("k10 has a 0 or negative value");
   // https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/
-  if(std::fabs(ka-k10) <= (std::max(std::fabs(ka), std::abs(k10)) * 1e-9)) {
+  // Going for the simpler method
+  if(std::fabs(ka-k10) <= DBL_EPSILON*100.0) {
     Rcpp::stop("k10 is too close to ka for analytical solution to one-compartment model.");
   }
   

--- a/src/odeproblem.cpp
+++ b/src/odeproblem.cpp
@@ -379,6 +379,10 @@ void odeproblem::advan2(const double& tfrom, const double& tto) {
   double ka =  MRGSOLVE_GET_PRED_KA;
   
   if(k10 <= 0) Rcpp::stop("k10 has a 0 or negative value");
+  // https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/
+  if(std::fabs(ka-k10) <= (std::max(std::fabs(ka), std::abs(k10)) * 1e-9)) {
+    Rcpp::stop("k10 is too close to ka for analytical solution to one-compartment model.");
+  }
   
   //a and alpha are private members
   alpha[0] = k10;


### PR DESCRIPTION
For closed-form solution to one-compartment model, error when KA and CL/V are too close together. 

- [x] Write test
- [x] Decide on eps