### PR TITLE
Drop skipped tests for deprecated simeta syntax

### DIFF
--- a/inst/maintenance/unit/test-simeta.R
+++ b/inst/maintenance/unit/test-simeta.R
@@ -93,35 +93,6 @@ test_that("resimulate all eta", {
   
 })
 
-test_that("resimulate specific eta", {
-  skip_if(TRUE, message="resim(n) is deprecated")
-  set.seed(5678)
-  # simeta with n = 1 (simeta(3))
-  n1 <-  mrgsim_df(mod, param = list(n = 1, mode = 2)) 
-  expect_true(all(n1$b==n1$b[1]))
-  expect_true(all(n1$c==n1$c[1]))
-  expect_false(any(duplicated(n1$a)))
-  
-  # simeta with n = 2 (simeta(2))
-  n2 <-  mrgsim(mod, param = list(n = 2, mode = 2))
-  expect_true(all(n2$a==n2$a[1]))
-  expect_true(all(n2$c==n2$c[1]))
-  expect_false(any(duplicated(n2$b)))
-  
-  # simeta with n = 3 (simeta(3))
-  n3 <-  mrgsim(mod, param = list(n = 3, mode = 2))
-  expect_true(all(n3$a==n3$a[1]))
-  expect_true(all(n3$b==n3$b[1]))
-  expect_false(any(duplicated(n3$c)))
-  
-  # simeta  with simeta(1) and simeta(3)
-  n13 <- mrgsim(mod, param = list(n = 1, m = 3,  mode = 3))
-  expect_true(all(n13$b==n13$b[1]))
-  expect_false(any(duplicated(n13$a)))
-  expect_false(any(duplicated(n13$c)))
-  
-})
-
 test_that("resimulate all or specific eps", {
   data <- data.frame(amt = 0, evid = 0, time = c(0,0,0), cmt = 0, ID = 1)
   set.seed(87654)
@@ -131,24 +102,6 @@ test_that("resimulate all or specific eps", {
   all$d <- NULL
   all$time <- NULL
   expect_false(any(duplicated(unlist(all))))
-  
-  # simeps with n = 2 (simeps(2))
-  skip_if(TRUE, message="resim(n) is deprecated")
-  n <-  mrgsim(mod, data = data, param = list(n = 2, mode = 5))
-  expect_true(all(n$a==n$a[1]))
-  expect_false(any(duplicated(n$b)))
-})
-
-test_that("invalid value for n when calling simeta or simeps", {
-  skip_if(TRUE, message="resim(n) is deprecated")
-  expect_error(
-    mrgsim(mod, param = list(mode = 2, n = 100)), 
-    "simeta index out of bounds"
-  )
-  expect_error(
-    mrgsim(mod, param = list(mode = 5, n = 100)), 
-    "simeps index out of bounds"
-  )
 })
 
 test_that("warn when simeta(n) is called with off diagonals", {


### PR DESCRIPTION
These tests have been skipped for a while now; ready to get rid of them