### PR TITLE
Release/1.5.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: mrgsolve
 Title: Simulate from ODE-Based Models
-Version: 1.4.2.9001
+Version: 1.5.0
 Authors@R: 
     c(person(given = "Kyle T", family = "Baron",
              role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,10 +2,10 @@
 
 - New functions `mwrite_yaml()` and `mwrite_cpp()` can write a model object back
   to a file, accounting for all updates since the model was read from native
-  mrgsolve format using `mread()` (#1213).
+  mrgsolve format using `mread()` (#1190, #1213).
   
 - New function `mread_yaml()` for reading back models written out with 
-  `mwrite_yaml()` (#1213).
+  `mwrite_yaml()` (#1190, #1213).
   
 - New functions in `evtools` plugin: `evt::replace()` works like `evt::bolus()`,
   but will replace the amount in a given compartment rather than add to it

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,28 @@
-# mrgsolve (development version)
+# mrgsolve 1.5.0
+
+- New functions `mwrite_yaml()` and `mwrite_cpp()` can write a model object back
+  to a file, accounting for all updates since the model was read from native
+  mrgsolve format using `mread()` (#1213).
+  
+- New function `mread_yaml()` for reading back models written out with 
+  `mwrite_yaml()` (#1213).
+  
+- New functions in `evtools` plugin: `evt::replace()` works like `evt::bolus()`,
+  but will replace the amount in a given compartment rather than add to it
+  (#1203).
+  
+- The `nm-vars` plugin now exposes `DEXP()`, `LOG10()`, `COS()` and `SIN()` 
+  for use in the mrgsolve C++ code blocks (#1199).
+
+- An error is now generated when `KA` is equal to `CL/VC` while simulating from
+  the one-compartment model with analytical solution invoked through 
+  `$PKMODEL` (#1179, #1197). 
+
+
+## Bugs Fixed
+
+- A bug was fixed when certain data frame inputs were passed to `as_data_set()`
+  (#1115, #1196). 
 
 # mrgsolve 1.4.2
 

--- a/inst/include/datarecord.h
+++ b/inst/include/datarecord.h
@@ -161,7 +161,7 @@ struct CompRec {
   }
 };
 
-void insert_record(reclist& thisi, const int start, rec_ptr& rec, 
+void insert_record(reclist& thisi, const size_t start, rec_ptr& rec, 
                    const bool put_ev_first);
 
 #endif

--- a/src/datarecord.cpp
+++ b/src/datarecord.cpp
@@ -592,10 +592,10 @@ void datarecord::schedule(reclist& thisi, double maxtime,
  * infusion end. 
  * 
  */
-void insert_record(reclist& thisi, const int start, rec_ptr& rec, 
+void insert_record(reclist& thisi, const size_t start, rec_ptr& rec, 
                    const bool put_ev_first) {
   double time = rec->time();
-  int i = start;
+  size_t i = start;
   if(put_ev_first) {
     for(i = start + 1; i < thisi.size(); ++i) {
       if(thisi[i]->time() >= time) {


### PR DESCRIPTION
# mrgsolve 1.5.0

- New functions `mwrite_yaml()` and `mwrite_cpp()` can write a model object back
  to a file, accounting for all updates since the model was read from native
  mrgsolve format using `mread()` (#1213).
  
- New function `mread_yaml()` for reading back models written out with 
  `mwrite_yaml()` (#1213).
  
- New functions in `evtools` plugin: `evt::replace()` works like `evt::bolus()`,
  but will replace the amount in a given compartment rather than add to it
  (#1203).
  
- The `nm-vars` plugin now exposes `DEXP()`, `LOG10()`, `COS()` and `SIN()` 
  for use in the mrgsolve C++ code blocks (#1199).

- An error is now generated when `KA` is equal to `CL/VC` while simulating from
  the one-compartment model with analytical solution invoked through 
  `$PKMODEL` (#1179, #1197). 


## Bugs Fixed

- A bug was fixed when certain data frame inputs were passed to `as_data_set()`
  (#1115, #1196).
