### PR TITLE
CI: test with more R releases and resolve 4.0.5 failure

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -25,6 +25,10 @@ jobs:
             r: 4.0.5
           - os: ubuntu-20.04
             r: 4.1.3
+          - os: ubuntu-20.04
+            r: 4.2.3
+          - os: ubuntu-20.04
+            r: 4.3.1
           - os: ubuntu-latest
             r: release
     env:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -23,6 +23,9 @@ jobs:
             rspm: 'https://packagemanager.posit.co/cran/__linux__/focal/2023-02-01'
           - os: ubuntu-20.04
             r: 4.0.5
+            # Use pinned URL because PKNCA v0.11.0 (a pmxTools dependency) uses
+            # the native pipe (added in R 4.1).
+            rspm: 'https://packagemanager.posit.co/cran/__linux__/focal/2024-06-18'
           - os: ubuntu-20.04
             r: 4.1.3
           - os: ubuntu-20.04
@@ -45,7 +48,7 @@ jobs:
         with:
           extra-packages: |
             any::rcmdcheck
-          upgrade: ${{ matrix.config.r == '3.6.3' && 'FALSE' || 'TRUE' }}
+          upgrade: ${{ (matrix.config.r == '3.6.3' || matrix.config.r == '4.0.5') && 'FALSE' || 'TRUE' }}
       - name: Install pdflatex
         shell: bash
         run: sudo apt-get install texlive-latex-base texlive-fonts-extra


### PR DESCRIPTION
 * add jobs for two most recent R versions on latest Metworx AMI
 * resolve recent failure in R 4.0.5 job that's due to recent PKNCA using the native pipe