### PR TITLE
Fix compiler warning - comparison of signed and unsigned integers

### DIFF
--- a/inst/include/datarecord.h
+++ b/inst/include/datarecord.h
@@ -161,7 +161,7 @@ struct CompRec {
   }
 };
 
-void insert_record(reclist& thisi, const int start, rec_ptr& rec, 
+void insert_record(reclist& thisi, size_t start, rec_ptr& rec, 
                    const bool put_ev_first);
 
 #endif

--- a/inst/include/datarecord.h
+++ b/inst/include/datarecord.h
@@ -161,7 +161,7 @@ struct CompRec {
   }
 };
 
-void insert_record(reclist& thisi, size_t start, rec_ptr& rec, 
+void insert_record(reclist& thisi, const size_t start, rec_ptr& rec, 
                    const bool put_ev_first);
 
 #endif

--- a/src/datarecord.cpp
+++ b/src/datarecord.cpp
@@ -592,7 +592,7 @@ void datarecord::schedule(reclist& thisi, double maxtime,
  * infusion end. 
  * 
  */
-void insert_record(reclist& thisi, const int start, rec_ptr& rec, 
+void insert_record(reclist& thisi, size_t start, rec_ptr& rec, 
                    const bool put_ev_first) {
   double time = rec->time();
   size_t i = start;

--- a/src/datarecord.cpp
+++ b/src/datarecord.cpp
@@ -595,7 +595,7 @@ void datarecord::schedule(reclist& thisi, double maxtime,
 void insert_record(reclist& thisi, const int start, rec_ptr& rec, 
                    const bool put_ev_first) {
   double time = rec->time();
-  int i = start;
+  size_t i = start;
   if(put_ev_first) {
     for(i = start + 1; i < thisi.size(); ++i) {
       if(thisi[i]->time() >= time) {

--- a/src/datarecord.cpp
+++ b/src/datarecord.cpp
@@ -592,7 +592,7 @@ void datarecord::schedule(reclist& thisi, double maxtime,
  * infusion end. 
  * 
  */
-void insert_record(reclist& thisi, size_t start, rec_ptr& rec, 
+void insert_record(reclist& thisi, const size_t start, rec_ptr& rec, 
                    const bool put_ev_first) {
   double time = rec->time();
   size_t i = start;


### PR DESCRIPTION
Fixing a type  (`int` to `size_t`) warning based on winbuilder output (#1217). This is a harmless compiler warning, but going to fix this now to get it as clean as possible. 

`start` gets passed in from `j`, which is `size_t` because we're always comparing to `object.size()`.  This PR just makes it consistent and should avoid the compiler warning for comparing signed and unsigned integers. 
