### PR TITLE
Fill out evtools function set for dosing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: mrgsolve
 Title: Simulate from ODE-Based Models
-Version: 1.5.1
+Version: 1.5.1.9000
 Authors@R: 
     c(person(given = "Kyle T", family = "Baron",
              role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# mrgsolve (development version)
+
 # mrgsolve 1.5.1
 
 - Fixed `yaml_to_cpp()` example code to prevent saving the file to the working 

--- a/inst/base/mrgsolv.h
+++ b/inst/base/mrgsolv.h
@@ -53,7 +53,9 @@ struct evdata {
     cmt = 1;
     amt = 0.0;
     rate = 0.0;
+    ii = 0.0;
     ss = 0; 
+    addl = 0;
     now = false;
     check_unique = false;
   } 
@@ -62,7 +64,9 @@ struct evdata {
   int cmt;
   double amt; 
   double rate;
+  double ii; 
   int ss; 
+  int addl;
   bool now;
   bool check_unique;
 }; 

--- a/inst/base/mrgsolv.h
+++ b/inst/base/mrgsolv.h
@@ -53,6 +53,7 @@ struct evdata {
     cmt = 1;
     amt = 0.0;
     rate = 0.0;
+    ss = 0; 
     now = false;
     check_unique = false;
   } 
@@ -61,6 +62,7 @@ struct evdata {
   int cmt;
   double amt; 
   double rate;
+  int ss; 
   bool now;
   bool check_unique;
 }; 

--- a/inst/base/mrgsolve-evtools.h
+++ b/inst/base/mrgsolve-evtools.h
@@ -101,6 +101,21 @@ void ss(mrgsolve::evdata& ev, const int ss) {
   return;
 }
 
+void amt(mrgsolve::evdata& ev, const double amt) {
+  ev.amt = amt; 
+  return;
+}
+
+void rate(mrgsolve::evdata& ev, const double rate) {
+  ev.rate = rate; 
+  return;
+}
+
+void cmt(mrgsolve::evdata& ev, const int cmt) {
+  ev.cmt = cmt;
+  return;
+}
+
 void now(mrgsolve::evdata& ev) {
   ev.now = true;
   return;

--- a/inst/base/mrgsolve-evtools.h
+++ b/inst/base/mrgsolve-evtools.h
@@ -86,6 +86,21 @@ void retime(mrgsolve::evdata& ev, const double time) {
   return;
 }
 
+void addl(mrgsolve::evdata& ev, const int addl) {
+  ev.addl = addl;
+  return;
+}
+
+void ii(mrgsolve::evdata& ev, const double ii) {
+  ev.ii = ii;
+  return;
+}
+
+void ss(mrgsolve::evdata& ev, const int ss) {
+  ev.ss = ss;
+  return;
+}
+
 void now(mrgsolve::evdata& ev) {
   ev.now = true;
   return;

--- a/inst/maintenance/tests.R
+++ b/inst/maintenance/tests.R
@@ -4,15 +4,12 @@ library(testthat)
 library(dplyr)
 
 message("tests/testthat")
-e <- new.env()
-a <- test_dir("tests/testthat", env = e)
+a <- test_dir("tests/testthat")
 a$result <- NULL
 message("\ninst/maintenance/unit")
-e <- new.env()
-b <- test_dir("inst/maintenance/unit/", env = e)
+b <- test_dir("inst/maintenance/unit/")
 b$result <- NULL
-e <- new.env()
-c <- test_dir("inst/maintenance/unit-cpp/", env = e)
+c <- test_dir("inst/maintenance/unit-cpp/")
 c$result <- NULL
 
 results <- dplyr::bind_rows(as_tibble(a),as_tibble(b),as_tibble(c))

--- a/inst/maintenance/tests.R
+++ b/inst/maintenance/tests.R
@@ -4,12 +4,18 @@ library(testthat)
 library(dplyr)
 
 message("tests/testthat")
-a <- test_dir("tests/testthat")
+e <- new.env()
+a <- test_dir("tests/testthat", env = e)
 a$result <- NULL
 message("\ninst/maintenance/unit")
-b <- test_dir("inst/maintenance/unit/")
+e <- new.env()
+b <- test_dir("inst/maintenance/unit/", env = e)
 b$result <- NULL
-results <- dplyr::bind_rows(as_tibble(a),as_tibble(b))
+e <- new.env()
+c <- test_dir("inst/maintenance/unit-cpp/", env = e)
+c$result <- NULL
+
+results <- dplyr::bind_rows(as_tibble(a),as_tibble(b),as_tibble(c))
 results$user <- NULL
 results$system <- NULL
 results$real <- NULL

--- a/inst/maintenance/unit-cpp/test-evtools-dosing.R
+++ b/inst/maintenance/unit-cpp/test-evtools-dosing.R
@@ -62,8 +62,8 @@ test_that("Bolus - ss and addl via evt", {
   expect_identical(out1$B, out2$B)
   
   # same dose, but "later"
-  d <-   ev(amt = 100, ii = 24, addl = 3, time = 3)
-  p <- list(Amt = 100, Ii = 24, Addl = 3, Time2 = 3)
+  d <-   mutate(d, time = 3)
+  p$Time2 <- 3
   out3 <- mrgsim(mod1, d, recsort = 3, obsonly = TRUE)
   out4 <- mrgsim(mod2, param = p, obsonly = TRUE, recsort = 3)
   
@@ -79,8 +79,8 @@ test_that("Bolus, lag - ss and addl via evt", {
   expect_identical(out1$B, out2$B)
   
   # same dose, but "later"
-  d <-   ev(amt = 100, ii = 24, addl = 3, Lag = 5, time = 2.5)
-  p <- list(Amt = 100, Ii = 24, Addl = 3, Lag = 5, Time2 = 2.5)
+  d <-   mutate(d, time = 2.5)
+  p$Time2 <- 2.5
   out3 <- mrgsim(mod1, d, recsort = 3, obsonly = TRUE)
   out4 <- mrgsim(mod2, param = p, obsonly = TRUE, recsort = 3)
 
@@ -96,8 +96,8 @@ test_that("Bolus, ss - ss and addl via evt", {
   expect_identical(out1$B, out2$B)
   
   # same dose, but "later"
-  d <-   ev(amt = 100, ii = 24, addl = 3, ss = 1, time = 3.5)
-  p <- list(Amt = 100, Ii = 24, Addl = 3, Ss = 1, Time2 = 3.5)
+  d <-   mutate(d, time = 3.5)
+  p$Time2 <- 3.5
   out3 <- mrgsim(mod1, d, recsort = 3, obsonly = TRUE)
   out4 <- mrgsim(mod2, param = p, obsonly = TRUE, recsort = 3)
   
@@ -113,8 +113,8 @@ test_that("Bolus, ss, lag - ss and addl via evt", {
   expect_identical(out1$B, out2$B)
   
   # same dose, but "later"
-  d <-   ev(amt = 100, ii = 24, addl = 3, ss = 1, Lag = 3, time = 3.1)
-  p <- list(Amt = 100, Ii = 24, Addl = 3, Ss = 1, Lag = 3, Time2 = 3.1)
+  d <- mutate(d, time = 3.1)
+  p$Time2 <- 3.1
   out3 <- mrgsim(mod1, d, recsort = 3, obsonly = TRUE)
   out4 <- mrgsim(mod2, param = p, obsonly = TRUE, recsort = 3)
   
@@ -130,8 +130,8 @@ test_that("Infusion - ss and addl via evt", {
   expect_identical(out1$B, out2$B)
   
   # same dose, but "later"
-  d <-   ev(amt = 100, ii = 12, addl = 3, Dur = 7, rate = -2, time = 2)
-  p <- list(Amt = 100, Ii = 12, Addl = 3, Dur = 7, Rate = -2, Time2 = 2)
+  d <- mutate(d, time = 2)
+  p$Time2 <- 2
   out3 <- mrgsim(mod1, d, recsort = 3, obsonly = TRUE)
   out4 <- mrgsim(mod2, param = p, obsonly = TRUE, recsort = 3)
   
@@ -147,8 +147,8 @@ test_that("Infusion, lag - ss and addl via evt", {
   expect_identical(out1$B, out2$B)
   
   # same dose, but "later"
-  d <-   ev(amt = 100, ii = 8, addl = 3, Lag = 5, Dur = 5, rate = -2, time = 4)
-  p <- list(Amt = 100, Ii = 8, Addl = 3, Lag = 5, Dur = 5, Rate = -2, Time2 = 4)
+  d <- mutate(d, time = 4)
+  p$Time2 <- 4
   out3 <- mrgsim(mod1, d, recsort = 3, obsonly = TRUE)
   out4 <- mrgsim(mod2, param = p, obsonly = TRUE, recsort = 3)
   
@@ -164,8 +164,8 @@ test_that("Infusion, ss - ss and addl via evt", {
   expect_identical(out1$B, out2$B)
   
   # same dose, but "later"
-  d <-   ev(amt = 100, ii = 24, addl = 2, ss = 1, Dur = 8, rate = -2, time = 1.5)
-  p <- list(Amt = 100, Ii = 24, Addl = 2, Ss = 1, Dur = 8, Rate = -2, Time2 = 1.5)
+  d <- mutate(d, time = 1.5)
+  p$Time2 <- 1.5
   out3 <- mrgsim(mod1, d, recsort = 3, obsonly = TRUE)
   out4 <- mrgsim(mod2, param = p, obsonly = TRUE, recsort = 3)
   
@@ -181,23 +181,30 @@ test_that("Infusion, ss, lag - ss and addl via evt", {
   expect_identical(out1$B, out2$B)
   
   # same dose, but "later"
-  d <-   ev(amt = 100, ii = 16, addl = 3, ss = 1, Lag = 3, Dur = 9, rate = -2, 
-            time = 2.1)
-  p <- list(Amt = 100, Ii = 16, Addl = 3, Ss = 1, Lag = 3, Dur = 9, Rate = -2, 
-            Time2 = 2.1)
+  d <- mutate(d, time = 2.1)
+  p$Time2 <- 2.1
   out3 <- mrgsim(mod1, d, recsort = 3, obsonly = TRUE)
   out4 <- mrgsim(mod2, param = p, obsonly = TRUE, recsort = 3)
   
   expect_identical(out3$B, out4$B)
 })
 
-test_that("Alternate infusion - ss and addl via evt", {
+test_that("Alternate infusion - dosing via evt", {
+  # data event passes the rate directly rather than modeled duration
   d <-   ev(amt = 100, ii = 24, addl = 1, tinf = 4)
   p <- list(Amt = 100, Ii = 24, Addl = 1, Dur = 4, Rate = -2)
   out1 <- mrgsim(mod1, d, recsort = 3, obsonly = TRUE)
   out2 <- mrgsim(mod2, param = p, obsonly = TRUE, recsort = 3)
   
   expect_identical(out1$B, out2$B)
+  
+  # Both use direct rate rather than modeled duration
+  d <- ev(amt = 100, ii = 24, addl = 1, rate = 20)
+  p <- list(Amt = 100, Ii = 24, Addl = 1, Rate = 20)
+  out3 <- mrgsim(mod1, d, recsort = 3, obsonly = TRUE)
+  out4 <- mrgsim(mod2, param = p, obsonly = TRUE, recsort = 3)
+  
+  expect_identical(out3$B, out4$B)
 })
 
 test_that("Single dose - dosing via evt", {
@@ -208,8 +215,8 @@ test_that("Single dose - dosing via evt", {
   
   expect_identical(out1$B, out2$B)
   
-  d <-   ev(amt = 100, ii = 24, tinf = 3, time = 3.3)
-  p <- list(Amt = 100, Ii = 24, Addl = 0, Dur = 3, Rate = -2, Time2 = 3.3)
+  d <- mutate(d, time = 3.3)
+  p$Time2 <- 3.3
   out3 <- mrgsim(mod1, d, recsort = 3, obsonly = TRUE)
   out4 <- mrgsim(mod2, param = p, obsonly = TRUE, recsort = 3)
   

--- a/inst/maintenance/unit-cpp/test-evtools-dosing.R
+++ b/inst/maintenance/unit-cpp/test-evtools-dosing.R
@@ -51,9 +51,6 @@ if(TIME==0 && Mdose > 0) {
 mod1 <- mcode("reset", code, delta = 0.1, end = 96)
 mod2 <- update(mod1, param = list(Mdose = 1))
 
-
-# Bolus
-
 test_that("Bolus - ss and addl via evt", {
   d <-   ev(amt = 100, ii = 24, addl = 3)
   p <- list(Amt = 100, Ii = 24, Addl = 3)
@@ -151,6 +148,7 @@ test_that("Switch compartment - dosing via evt", {
   out2 <- mrgsim(mod2, param = p, obsonly = TRUE, recsort = 3)
   
   expect_identical(out1$B, out2$B)
+  expect_identical(out1$D, out2$D)
 })
 
 test_that("Switch dose amount - dosing via evt", {

--- a/inst/maintenance/unit-cpp/test-evtools-dosing.R
+++ b/inst/maintenance/unit-cpp/test-evtools-dosing.R
@@ -1,0 +1,172 @@
+library(testthat)
+library(mrgsolve)
+library(dplyr)
+
+Sys.setenv(R_TESTS="")
+options("mrgsolve_mread_quiet"=TRUE)
+
+local_edition(3)
+
+code <- '
+$PLUGIN evtools
+
+$PARAM Mdose = 0
+
+$PARAM 
+Lag   =  0
+Ii    =  24
+Ss    =  0
+Addl  =  0
+Rate  =  0
+Dur   =  0
+Amt   =  100
+Cmt2  = -1
+Amt2  = -1
+Rate2 = -1
+
+$CMT B D
+
+$MAIN 
+ALAG_B = Lag;
+D_B = Dur; 
+
+$ODE
+dxdt_D =  -0.3 * D;
+dxdt_B =   0.3 * D - 0.1*B;
+
+$ERROR
+
+if(TIME==0 && Mdose > 0) {
+  evt::ev dose = evt::infuse(Amt, 1, Rate); 
+  evt::ss(dose, Ss); 
+  evt::ii(dose, Ii); 
+  evt::addl(dose, Addl); 
+  if(Rate2 > 0) evt::rate(dose, Rate2);
+  if(Cmt2 > 0) evt::cmt(dose, Cmt2);
+  if(Amt2 > 0) evt::amt(dose, Amt2);
+  self.push(dose);
+}
+'
+
+mod1 <- mcode("reset", code, delta = 0.1, end = 96)
+mod2 <- update(mod1, param = list(Mdose = 1))
+
+
+# Bolus
+
+test_that("Bolus - ss and addl via evt", {
+  d <-   ev(amt = 100, ii = 24, addl = 3)
+  p <- list(Amt = 100, Ii = 24, Addl = 3)
+  out1 <- mrgsim(mod1, d, recsort = 3, obsonly = TRUE)
+  out2 <- mrgsim(mod2, param = p, obsonly = TRUE, recsort = 3)
+  
+  expect_identical(out1$B, out2$B)
+})
+
+test_that("Bolus, lag - ss and addl via evt", {
+  d <-   ev(amt = 100, ii = 24, addl = 3, Lag = 5)
+  p <- list(Amt = 100, Ii = 24, Addl = 3, Lag = 5)
+  out1 <- mrgsim(mod1, d, recsort = 3, obsonly = TRUE)
+  out2 <- mrgsim(mod2, param = p, obsonly = TRUE, recsort = 3)
+  
+  expect_identical(out1$B, out2$B)
+})
+
+test_that("Bolus, ss - ss and addl via evt", {
+  d <-   ev(amt = 100, ii = 24, addl = 3, ss = 1)
+  p <- list(Amt = 100, Ii = 24, Addl = 3, Ss = 1)
+  out1 <- mrgsim(mod1, d, recsort = 3, obsonly = TRUE)
+  out2 <- mrgsim(mod2, param = p, obsonly = TRUE, recsort = 3)
+  
+  expect_identical(out1$B, out2$B)
+})
+
+test_that("Bolus, ss, lag - ss and addl via evt", {
+  d <-   ev(amt = 100, ii = 24, addl = 3, ss = 1, Lag = 3)
+  p <- list(Amt = 100, Ii = 24, Addl = 3, Ss = 1, Lag = 3)
+  out1 <- mrgsim(mod1, d, recsort = 3, obsonly = TRUE)
+  out2 <- mrgsim(mod2, param = p, obsonly = TRUE, recsort = 3)
+  
+  expect_identical(out1$B, out2$B)
+})
+
+test_that("Infusion - ss and addl via evt", {
+  d <-   ev(amt = 100, ii = 12, addl = 3, Dur = 7, rate = -2)
+  p <- list(Amt = 100, Ii = 12, Addl = 3, Dur = 7, Rate = -2)
+  out1 <- mrgsim(mod1, d, recsort = 3, obsonly = TRUE)
+  out2 <- mrgsim(mod2, param = p, obsonly = TRUE, recsort = 3)
+  
+  expect_identical(out1$B, out2$B)
+})
+
+test_that("Infusion, lag - ss and addl via evt", {
+  d <-   ev(amt = 100, ii = 8, addl = 3, Lag = 5, Dur = 5, rate = -2)
+  p <- list(Amt = 100, Ii = 8, Addl = 3, Lag = 5, Dur = 5, Rate = -2)
+  out1 <- mrgsim(mod1, d, recsort = 3, obsonly = TRUE)
+  out2 <- mrgsim(mod2, param = p, obsonly = TRUE, recsort = 3)
+  
+  expect_identical(out1$B, out2$B)
+})
+
+test_that("Infusion, ss - ss and addl via evt", {
+  d <-   ev(amt = 100, ii = 24, addl = 2, ss = 1, Dur = 8, rate = -2)
+  p <- list(Amt = 100, Ii = 24, Addl = 2, Ss = 1, Dur = 8, Rate = -2)
+  out1 <- mrgsim(mod1, d, recsort = 3, obsonly = TRUE)
+  out2 <- mrgsim(mod2, param = p, obsonly = TRUE, recsort = 3)
+  
+  expect_identical(out1$B, out2$B)
+})
+
+test_that("Infusion, ss, lag - ss and addl via evt", {
+  d <-   ev(amt = 100, ii = 16, addl = 3, ss = 1, Lag = 3, Dur = 9, rate = -2)
+  p <- list(Amt = 100, Ii = 16, Addl = 3, Ss = 1, Lag = 3, Dur = 9, Rate = -2)
+  out1 <- mrgsim(mod1, d, recsort = 3, obsonly = TRUE)
+  out2 <- mrgsim(mod2, param = p, obsonly = TRUE, recsort = 3)
+  
+  expect_identical(out1$B, out2$B)
+})
+
+test_that("Alternate infusion - ss and addl via evt", {
+  d <-   ev(amt = 100, ii = 24, addl = 1, tinf = 4)
+  p <- list(Amt = 100, Ii = 24, Addl = 1, Dur = 4, Rate = -2)
+  out1 <- mrgsim(mod1, d, recsort = 3, obsonly = TRUE)
+  out2 <- mrgsim(mod2, param = p, obsonly = TRUE, recsort = 3)
+  
+  expect_identical(out1$B, out2$B)
+})
+
+test_that("Single dose - dosing via evt", {
+  d <-   ev(amt = 100, ii = 24, tinf = 3)
+  p <- list(Amt = 100, Ii = 24, Addl = 0, Dur = 3, Rate = -2)
+  out1 <- mrgsim(mod1, d, recsort = 3, obsonly = TRUE)
+  out2 <- mrgsim(mod2, param = p, obsonly = TRUE, recsort = 3)
+  
+  expect_identical(out1$B, out2$B)
+})
+
+test_that("Switch compartment - dosing via evt", {
+  d <-   ev(amt = 100, ii = 24, addl = 2, cmt = 2)
+  p <- list(Amt = 100, Ii = 24, Addl = 2, Cmt2 = 2)
+  out1 <- mrgsim(mod1, d, recsort = 3, obsonly = TRUE)
+  out2 <- mrgsim(mod2, param = p, obsonly = TRUE, recsort = 3)
+  
+  expect_identical(out1$B, out2$B)
+})
+
+test_that("Switch dose amount - dosing via evt", {
+  d <-   ev(amt = 200, ii = 24, addl = 2)
+  p <- list(Amt = 100, Ii = 24, Addl = 2, Amt2 = 200)
+  out1 <- mrgsim(mod1, d, recsort = 3, obsonly = TRUE)
+  out2 <- mrgsim(mod2, param = p, obsonly = TRUE, recsort = 3)
+  
+  expect_identical(out1$B, out2$B)
+})
+
+test_that("Switch infusion rate - dosing via evt", {
+  d <-   ev(amt = 100, ii = 24, addl = 2, tinf = 5)
+  p <- list(Amt = 100, Ii = 24, Addl = 2, Rate2 = 100/5, Rate = -2, Dur = 10)
+  out1 <- mrgsim(mod1, d, recsort = 3, obsonly = TRUE)
+  out2 <- mrgsim(mod2, param = p, obsonly = TRUE, recsort = 3)
+  
+  expect_identical(out1$B, out2$B)
+})

--- a/inst/maintenance/unit-cpp/test-evtools-dosing.R
+++ b/inst/maintenance/unit-cpp/test-evtools-dosing.R
@@ -23,6 +23,7 @@ Amt   =  100
 Cmt2  = -1
 Amt2  = -1
 Rate2 = -1
+Time2 = -1
 
 $CMT B D
 
@@ -44,6 +45,7 @@ if(TIME==0 && Mdose > 0) {
   if(Rate2 > 0) evt::rate(dose, Rate2);
   if(Cmt2 > 0) evt::cmt(dose, Cmt2);
   if(Amt2 > 0) evt::amt(dose, Amt2);
+  if(Time2 > 0) evt::retime(dose, Time2);
   self.push(dose);
 }
 '
@@ -58,6 +60,14 @@ test_that("Bolus - ss and addl via evt", {
   out2 <- mrgsim(mod2, param = p, obsonly = TRUE, recsort = 3)
   
   expect_identical(out1$B, out2$B)
+  
+  # same dose, but "later"
+  d <-   ev(amt = 100, ii = 24, addl = 3, time = 3)
+  p <- list(Amt = 100, Ii = 24, Addl = 3, Time2 = 3)
+  out3 <- mrgsim(mod1, d, recsort = 3, obsonly = TRUE)
+  out4 <- mrgsim(mod2, param = p, obsonly = TRUE, recsort = 3)
+  
+  expect_identical(out3$B, out4$B)
 })
 
 test_that("Bolus, lag - ss and addl via evt", {
@@ -67,6 +77,14 @@ test_that("Bolus, lag - ss and addl via evt", {
   out2 <- mrgsim(mod2, param = p, obsonly = TRUE, recsort = 3)
   
   expect_identical(out1$B, out2$B)
+  
+  # same dose, but "later"
+  d <-   ev(amt = 100, ii = 24, addl = 3, Lag = 5, time = 2.5)
+  p <- list(Amt = 100, Ii = 24, Addl = 3, Lag = 5, Time2 = 2.5)
+  out3 <- mrgsim(mod1, d, recsort = 3, obsonly = TRUE)
+  out4 <- mrgsim(mod2, param = p, obsonly = TRUE, recsort = 3)
+
+  expect_identical(out3$B, out4$B)
 })
 
 test_that("Bolus, ss - ss and addl via evt", {
@@ -76,6 +94,14 @@ test_that("Bolus, ss - ss and addl via evt", {
   out2 <- mrgsim(mod2, param = p, obsonly = TRUE, recsort = 3)
   
   expect_identical(out1$B, out2$B)
+  
+  # same dose, but "later"
+  d <-   ev(amt = 100, ii = 24, addl = 3, ss = 1, time = 3.5)
+  p <- list(Amt = 100, Ii = 24, Addl = 3, Ss = 1, Time2 = 3.5)
+  out3 <- mrgsim(mod1, d, recsort = 3, obsonly = TRUE)
+  out4 <- mrgsim(mod2, param = p, obsonly = TRUE, recsort = 3)
+  
+  expect_identical(out3$B, out4$B)
 })
 
 test_that("Bolus, ss, lag - ss and addl via evt", {
@@ -85,6 +111,14 @@ test_that("Bolus, ss, lag - ss and addl via evt", {
   out2 <- mrgsim(mod2, param = p, obsonly = TRUE, recsort = 3)
   
   expect_identical(out1$B, out2$B)
+  
+  # same dose, but "later"
+  d <-   ev(amt = 100, ii = 24, addl = 3, ss = 1, Lag = 3, time = 3.1)
+  p <- list(Amt = 100, Ii = 24, Addl = 3, Ss = 1, Lag = 3, Time2 = 3.1)
+  out3 <- mrgsim(mod1, d, recsort = 3, obsonly = TRUE)
+  out4 <- mrgsim(mod2, param = p, obsonly = TRUE, recsort = 3)
+  
+  expect_identical(out3$B, out4$B)
 })
 
 test_that("Infusion - ss and addl via evt", {
@@ -94,6 +128,14 @@ test_that("Infusion - ss and addl via evt", {
   out2 <- mrgsim(mod2, param = p, obsonly = TRUE, recsort = 3)
   
   expect_identical(out1$B, out2$B)
+  
+  # same dose, but "later"
+  d <-   ev(amt = 100, ii = 12, addl = 3, Dur = 7, rate = -2, time = 2)
+  p <- list(Amt = 100, Ii = 12, Addl = 3, Dur = 7, Rate = -2, Time2 = 2)
+  out3 <- mrgsim(mod1, d, recsort = 3, obsonly = TRUE)
+  out4 <- mrgsim(mod2, param = p, obsonly = TRUE, recsort = 3)
+  
+  expect_identical(out3$B, out4$B)
 })
 
 test_that("Infusion, lag - ss and addl via evt", {
@@ -103,6 +145,14 @@ test_that("Infusion, lag - ss and addl via evt", {
   out2 <- mrgsim(mod2, param = p, obsonly = TRUE, recsort = 3)
   
   expect_identical(out1$B, out2$B)
+  
+  # same dose, but "later"
+  d <-   ev(amt = 100, ii = 8, addl = 3, Lag = 5, Dur = 5, rate = -2, time = 4)
+  p <- list(Amt = 100, Ii = 8, Addl = 3, Lag = 5, Dur = 5, Rate = -2, Time2 = 4)
+  out3 <- mrgsim(mod1, d, recsort = 3, obsonly = TRUE)
+  out4 <- mrgsim(mod2, param = p, obsonly = TRUE, recsort = 3)
+  
+  expect_identical(out3$B, out4$B)
 })
 
 test_that("Infusion, ss - ss and addl via evt", {
@@ -112,6 +162,14 @@ test_that("Infusion, ss - ss and addl via evt", {
   out2 <- mrgsim(mod2, param = p, obsonly = TRUE, recsort = 3)
   
   expect_identical(out1$B, out2$B)
+  
+  # same dose, but "later"
+  d <-   ev(amt = 100, ii = 24, addl = 2, ss = 1, Dur = 8, rate = -2, time = 1.5)
+  p <- list(Amt = 100, Ii = 24, Addl = 2, Ss = 1, Dur = 8, Rate = -2, Time2 = 1.5)
+  out3 <- mrgsim(mod1, d, recsort = 3, obsonly = TRUE)
+  out4 <- mrgsim(mod2, param = p, obsonly = TRUE, recsort = 3)
+  
+  expect_identical(out3$B, out4$B)
 })
 
 test_that("Infusion, ss, lag - ss and addl via evt", {
@@ -121,6 +179,16 @@ test_that("Infusion, ss, lag - ss and addl via evt", {
   out2 <- mrgsim(mod2, param = p, obsonly = TRUE, recsort = 3)
   
   expect_identical(out1$B, out2$B)
+  
+  # same dose, but "later"
+  d <-   ev(amt = 100, ii = 16, addl = 3, ss = 1, Lag = 3, Dur = 9, rate = -2, 
+            time = 2.1)
+  p <- list(Amt = 100, Ii = 16, Addl = 3, Ss = 1, Lag = 3, Dur = 9, Rate = -2, 
+            Time2 = 2.1)
+  out3 <- mrgsim(mod1, d, recsort = 3, obsonly = TRUE)
+  out4 <- mrgsim(mod2, param = p, obsonly = TRUE, recsort = 3)
+  
+  expect_identical(out3$B, out4$B)
 })
 
 test_that("Alternate infusion - ss and addl via evt", {
@@ -139,6 +207,13 @@ test_that("Single dose - dosing via evt", {
   out2 <- mrgsim(mod2, param = p, obsonly = TRUE, recsort = 3)
   
   expect_identical(out1$B, out2$B)
+  
+  d <-   ev(amt = 100, ii = 24, tinf = 3, time = 3.3)
+  p <- list(Amt = 100, Ii = 24, Addl = 0, Dur = 3, Rate = -2, Time2 = 3.3)
+  out3 <- mrgsim(mod1, d, recsort = 3, obsonly = TRUE)
+  out4 <- mrgsim(mod2, param = p, obsonly = TRUE, recsort = 3)
+  
+  expect_identical(out3$B, out4$B)
 })
 
 test_that("Switch compartment - dosing via evt", {

--- a/inst/maintenance/unit-cpp/test-evtools-dosing.R
+++ b/inst/maintenance/unit-cpp/test-evtools-dosing.R
@@ -207,6 +207,25 @@ test_that("Alternate infusion - dosing via evt", {
   expect_identical(out3$B, out4$B)
 })
 
+test_that("Steady state continuous infusion - dosing via evt", {
+  d <-   ev(amt = 0, ii = 24, rate = 20, ss = 1)
+  p <- list(Amt = 0, Ii = 24, Rate = 20, Ss = 1)
+  out1 <- mrgsim(mod1, d, recsort = 3, obsonly = TRUE)
+  out2 <- mrgsim(mod2, param = p, obsonly = TRUE, recsort = 3)
+  
+  expect_identical(out1$B, out2$B)
+  expect_equal(out2$B[1], 20/0.1)
+  
+  # same dose at a later time
+  d <- mutate(d, time = 10)
+  p$Time2 <- 10
+  out3 <- mrgsim(mod1, d, recsort = 3, obsonly = TRUE)
+  out4 <- mrgsim(mod2, param = p, obsonly = TRUE, recsort = 3)
+  
+  expect_identical(out3$B, out4$B)
+  expect_equal(out3$B[out3$time==10], 20/0.1)
+})
+
 test_that("Single dose - dosing via evt", {
   d <-   ev(amt = 100, ii = 24, tinf = 3)
   p <- list(Amt = 100, Ii = 24, Addl = 0, Dur = 3, Rate = -2)

--- a/inst/maintenance/unit-cpp/test-evtools-regimen.R
+++ b/inst/maintenance/unit-cpp/test-evtools-regimen.R
@@ -42,7 +42,7 @@ capture ccmt = reg.cmt();
 '
 
 mod1 <- mcode("test-evtools-regimen", code, quiet = TRUE)
-mod2 <- modlib("pk1", quiet = TRUE)
+mod2 <- modlib("pk1", quiet = TRUE, preclean = TRUE)
 mod2 <- param(mod2, as.list(param(mod1)))
 
 test_that("Identical results with pk1", {

--- a/src/devtran.cpp
+++ b/src/devtran.cpp
@@ -644,6 +644,10 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
           new_ev->ss((mt[mti]).ss);
           new_ev->ii((mt[mti]).ii);
           new_ev->addl((mt[mti]).addl);
+          // if doses happen "later" we never schedule here; it will
+          //   get handled later
+          // if the dose happens "now", we schedule now, even if there is lag
+          //   time in play
           bool schedule_addl = false;
           if(mt[mti].now) {
             schedule_addl  = new_ev->addl() > 0;
@@ -702,13 +706,16 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
             }
           } // Done processing "this" event
           if(schedule_addl) {
+            // For parent doses happening "now", with or without lag time
+            // There is *no* unique check for additional doses
             new_ev->schedule(a[i], maxtime, addl_ev_first, NN, 0.0);
             std::sort(a[i].begin()+j+1,a[i].end(),CompRec());
           }
         } // Closes iteration across vector of events
         used_mtimehx = mtimehx.size() > 0;
         prob.clear_mtime();
-      }
+      } // Close handling of modeled events
+      
       if(this_rec->output()) {
         ans(crow,0) = id;
         ans(crow,1) = tto;

--- a/src/devtran.cpp
+++ b/src/devtran.cpp
@@ -645,7 +645,7 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
           new_ev->ii((mt[mti]).ii);
           new_ev->addl((mt[mti]).addl);
           // if doses happen "later" we never schedule here; it will
-          //   get handled later
+          //   get handled later as well
           // if the dose happens "now", we schedule now, even if there is lag
           //   time in play
           bool schedule_addl = false;
@@ -706,7 +706,8 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
             }
           } // Done processing "this" event
           if(schedule_addl) {
-            // For parent doses happening "now", with or without lag time
+            // For parent doses happening "now", with or without lag time,
+            //   but with positive addl
             // There is *no* unique check for additional doses
             new_ev->schedule(a[i], maxtime, addl_ev_first, NN, 0.0);
             std::sort(a[i].begin()+j+1,a[i].end(),CompRec());

--- a/src/devtran.cpp
+++ b/src/devtran.cpp
@@ -716,7 +716,7 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
         used_mtimehx = mtimehx.size() > 0;
         prob.clear_mtime();
       } // Close handling of modeled events
-      
+
       if(this_rec->output()) {
         ans(crow,0) = id;
         ans(crow,1) = tto;

--- a/src/devtran.cpp
+++ b/src/devtran.cpp
@@ -660,6 +660,11 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
               prob.rate_main(new_ev);    
             }
             if(prob.alag(new_ev->cmtn()) > mindt && new_ev->is_dose()) {
+              if(new_ev->ss() > 0) {
+                new_ev->steady(&prob, a[i], solver);
+                tfrom = tto;
+                new_ev->ss(0);
+              }
               new_ev->time(new_ev->time() + prob.alag(new_ev->cmtn()));
               new_ev->lagged();
               new_ev->pos(__ALAG_POS);
@@ -694,8 +699,9 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
               mtimehx.push_back(new_ev);
             }
           } // Done processing "this" event
-          if(mt[mti].ss > 0 || mt[mti].addl > 0) {
-            
+          if(new_ev->addl() > 0) {
+            new_ev->schedule(a[i], maxtime, addl_ev_first, NN, 0.0);
+            std::sort(a[i].begin()+j+1,a[i].end(),CompRec());
           }
         } // Closes iteration across vector of events
         used_mtimehx = mtimehx.size() > 0;

--- a/src/devtran.cpp
+++ b/src/devtran.cpp
@@ -644,7 +644,9 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
           new_ev->ss((mt[mti]).ss);
           new_ev->ii((mt[mti]).ii);
           new_ev->addl((mt[mti]).addl);
+          bool schedule_addl = false;
           if(mt[mti].now) {
+            schedule_addl  = new_ev->addl() > 0;
             new_ev->fn(prob.fbio(new_ev->cmtn()));
             if(new_ev->fn() < 0) {
               CRUMP("[mrgsolve] bioavailability fraction is less than zero.");
@@ -699,7 +701,7 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
               mtimehx.push_back(new_ev);
             }
           } // Done processing "this" event
-          if(new_ev->addl() > 0) {
+          if(schedule_addl) {
             new_ev->schedule(a[i], maxtime, addl_ev_first, NN, 0.0);
             std::sort(a[i].begin()+j+1,a[i].end(),CompRec());
           }

--- a/src/devtran.cpp
+++ b/src/devtran.cpp
@@ -641,6 +641,9 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
           rec_ptr new_ev = NEWREC(this_cmt,this_evid,this_amt,this_time,
                                   this_rate,1.0);    
           new_ev->phantom_rec();
+          new_ev->ss((mt[mti]).ss);
+          new_ev->ii((mt[mti]).ii);
+          new_ev->addl((mt[mti]).addl);
           if(mt[mti].now) {
             new_ev->fn(prob.fbio(new_ev->cmtn()));
             if(new_ev->fn() < 0) {
@@ -666,6 +669,7 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
           // If the event is still happening now
           if(mt[mti].now) {
             new_ev->time(tto);
+            new_ev->steady(&prob,a[i],solver);
             new_ev->implement(&prob);
             told = new_ev->time();
             if(new_ev->int_infusion() && new_ev->armed()) {
@@ -688,9 +692,12 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
             if(do_mt_ev) {
               insert_record(a[i], j, new_ev, put_ev_first);
               mtimehx.push_back(new_ev);
-            } 
+            }
+          } // Done processing "this" event
+          if(mt[mti].ss > 0 || mt[mti].addl > 0) {
+            
           }
-        }
+        } // Closes iteration across vector of events
         used_mtimehx = mtimehx.size() > 0;
         prob.clear_mtime();
       }


### PR DESCRIPTION
# Summary 

These functions provide _new_ functionality to (1) gives doses at steady state and (2) give additional doses. We also provide  the user some of the "missing" api for working with these event objects in C++. 

Note: working on this feature, I discovered behavior in #1229 that will need to be addressed in another work stream; it's a known issue now and will need some reimagining of how this in-model dosing is done.

All of the tests compare doses set up via the data set (or event object) and doses that are issued from inside the model. For each combination, there is a test for when the parent event is done "now" and another test when the parent dose is done "later".

**New data members** in `evdata`:
- `ss`
- `ii`
- `addl`

All of these items naturally initialize to `0`. There is no new central functionality needed to handle these items; they just get passed into existing machinery.  

**New functions**: 
- `ss()` - advance the system to steady state prior to diving the dose
- `ii()` - specify the dose interval
- `addl()` - give additional doses
- `amt()` - set / reset the dose amount
- `rate()` - set / reset the infusion rate
- `cmt()`-  set / reset the dose compartment

**Existing functions**: 
- `bolus()` - bolus dose
- `infuse()` - start an infusion
- `reset()` - reset the system or reset and dose
- `replace()` - replace the amount in a compartment (evid 8)
- `retime()` - sets the time attribute _and_ forces `now` to `false`
- `now()` - make an event happen "now"

The goal is to have a fairly complete set of functions to deal with these objects. 

# Example

``` r
library(mrgsolve)
#> 
#> Attaching package: 'mrgsolve'
#> The following object is masked from 'package:stats':
#> 
#>     filter
library(dplyr)
#> 
#> Attaching package: 'dplyr'
#> The following objects are masked from 'package:stats':
#> 
#>     filter, lag
#> The following objects are masked from 'package:base':
#> 
#>     intersect, setdiff, setequal, union


code <- '
$PLUGIN evtools autodec

$PARAM 
CL = 1, V = 25, KA = 1.3
Dose = 100, Ii = 24, End = 240, Ss = -1

$PKMODEL cmt = "A1,A2", depot = TRUE

$ERROR
if(NEWIND <= 1) {
  evt::ev dose = evt::bolus(Dose, 1);
  evt::ii(dose, Ii); 
  evt::addl(dose, (End/Ii));
  if(Ss > 0) evt::ss(dose, 1);
  self.push(dose);
}
'
mod <- mcode('foo', code)
#> Building foo ...
#> done.
```

# Sensitivity analysis on dose, ii and addl

``` r
idata <- expand.idata(Dose = c(50, 100, 200), Ii = c(6, 12, 24), End = c(120, 240, 360))
```

``` r
out <- mrgsim(mod, idata = idata, end = 360, recover = "Dose,Ii,End", recsort = 3) 

plot(out, A2~time|factor(End)*factor(Ii))
```

![](https://i.imgur.com/IHulNsk.png)<!-- -->

# Simulation at steady-state

``` r
idata <- expand.idata(Dose = 100, Ii = c(6, 12, 24), Ss = c(0,1), End = 240)
```

``` r
out <- mrgsim(mod, idata = idata, end = 360, recover = "Dose,Ii,Ss", recsort = 3) 

plot(out, A2~time|factor(Ss))
```

![](https://i.imgur.com/26Fr3J9.png)<!-- -->

<sup>Created on 2024-09-03 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>