### PR TITLE
Refactor autodec cpp variable discovery

### DIFF
--- a/R/modspec.R
+++ b/R/modspec.R
@@ -431,10 +431,6 @@ token_space <- function(x) {
 }
 
 get_c_vars2 <- function(y,context) {
-  fors <- grep("\\bfor\\s*\\(", y, perl = TRUE)
-  if(length(fors)) {
-    y <- y[-fors]  
-  }
   m <- gregexpr(move_global_re_find,y,perl=TRUE)
   regm <- unlist(regmatches(y,m))
   if(length(regm)==0) return(data.frame())

--- a/R/modspec.R
+++ b/R/modspec.R
@@ -871,11 +871,12 @@ autodec_find <- function(code) {
   ans <- regmatches(code, m)
   if(!length(ans)) return(character(0))
   ans <- sub(" *=.?$", "", ans, perl = TRUE)
+  has_dot <- grepl(".", ans, fixed = TRUE)
   code <- code[m > 0]
   m <- m[m > 0]
   pre <- trimws(substr(code, start = 0, stop = m-1), which = "left")
   if(all(pre=="")) {
-    return(unique(ans))  
+    return(unique(ans[!has_dot]))  
   }
   pre <- strsplit(pre, "[ )(}{\\[\\]]", perl = TRUE)
   p0 <- sapply(pre, "[", 1L)
@@ -885,8 +886,7 @@ autodec_find <- function(code) {
   drop1 <- p1 %in% c("double", "int", "bool", "const", "static", "unsigned")
   drop2 <- p2 %in% c("static", "const", "unsigned")
   drop3 <- grepl("::", p0, fixed = TRUE)
-  ans <- ans[!(drop1 | drop2 | drop3)]
-  ans <- ans[!grepl(".", ans, fixed = TRUE)]
+  ans <- ans[!(drop1 | drop2 | drop3 | has_dot)]
   ans <- unique(ans)
   ans
 }

--- a/R/modspec.R
+++ b/R/modspec.R
@@ -1,4 +1,4 @@
-# Copyright (C) 2013 - 2023  Metrum Research Group
+# Copyright (C) 2013 - 2024  Metrum Research Group
 #
 # This file is part of mrgsolve.
 #

--- a/R/modspec.R
+++ b/R/modspec.R
@@ -431,6 +431,10 @@ token_space <- function(x) {
 }
 
 get_c_vars2 <- function(y,context) {
+  fors <- grep("\\bfor\\s*\\(", y, perl = TRUE)
+  if(length(fors)) {
+    y <- y[-fors]  
+  }
   m <- gregexpr(move_global_re_find,y,perl=TRUE)
   regm <- unlist(regmatches(y,m))
   if(length(regm)==0) return(data.frame())

--- a/R/modspec.R
+++ b/R/modspec.R
@@ -874,7 +874,8 @@ autodec_find <- function(code) {
   has_dot <- grepl(".", ans, fixed = TRUE)
   code <- code[m > 0]
   m <- m[m > 0]
-  pre <- trimws(substr(code, start = 0, stop = m-1), which = "left")
+  pre <- substr(code, start = 0, stop = m-1)
+  pre <- trimws(pre, which = "left")
   if(all(pre=="")) {
     return(unique(ans[!has_dot]))  
   }

--- a/tests/testthat/test-modspec.R
+++ b/tests/testthat/test-modspec.R
@@ -729,34 +729,3 @@ test_that("Skip cpp dot check gh-1159", {
   
   expect_s4_class(mcode("cpp-dot-skip-4", code, compile = FALSE), "mrgmod")
 })
-
-test_that("variables in for loops aren't discovered", {
-  code <- '
-  $MAIN 
-  double a = 1.23;
-  int b = 2; 
-  bool c = true;
-  for(int i = 0; i < b; ++i) {
-    b = b + i;
-  }
-  for ( int j = 0; j == 10; ++j) {
-    a = a + b + 2;
-  }
-  '
-  mod <- mcode("test-modspec-ignore-for", code, compile = FALSE)
-  cpp <- as.list(mod)$cpp_variables
-  expect_equal(cpp$var, c("a", "b", "c"))
-  
-  bl <- modelparse(code, split = TRUE)
-  ans <- mrgsolve:::get_c_vars2(bl$MAIN, context = "unit")
-  expect_identical(ans$type, cpp$type)
-  expect_identical(ans$var, cpp$var)
-  expect_true(all(ans$context=="unit"))
-  
-  code <- '
-  $MAIN
-  if(xfor(1)==1) double b = 2;
-  '
-  mod <- mcode("test-modspec-for-b", code, compile = FALSE)
-  cpp <- as.list(mod)$cpp_variables
-})

--- a/tests/testthat/test-modspec.R
+++ b/tests/testthat/test-modspec.R
@@ -442,12 +442,6 @@ test_that("autodec parsing", {
   expect_equal(x, "ccc")
   x <- mrgsolve:::autodec_find("self.foo = 1;")
   expect_equal(x, character(0))
-  # refuse to look at anything on a line with for loop
-  x <- mrgsolve:::autodec_find("for(int i = 2; i < 5; ++i) { aaa = 3;")
-  expect_equal(x, character(0))
-  # to find it, just put on a new line
-  x <- mrgsolve:::autodec_find(c("for(int i = 2; i < 5; ++i) {"," aaa = 3;"))
-  expect_equal(x, "aaa")
   code <- strsplit(split = "\n", '
     double a = 2;
     b = 3;

--- a/tests/testthat/test-modspec.R
+++ b/tests/testthat/test-modspec.R
@@ -1,4 +1,4 @@
-# Copyright (C) 2013 - 2021  Metrum Research Group
+# Copyright (C) 2013 - 2024  Metrum Research Group
 #
 # This file is part of mrgsolve.
 #
@@ -722,4 +722,28 @@ test_that("Skip cpp dot check gh-1159", {
   code <- glue::glue(temp)
   
   expect_s4_class(mcode("cpp-dot-skip-4", code, compile = FALSE), "mrgmod")
+})
+
+test_that("variables in for loops aren't discovered", {
+  code <- '
+  $MAIN 
+  double a = 1.23;
+  int b = 2; 
+  bool c = true;
+  for(int i = 0; i < b; ++i) {
+    b = b + i;
+  }
+  for ( int j = 0; j == 10; ++j) {
+    a = a + b + 2;
+  }
+  '
+  mod <- mcode("test-modspec-ignore-for", code, compile = FALSE)
+  cpp <- as.list(mod)$cpp_variables
+  expect_equal(cpp$var, c("a", "b", "c"))
+  
+  bl <- modelparse(code, split = TRUE)
+  ans <- mrgsolve:::get_c_vars2(bl$MAIN, context = "unit")
+  expect_identical(ans$type, cpp$type)
+  expect_identical(ans$var, cpp$var)
+  expect_true(all(ans$context=="unit"))
 })


### PR DESCRIPTION
# Summary 

First, when the `autodec` plugin is invoked, mrgsolve discovers and declares variables that the user creates. This PR limits the scope of what is discovered by excluding any variable that has a type of the form `namespace::type` (e.g. `evt::ev`). 

EDIT: 
Discussion with @kyleam 

- Keep going with new code to parse out prefix from autodec discovery
- We'll continue to exclude `namespace::type` declarations
- We'll continue to narrow the autodec code to only work on variables that weren't declared by the user (no change in function)
- Going forward, tighten up autodec search to bypass _anything_ that has _any_ prefix; we'll do that in a stage or two
