### PR TITLE
README: update install_github command

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -60,7 +60,7 @@ __Please__ be sure to see important install-related information
 Install the current development version
 
 ```{r,eval=FALSE}
-remotes::install_github("metrumresearchgroup/mrgsolve@develop")
+remotes::install_github("metrumresearchgroup/mrgsolve")
 ```
 
 ## Interaction

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ install.packages("mrgsolve")
 Install the current development version
 
 ``` r
-remotes::install_github("metrumresearchgroup/mrgsolve@develop")
+remotes::install_github("metrumresearchgroup/mrgsolve")
 ```
 
 ## Interaction


### PR DESCRIPTION
The develop branch no longer exists.  Update the install_github() call to use the default branch of the GitHub remote.