### PR TITLE
Add reset functions to evtools

### DIFF
--- a/inst/base/mrgsolve-evtools.h
+++ b/inst/base/mrgsolve-evtools.h
@@ -58,10 +58,12 @@ mrgsolve::evdata reset() {
 
 mrgsolve::evdata reset(const double amt, const int cmt, 
                        const double rate = 0) {
-  mrgsolve::evdata ev = evt::reset();
-  ev.cmt = cmt;
+  mrgsolve::evdata ev(0, 4);
   ev.amt = amt;
+  ev.cmt = cmt;
   ev.rate = rate;
+  ev.now = true;
+  ev.check_unique = false;
   return ev;
 }
 
@@ -73,10 +75,7 @@ void reset(databox& self) {
 
 void reset(databox& self, const double amt, const int cmt, 
            const double rate = 0) {
-  mrgsolve::evdata ev = evt::reset();
-  ev.cmt = cmt;
-  ev.amt = amt;
-  ev.rate = rate;
+  mrgsolve::evdata ev = evt::reset(amt, cmt, rate);
   self.mevector.push_back(ev);
   return;
 }

--- a/inst/base/mrgsolve-evtools.h
+++ b/inst/base/mrgsolve-evtools.h
@@ -49,6 +49,42 @@ void replace(databox& self, const double amt, const int cmt) {
   return;
 }
 
+mrgsolve::evdata reset() {
+  mrgsolve::evdata ev(0, 3); 
+  ev.now = true;
+  ev.check_unique = false;
+  return ev;
+}
+
+mrgsolve::evdata reset(const double amt, const int cmt, 
+                       const double rate = 0) {
+  mrgsolve::evdata ev(0, 4);
+  ev.cmt = cmt;
+  ev.amt = amt;
+  ev.rate = rate;
+  ev.now = true;
+  ev.check_unique = false;
+  return ev;
+}
+
+void reset(databox& self) {
+  evt::ev ev = reset(); 
+  self.mevector.push_back(ev);
+  return;
+}
+
+void reset(databox& self, const double amt, const int cmt, 
+           const double rate = 0) {
+  evt::ev ev(0, 4);
+  ev.cmt = cmt;
+  ev.amt = amt;
+  ev.rate = rate;
+  ev.now = true;
+  ev.check_unique = false;
+  self.mevector.push_back(ev);
+  return;
+}
+
 void retime(mrgsolve::evdata& ev, const double time) {
   ev.time = time;
   ev.now = false;

--- a/inst/base/mrgsolve-evtools.h
+++ b/inst/base/mrgsolve-evtools.h
@@ -13,7 +13,7 @@ mrgsolve::evdata bolus(const double amt, const int cmt) {
 }
 
 void bolus(databox& self, const double amt, const int cmt) {
-  mrgsolve::evdata ev = bolus(amt, cmt);
+  mrgsolve::evdata ev = evt::bolus(amt, cmt);
   self.mevector.push_back(ev);
   return;
 }
@@ -29,7 +29,7 @@ mrgsolve::evdata infuse(const double amt, const int cmt, const double rate) {
 }
 
 void infuse(databox& self, const double amt, const int cmt, const double rate) {
-  mrgsolve::evdata ev = infuse(amt, cmt, rate);
+  mrgsolve::evdata ev = evt::infuse(amt, cmt, rate);
   self.mevector.push_back(ev);
   return;
 }
@@ -44,7 +44,7 @@ mrgsolve::evdata replace(const double amt, const int cmt) {
 }
 
 void replace(databox& self, const double amt, const int cmt) {
-  mrgsolve::evdata ev = replace(amt, cmt);
+  mrgsolve::evdata ev = evt::replace(amt, cmt);
   self.mevector.push_back(ev);
   return;
 }
@@ -58,29 +58,25 @@ mrgsolve::evdata reset() {
 
 mrgsolve::evdata reset(const double amt, const int cmt, 
                        const double rate = 0) {
-  mrgsolve::evdata ev(0, 4);
+  mrgsolve::evdata ev = evt::reset();
   ev.cmt = cmt;
   ev.amt = amt;
   ev.rate = rate;
-  ev.now = true;
-  ev.check_unique = false;
   return ev;
 }
 
 void reset(databox& self) {
-  evt::ev ev = reset(); 
+  mrgsolve::evdata ev = evt::reset(); 
   self.mevector.push_back(ev);
   return;
 }
 
 void reset(databox& self, const double amt, const int cmt, 
            const double rate = 0) {
-  evt::ev ev(0, 4);
+  mrgsolve::evdata ev = evt::reset();
   ev.cmt = cmt;
   ev.amt = amt;
   ev.rate = rate;
-  ev.now = true;
-  ev.check_unique = false;
   self.mevector.push_back(ev);
   return;
 }

--- a/inst/maintenance/unit-cpp/test-evtools.R
+++ b/inst/maintenance/unit-cpp/test-evtools.R
@@ -196,7 +196,7 @@ test_that("evtools - reset with bolus", {
   mod <- update(mod, rtol = 1e-10, delta = 0.25)
   out <- mrgsim(mod)
   
-  # Bolus into C; will check 
+  # Bolus into C; will check when this happens next 
   expect_equal(sort(unique(out$C)), c(0, 100))
   
   # At the reset time, B is back to the initial and we have dosed into C

--- a/inst/maintenance/unit-cpp/test-evtools.R
+++ b/inst/maintenance/unit-cpp/test-evtools.R
@@ -13,16 +13,19 @@ $SET end = 12, rtol = 1e-4, atol = 1e-4, delta = 0.25
 $PLUGIN evtools
 $PARAM 
 mode = 0, f1 = 1, dose = 100, irate = 50, newtime = 2
-reptime = 5
+reptime = 5, A0 = 0, B0 = 0, C0 = 0, dosetime = 0
 $CMT A B C
 $PK
 F_A = f1;
+A_0 = A0;
+B_0 = B0;
+
 $DES
 dxdt_A = -1 * A;
 dxdt_B =  1 * A - 0.1 * B;
 dxdt_C = 0;
 $TABLE
-bool givedose = TIME==0;
+bool givedose = TIME==dosetime;
 if(mode==1 && givedose) {
   evt::bolus(self, dose, 1);
 }
@@ -58,11 +61,31 @@ if(mode==8 && givedose) {
   evt::retime(rep, reptime);
   self.push(rep);
 }
+if(mode==9 && givedose) {
+  evt::reset(self);
+}
+if(mode==10 && givedose) {
+  evt::ev res = evt::reset();
+  res.time = 15;
+  self.push(res);
+}
+if(mode==11 && givedose) {
+  evt::reset(self, 100, 3);
+}
+if(mode==12 && givedose) {
+  evt::reset(self, 100, 1, 20);
+}
+if(mode==13 && givedose) {
+  evt::ev res = evt::reset(100, 3);
+  self.push(res);
+}
+if(mode==14 && givedose) {
+  evt::ev res = evt::reset(100, 1, 20);
+  self.push(res);
+}
 '
 
 mod <- mcode("test-evtools-model-1", code)
-
-mrgsim(mod, param = list(mode = 1, f1 = 1)) 
 
 test_that("evtools - bolus now", {
   
@@ -137,4 +160,55 @@ test_that("evtools - replace", {
   expect_true(all(before$C==100))
   after <- filter(c, time >= 8) # note: >= 8
   expect_true(all(after$C==10))
+})
+
+test_that("evtools - reset", {
+  mod <- param(mod, dosetime = 5, B0 = 50, mode = 9)
+  out <- mrgsim(mod)
+  expect_true(all(out$A==0))
+  expect_true(all(out$C==0))
+  x <- filter(out, time %in% c(0,5))
+  expect_true(all(x$B==50))
+  x <- filter(out, time==4)
+  expect_equal(x$B, 50*exp(-0.1*4), tolerance = 1e-2)
+  mod <- param(mod, mode = 10)
+  out2 <- mrgsim(mod)
+  expect_equal(out@data, out2@data)
+})
+
+test_that("evtools - reset with bolus", {
+  mod <- param(mod, dosetime = 5, B0 = 50, mode = 11)
+  out <- mrgsim(mod)
+  x <- filter(out, time==5)
+  expect_equal(x$A, 0)
+  expect_equal(x$B, 50)
+  expect_equal(x$C, 100)
+  x <- filter(out, time==4.75)
+  expect_equal(x$C, 0)
+  x <- filter(out, time > 5)
+  expect_true(all(x$C==100))
+})
+
+
+test_that("evtools - reset with infusion", {
+  mod <- param(mod, dosetime = 5, B0 = 50, mode = 12)
+  out <- mrgsim(mod, rtol = 1e-12)
+  x <- filter(out, time %in% c(0,5))
+  expect_true(all(x$B==50))
+  expect_true(all(x$A==0))
+  x <- filter(out, time == 4.75)
+  expect_equal(x$A, 0)
+  expect_equal(x$B, 50*exp(-0.1*4.75), tolerance = 1e-2)
+  # Maximum A is at the end of the infusion
+  x <- filter(out, A==max(A))
+  expect_equal(x$time, 10)
+  
+  # Identical results
+  out1 <- mrgsim(mod, param = list(mode = 11))
+  out2 <- mrgsim(mod, param = list(mode = 12))
+  out3 <- mrgsim(mod, param = list(mode = 13))
+  out4 <- mrgsim(mod, param = list(mode = 14))
+  
+  expect_identical(out1@data, out3@data)
+  expect_identical(out2@data, out4@data)
 })


### PR DESCRIPTION
# Summary

Trying to follow a similar pattern to what we do for replace, bolus and friends; this should (hopefully) all be natural / consistent riffing on the `evtools` machinery that is already in place. 

- Reset sends `EVID 3`; it resets the entire PK system (all compartments)
- We have to use some value for compartment; keeping that at the default value of 1 
- Providing `reset()` functions with `self` as the first argument (the event is sent off right away, no return) and without `self` as first argument (you get the object back, with opportunity to interact with it)
- Also providing `reset()` with option to pass along dosing information; this is `EVID 4` in NONMEM and mrgsolve; it resets the system and then doses
- For `reset()` with dose, I'm tacking on `rate` as an optional argument, defaulting to `0` (or bolus); this is a slight difference from what we've done before in that we don't provide separate functions to reset and bolus or reset and infuse
- You can always ask for an infusion dose, update the evid to 4 and get the same result 

I also went back into some of the previously-developed functions and used explicit `evt::` references to functions inside the `evtools` namespace. I got a little spooked adding a function with a vanilla name like `reset()` and wanted to get explicit about all of this in the code. 

## Tests

You can see from Files Changed that tests are in `inst/maintenance/unit-cpp/test-evtools.R`. This can be run with `make test-cpp` from the command line. 

The tests are a little tedious, trying to figure out when the system was reset and when there was a dose. I thought to run the equivalent simulation with no evtools involvement and verify results later on in the process; I think this is pretty compelling, but kept the more brute force tests anyway; probably still useful for catching something that might go wrong some day.
