### PR TITLE
Release/1.5.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: mrgsolve
 Title: Simulate from ODE-Based Models
-Version: 1.5.0
+Version: 1.5.1
 Authors@R: 
     c(person(given = "Kyle T", family = "Baron",
              role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # mrgsolve 1.5.1
 
-- Fixed `yaml_to_cpp()` example code to prevent saving the file to the 
-  working directory; discovered when 1.5.0 was submitted to CRAN (#1220). 
+- Fixed `yaml_to_cpp()` example code to prevent saving the file to the working 
+  directory (#1220).
 
 # mrgsolve 1.5.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # mrgsolve 1.5.1
 
 - Fixed `yaml_to_cpp()` example code to prevent saving the file to the 
-  working directory (#1220). 
+  working directory; discovered when submitted 1.5.0 to CRAN (#1220). 
 
 # mrgsolve 1.5.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # mrgsolve 1.5.1
 
 - Fixed `yaml_to_cpp()` example code to prevent saving the file to the 
-  working directory (#1219). 
+  working directory (#1220). 
 
 # mrgsolve 1.5.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # mrgsolve 1.5.1
 
 - Fixed `yaml_to_cpp()` example code to prevent saving the file to the 
-  working directory; discovered when submitted 1.5.0 to CRAN (#1220). 
+  working directory; discovered when 1.5.0 was submitted to CRAN (#1220). 
 
 # mrgsolve 1.5.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# mrgsolve 1.5.1
+
+- Fixed `yaml_to_cpp()` example code to prevent saving the file to the 
+  working directory (#1219). 
+
 # mrgsolve 1.5.0
 
 - New functions `mwrite_yaml()` and `mwrite_cpp()` can write a model object back

--- a/R/mwrite.R
+++ b/R/mwrite.R
@@ -301,7 +301,7 @@ mwrite_cpp <- function(x, file, update = TRUE) {
 #' mod <- mread_yaml(temp, model = "new-house", compile = FALSE)
 #' mod
 #' 
-#' cppfile <- yaml_to_cpp(temp)
+#' cppfile <- yaml_to_cpp(temp, project = tempdir())
 #' 
 #' readLines(cppfile)
 #' 

--- a/man/mread_yaml.Rd
+++ b/man/mread_yaml.Rd
@@ -51,7 +51,7 @@ mwrite_yaml(mod, file = temp)
 mod <- mread_yaml(temp, model = "new-house", compile = FALSE)
 mod
 
-cppfile <- yaml_to_cpp(temp)
+cppfile <- yaml_to_cpp(temp, project = tempdir())
 
 readLines(cppfile)
 


### PR DESCRIPTION
# mrgsolve 1.5.1

- Fixed `yaml_to_cpp()` example code to prevent saving the file to the working 
  directory (#1220).