### PR TITLE
Add replace() function to evtools

### DIFF
--- a/inst/base/mrgsolv.h
+++ b/inst/base/mrgsolv.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2013 - 2023  Metrum Research Group
+// Copyright (C) 2013 - 2024  Metrum Research Group
 //
 // This file is part of mrgsolve.
 //
@@ -49,7 +49,7 @@ protected:
 }; 
 
 struct evdata {
-  evdata(double a_, int b_) :  time(a_), evid(b_) {
+  evdata(double a_, int b_) : time(a_), evid(b_) {
     cmt = 1;
     amt = 0.0;
     rate = 0.0;

--- a/inst/base/mrgsolve-evtools.h
+++ b/inst/base/mrgsolve-evtools.h
@@ -34,6 +34,21 @@ void infuse(databox& self, const double amt, const int cmt, const double rate) {
   return;
 }
 
+mrgsolve::evdata replace(const double amt, const int cmt) {
+  mrgsolve::evdata ev(0, 8); 
+  ev.amt = amt; 
+  ev.cmt = cmt;
+  ev.now = true;
+  ev.check_unique = false;
+  return ev;
+}
+
+void replace(databox& self, const double amt, const int cmt) {
+  mrgsolve::evdata ev = replace(amt, cmt);
+  self.mevector.push_back(ev);
+  return;
+}
+
 void retime(mrgsolve::evdata& ev, const double time) {
   ev.time = time;
   ev.now = false;

--- a/inst/maintenance/unit-cpp/test-evtools.R
+++ b/inst/maintenance/unit-cpp/test-evtools.R
@@ -123,15 +123,15 @@ test_that("evtools - replace", {
   after <- filter(a, time >= 5)
   expect_true(all(after$C==50))
   
-  #' When the replacement is timed into the future, we see the 
-  #' replacement right at the indicated time
+  # When the replacement is timed into the future, we see the 
+  # replacement right at the indicated time
   b <- mrgsim(mod, param = list(mode = 8, reptime = 8))
   before <- filter(b, time <= 8) # note: <= 8
   expect_true(all(before$C==100))
   after <- filter(b, time > 8) # note: > 8
   expect_true(all(after$C==10))
   
-  #' We can control this with `recsort`
+  # We can control this with `recsort`
   c <- mrgsim(mod, param = list(mode = 8, reptime = 8), recsort = 3)
   before <- filter(c, time < 8) # note: < 8
   expect_true(all(before$C==100))

--- a/inst/maintenance/unit-cpp/test-evtools.R
+++ b/inst/maintenance/unit-cpp/test-evtools.R
@@ -13,12 +13,14 @@ $SET end = 12, rtol = 1e-4, atol = 1e-4, delta = 0.25
 $PLUGIN evtools
 $PARAM 
 mode = 0, f1 = 1, dose = 100, irate = 50, newtime = 2
-$CMT A B
+reptime = 5
+$CMT A B C
 $PK
 F_A = f1;
 $DES
 dxdt_A = -1 * A;
 dxdt_B =  1 * A - 0.1 * B;
+dxdt_C = 0;
 $TABLE
 bool givedose = TIME==0;
 if(mode==1 && givedose) {
@@ -47,6 +49,14 @@ if(mode==6 && givedose) {
   ev.time = 100;
   evt::now(ev);
   evt::push(self, ev);
+}
+if(mode==7 && TIME==reptime) {
+  evt::replace(self, C/2.0, 3); 
+}
+if(mode==8 && givedose) {
+  evt::ev rep = evt::replace(10, 3);
+  evt::retime(rep, reptime);
+  self.push(rep);
 }
 '
 
@@ -102,4 +112,29 @@ test_that("evtools - give timed dose now", {
   a <- mrgsim(mod, param = list(mode = 6))
   b <- mrgsim(mod, param = list(mode = 1))
   expect_identical(as.data.frame(a), as.data.frame(b))
+})
+
+test_that("evtools - replace", {
+  mod <- init(mod, C = 100)
+  mod <- update(mod, delta = 0.1)
+  a <- mrgsim(mod, param = list(mode = 7))
+  before <- filter(a, time < 5)
+  expect_true(all(before$C==100))
+  after <- filter(a, time >= 5)
+  expect_true(all(after$C==50))
+  
+  #' When the replacement is timed into the future, we see the 
+  #' replacement right at the indicated time
+  b <- mrgsim(mod, param = list(mode = 8, reptime = 8))
+  before <- filter(b, time <= 8) # note: <= 8
+  expect_true(all(before$C==100))
+  after <- filter(b, time > 8) # note: > 8
+  expect_true(all(after$C==10))
+  
+  #' We can control this with `recsort`
+  c <- mrgsim(mod, param = list(mode = 8, reptime = 8), recsort = 3)
+  before <- filter(c, time < 8) # note: < 8
+  expect_true(all(before$C==100))
+  after <- filter(c, time >= 8) # note: >= 8
+  expect_true(all(after$C==10))
 })

--- a/inst/maintenance/unit-cpp/test-evtools.R
+++ b/inst/maintenance/unit-cpp/test-evtools.R
@@ -54,7 +54,7 @@ if(mode==7 && TIME==reptime) {
   evt::replace(self, C/2.0, 3); 
 }
 if(mode==8 && givedose) {
-  evt::ev rep = evt::replace(10, 3);
+  evt::ev rep = evt::replace(C/10.0, 3);
   evt::retime(rep, reptime);
   self.push(rep);
 }


### PR DESCRIPTION
# Summary

To date, the `evtools` plugin has been able to quickly create and give doses given as `bolus()` or `infuse()`. 

This PR implements an equivalent function to `replace()` the amount in a specific compartment with a new amount. This is accomplished via `evid 8` (already-existing functionality). 

The basic setup is similar to `bolus()` and `infuse()`: we provide two overloaded `replace()` functions, one that gets the `self` object first (this will create and "send" the dose in one function call) and another `replace()` function that will create the object and return it to the user for further config. 