### PR TITLE
ci: install tidy for R CMD check

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -51,7 +51,7 @@ jobs:
           upgrade: ${{ (matrix.config.r == '3.6.3' || matrix.config.r == '4.0.5') && 'FALSE' || 'TRUE' }}
       - name: Install pdflatex
         shell: bash
-        run: sudo apt-get install texlive-latex-base texlive-fonts-extra
+        run: sudo apt-get install texlive-latex-base texlive-fonts-extra tidy
       - name: Check package
         shell: bash
         run: make ci


### PR DESCRIPTION
Install tidy so that 'R CMD check' can doesn't skip its HTML validation:

    * checking HTML version of manual ... NOTE
    Skipping checking HTML validation: no command 'tidy' found