### PR TITLE
Removes space from Rbuildignore

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -29,7 +29,7 @@ inst/project/.*[.]so$
 inst/models/.*[.]o$
 inst/models/.*[.]so$
 inst/models/.*[.]check$
-inst/maintenance  
+inst/maintenance
 src/.*[.]tar.gz$
 .*[.]tar.gz$
 img


### PR DESCRIPTION
This was causing `inst/maintenance` to be included in the package tarball. 

@seth127 alerted me to this. I also read in the file, trimmed whitespace, and re-wrote to make sure there wasn't anything else in there (there wasn't). 