### PR TITLE
General updates to Rd documentation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,7 @@ Description: Fast simulation from ordinary differential equation
     (ODE) based models typically employed in quantitative pharmacology and
     systems biology.
 License: GPL (>=2)
-URL: https://mrgsolve.org, https://github.com/metrumresearchgroup/mrgsolve
+URL: https://mrgsolve.org/docs, https://github.com/metrumresearchgroup/mrgsolve
 BugReports: 
     https://github.com/metrumresearchgroup/mrgsolve/issues
 Depends:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,7 @@ Description: Fast simulation from ordinary differential equation
     (ODE) based models typically employed in quantitative pharmacology and
     systems biology.
 License: GPL (>=2)
-URL: https://github.com/metrumresearchgroup/mrgsolve
+URL: https://mrgsolve.org, https://github.com/metrumresearchgroup/mrgsolve
 BugReports: 
     https://github.com/metrumresearchgroup/mrgsolve/issues
 Depends:

--- a/R/chain.R
+++ b/R/chain.R
@@ -86,7 +86,7 @@ req.mrgmod <- function(x,...) {
 #' 
 #' e <- ev(amt = 100, ii = 6, addl = 3, WT = 70, dose = amt)
 #' 
-#' out <- mod %>% carry_out(amt, dose, WT)
+#' out <- mod %>% ev(e) %>% carry_out(amt, dose, WT) %>% mrgsim()
 #' 
 #' head(out)
 #' 

--- a/R/chain.R
+++ b/R/chain.R
@@ -75,11 +75,11 @@ req.mrgmod <- function(x,...) {
 #' @param ... unquoted names of data items to copy into the simulated output.
 #' 
 #' @details
-#' There is also a `carry_out` argument to [mrgsim()] that can 
-#' be set to accomplish the same thing as a call to `carry_out` in 
-#' the pipeline.
+#' There is also a `carry_out` argument to [mrgsim()] that can be set to 
+#' accomplish the same thing as a call to `carry_out` in the pipeline.
 #' 
-#' `carry.out` and carry_out`.  Using the underscore version is now preferred.
+#' `carry.out` and `carry_out` both do the same thing; using the underscore 
+#' version is now preferred.
 #' 
 #' @md
 #' @export

--- a/R/chain.R
+++ b/R/chain.R
@@ -32,7 +32,7 @@
 #' 
 #' Note the difference between `req` and `Req`: the former only 
 #' selects compartments to appear in output while the latter selects both 
-#' compartments and captured items.  Also, when there are items are explicitly
+#' compartments and captured items.  Also, when there are items explicitly
 #' listed in `Req`, all other compartments or captured items not listed
 #' there are ignored.  But when compartments are selected with `req`
 #' all of the captured items are returned.  Remember that `req` is 
@@ -137,7 +137,7 @@ tscale <- function(x,value=1,...) {
 #' @param ... not used.
 #' 
 #' @details
-#' There is also a `obsonly` argument to [mrgsim()] that can 
+#' There is also an `obsonly` argument to [mrgsim()] that can 
 #' be set to accomplish the same thing as a call to `obsonly()` in 
 #' the pipeline.
 #' 

--- a/R/chain.R
+++ b/R/chain.R
@@ -1,4 +1,4 @@
-# Copyright (C) 2013 - 2019  Metrum Research Group
+# Copyright (C) 2013 - 2024  Metrum Research Group
 #
 # This file is part of mrgsolve.
 #
@@ -63,33 +63,33 @@ req.mrgmod <- function(x,...) {
   x
 }
 
-##' Select items to carry into simulated output
-##' 
-##' When items named in this function are found in the input data set (either 
-##' \code{\link{data_set}} or \code{\link{idata_set}}), they are copied
-##' into the simulated output.  Special items like \code{evid} or \code{amt} or
-##' the like are not copied from the data set per se, but they are copied from
-##' \code{datarecord} objects that are created during the simulation.
-##'
-##' @param x model object
-##' @param ... passed along
-##' 
-##' @details
-##' There is also a \code{carry.out} argument to \code{\link{mrgsim}} that can 
-##' be set to accomplish the same thing as a call to \code{carry_out} in 
-##' the pipeline.
-##' 
-##' \code{carry.out} and \code{carry_out}.  Using the underscore version is 
-##' now preferred.
-##' 
-##' @export
+#' Select items to carry into simulated output
+#' 
+#' When items named in this function are found in the input data set (either 
+#' [data_set()] or [idata_set()]), they are copied
+#' into the simulated output.  Special items like `evid` or `amt` or
+#' the like are not copied from the data set per se, but they are copied from
+#' `datarecord` objects that are created during the simulation.
+#'
+#' @param x model object.
+#' @param ... unquoted names of data items to copy into the simulated output.
+#' 
+#' @details
+#' There is also a `carry_out` argument to [mrgsim()] that can 
+#' be set to accomplish the same thing as a call to `carry_out` in 
+#' the pipeline.
+#' 
+#' `carry.out` and carry_out`.  Using the underscore version is now preferred.
+#' 
+#' @md
+#' @export
 carry_out <- function(x,...) {
   x@args[["carry_out"]] <- as_character_args(match.call()[-1])
   x
 }
 
-##' @export
-##' @rdname carry_out
+#' @export
+#' @rdname carry_out
 carry.out <- function(x,...) {
   x@args[["carry_out"]] <- as_character_args(match.call()[-1])
   x
@@ -119,18 +119,18 @@ tscale <- function(x,value=1,...) {
   x
 }
 
-##' Collect only observations in the simulated output
-##'
-##' @param x model object
-##' @param value the value for \code{obsonly}
-##' @param ... passed along
-##' 
-##' @details
-##' There is also a \code{obsonly} argument to \code{\link{mrgsim}} that can 
-##' be set to accomplish the same thing as a call to \code{obsonly} in 
-##' the pipeline.
-##' 
-##' @export
+#' Collect only observation records in the simulated output
+#'
+#' @param x model object.
+#' @param value the value for `obsonly`.
+#' @param ... not used.
+#' 
+#' @details
+#' There is also a `obsonly` argument to [mrgsim()] that can 
+#' be set to accomplish the same thing as a call to `obsonly()` in 
+#' the pipeline.
+#' 
+#' @export
 obsonly <- function(x,value=TRUE,...) {
   x@args[["obsonly"]] <- value
   x

--- a/R/chain.R
+++ b/R/chain.R
@@ -81,6 +81,15 @@ req.mrgmod <- function(x,...) {
 #' `carry.out` and `carry_out` both do the same thing; using the underscore 
 #' version is now preferred.
 #' 
+#' @examples
+#' mod <- mrgsolve::house()
+#' 
+#' e <- ev(amt = 100, ii = 6, addl = 3, WT = 70, dose = amt)
+#' 
+#' out <- mod %>% carry_out(amt, dose, WT)
+#' 
+#' head(out)
+#' 
 #' @md
 #' @export
 carry_out <- function(x,...) {

--- a/R/chain.R
+++ b/R/chain.R
@@ -16,34 +16,35 @@
 # along with mrgsolve.  If not, see <http://www.gnu.org/licenses/>.
 
 
-##' Request simulated output
-##' 
-##' Use this function to select, by name, either compartments or derived 
-##' variables that have been captured (see \code{\link{CAPTURE}}) into
-##' the simulated output.
-##'
-##' @param x model object
-##' @param ... unquoted names of compartments or tabled items
-##' 
-##' @details
-##' There is also a \code{Req} argument to \code{\link{mrgsim}} that can 
-##' be set to accomplish the same thing as a call to \code{Req} in 
-##' the pipeline.
-##' 
-##' Note the difference between \code{req} and \code{Req}: the former only 
-##' selects compartments to appear in output while the latter selects both 
-##' compartments and captured items.  Also, when there are items are explicitly
-##' listed in \code{Req}, all other compartments or captured items not listed
-##' there are ignored.  But when compartments are selected with \code{req}
-##' all of the captured items are returned.  Remember that \code{req} is 
-##' strictly for compartments.
-##' 
-##' @examples
-##' mod <- mrgsolve::house()
-##'
-##' mod %>% Req(CP,RESP) %>% ev(amt=1000) %>%  mrgsim
-##'
-##' @export
+#' Request simulated output
+#' 
+#' Use this function to select, by name, either compartments or derived 
+#' variables that have been captured (see [CAPTURE]) into
+#' the simulated output.
+#'
+#' @param x model object.
+#' @param ... unquoted names of compartments or tabled items.
+#' 
+#' @details
+#' There is also a `Req` argument to [mrgsim()] that can 
+#' be set to accomplish the same thing as a call to `Req` in 
+#' the pipeline.
+#' 
+#' Note the difference between `req` and `Req`: the former only 
+#' selects compartments to appear in output while the latter selects both 
+#' compartments and captured items.  Also, when there are items are explicitly
+#' listed in `Req`, all other compartments or captured items not listed
+#' there are ignored.  But when compartments are selected with `req`
+#' all of the captured items are returned.  Remember that `req` is 
+#' strictly for compartments.
+#' 
+#' @examples
+#' mod <- mrgsolve::house()
+#'
+#' mod %>% Req(CP,RESP) %>% ev(amt=1000) %>%  mrgsim()
+#'
+#' @md
+#' @export
 Req <- function(x,...) UseMethod("Req")
 
 #' @export
@@ -52,12 +53,12 @@ Req.mrgmod <- function(x,...) {
   x  
 }
 
-##' @rdname Req
-##' @export
+#' @rdname Req
+#' @export
 req <- function(x,...) UseMethod("req")
 
-##' @export
-##' @rdname Req
+#' @export
+#' @rdname Req
 req.mrgmod <- function(x,...) {
   x <- update_request(x,as.character(match.call()[-1]))
   x
@@ -104,25 +105,26 @@ carry.out <- function(x,...) {
   x
 }
 
-##' Re-scale time in the simulated output
-##'
-##' @param x model object
-##' @param value value by which time will be scaled
-##' @param ... passed along
-##' 
-##' @details
-##' There is also a \code{tscale} argument to \code{\link{mrgsim}} that can 
-##' be set to accomplish the same thing as a call to \code{tscale} in 
-##' the pipeline.
-##' 
-##' @examples
-##' # The model is in hours:
-##' mod <- mrgsolve::house()
-##' 
-##' # The output is in days:
-##' mod %>% tscale(1/24) %>% mrgsim
-##' 
-##' @export
+#' Re-scale time in the simulated output
+#'
+#' @param x model object.
+#' @param value value by which time will be scaled.
+#' @param ... not used.
+#' 
+#' @details
+#' There is also a `tscale` argument to [mrgsim()] that can 
+#' be set to accomplish the same thing as a call to `tscale` in 
+#' the pipeline.
+#' 
+#' @examples
+#' # The model is in hours:
+#' mod <- mrgsolve::house()
+#' 
+#' # The output is in days:
+#' mod %>% tscale(1/24) %>% mrgsim()
+#' 
+#' @md
+#' @export
 tscale <- function(x,value=1,...) {
   x@args[["tscale"]] <- value
   x
@@ -131,7 +133,7 @@ tscale <- function(x,value=1,...) {
 #' Collect only observation records in the simulated output
 #'
 #' @param x model object.
-#' @param value the value for `obsonly`.
+#' @param value use `TRUE` to collect and return observation records only.
 #' @param ... not used.
 #' 
 #' @details

--- a/R/class_ev.R
+++ b/R/class_ev.R
@@ -1,4 +1,4 @@
-# Copyright (C) 2013 - 2022  Metrum Research Group
+# Copyright (C) 2013 - 2024  Metrum Research Group
 #
 # This file is part of mrgsolve.
 #
@@ -25,7 +25,7 @@
 #' If an event object, return `data` slot; otherwise, call as.data.frame. This 
 #' is supposed to be optimized for handling event objects. 
 #' 
-#' @param x An R object. 
+#' @param x an R object. 
 #' 
 #' @noRd
 to_data_frame <- function(x) {
@@ -90,12 +90,13 @@ is.ev <- function(x) {
   inherits(x, "ev")  
 }
 
-##' dplyr verbs for event objects
-##' 
-##' @param .data the event object
-##' @param ... passed to the \code{dplyr} function
-##' @rdname ev_dplyr
-##' @export
+#' dplyr verbs for event objects
+#' 
+#' @param .data the event object.
+#' @param ... passed to the `dplyr` function.
+#' @rdname ev_dplyr
+#' @md
+#' @export
 mutate.ev <- function(.data, ...) {
   input_cols <- names(match.call(expand.dots=TRUE))
   .data@data <- as.data.frame(mutate(.data@data, ...))
@@ -124,15 +125,15 @@ mutate.ev <- function(.data, ...) {
   .data
 }
 
-##' @rdname ev_dplyr
-##' @export
+#' @rdname ev_dplyr
+#' @export
 select.ev <- function(.data, ...) {
   .data@data <- as.data.frame(dplyr::select(.data@data, ...))
   .data 
 }
 
-##' @rdname ev_dplyr
-##' @export
+#' @rdname ev_dplyr
+#' @export
 filter.ev <-  function(.data, ...) {
   .data@data <- as.data.frame(dplyr::filter(.data@data, ...))
   .data

--- a/R/class_mrgmod.R
+++ b/R/class_mrgmod.R
@@ -406,7 +406,7 @@ setMethod("project", "packmod", function(x,...) {
 })
 
 #' @rdname cmtn
-#' @param tag compartment name
+#' @param tag compartment name.
 #' @export
 setMethod("cmtn", "mrgmod", function(x,tag,...) {
   return(which(cmt(x)==tag))
@@ -434,9 +434,9 @@ CAPTUREI <- function(x) c(length(x@capture),x@Icap-1L)
 #' This is also the directory where the model is built, which could be the 
 #' value of [tempdir()].
 #'
-#' @param x model object
-#' @param short logical; if `TRUE`, `soloc`s will
-#'  be rendered  with a short path name
+#' @param x model object.
+#' @param short logical; if `TRUE`, `soloc`s will be rendered  with a short 
+#' path name.
 #' 
 #' @examples
 #' mod <- mrgsolve::house()
@@ -493,7 +493,7 @@ setMethod("names", "mrgmod", function(x) {
 #' 
 #' @param x a model object.
 #' @param deep if `TRUE`, extra information is returned in the output list
-#' (see details). 
+#' (see **Details**). 
 #' @param ... not used.
 #' 
 #' @details 

--- a/R/class_mrgmod.R
+++ b/R/class_mrgmod.R
@@ -379,7 +379,8 @@ as_pack_mod <- function(model, project, PACKAGE) {
 #' @param x any object
 #' 
 #' @examples
-#' is.mrgmod(house())
+#' mod <- mrgsolve::house()
+#' is.mrgmod(mod)
 #' 
 #' @return 
 #' `TRUE` if the object inherits from either `mrgmod` or `packmod` class.
@@ -847,7 +848,7 @@ all.equal.mrgmod <- function(target, current,...) {
 #' of outvar names is returned.
 #' 
 #' @examples
-#' mod <- house()
+#' mod <- mrgsolve::house()
 #' outvars(mod)
 #' 
 #' @md

--- a/R/class_mrgmod.R
+++ b/R/class_mrgmod.R
@@ -491,16 +491,21 @@ setMethod("names", "mrgmod", function(x) {
 
 #' Coerce a model object to list
 #' 
-#' @param x mrgmod object
-#' @param deep if `TRUE`, extra information is returned
+#' @param x a model object.
+#' @param deep if `TRUE`, extra information is returned in the output list
 #' (see details). 
-#' @param ... not used
+#' @param ... not used.
 #' 
 #' @details 
-#' If `deep` is `TRUE`, then the values for
-#' `trans`,`advan`, and `mindt` are
-#' returned as well as a summary of internal model 
-#' functions (with a call to `mrgsolve:::funset`).
+#' If `deep` is `TRUE`, then the values for `trans`, `advan`, and `mindt` are
+#' returned as well as a summary of internal model functions (with a call to 
+#' `mrgsolve:::funset()`).
+#' 
+#' @examples
+#' mod <- mrgsolve::house()
+#' l <- as.list(mod)
+#' 
+#' @return A named list containing formatted contents from `x`.
 #' 
 #' @section Slots:
 #' - `npar`: number of parameters

--- a/R/class_mrgmod.R
+++ b/R/class_mrgmod.R
@@ -1,4 +1,4 @@
-# Copyright (C) 2013 - 2022 Metrum Research Group
+# Copyright (C) 2013 - 2024 Metrum Research Group
 #
 # This file is part of mrgsolve.
 #

--- a/R/class_mrgmod.R
+++ b/R/class_mrgmod.R
@@ -836,9 +836,9 @@ all.equal.mrgmod <- function(target, current,...) {
 #' Outputs can include model compartments or variables defined in the model 
 #' that have been marked to `capture` in simulated output.
 #' 
-#' @param x mrgmod object
+#' @param x model object.
 #' @param unlist if `TRUE` then a character vector (rather than list) is 
-#' returned
+#' returned.
 #' 
 #' @return
 #' When `unlist` is `FALSE` (default) : a named list, with `cmt` showing names 
@@ -847,8 +847,8 @@ all.equal.mrgmod <- function(target, current,...) {
 #' of outvar names is returned.
 #' 
 #' @examples
-#' 
-#' outvars(mrgsolve::house())
+#' mod <- house()
+#' outvars(mod)
 #' 
 #' @md
 #' @export

--- a/R/class_mrgsims.R
+++ b/R/class_mrgsims.R
@@ -1,4 +1,4 @@
-# Copyright (C) 2013 - 2019  Metrum Research Group
+# Copyright (C) 2013 - 2024  Metrum Research Group
 #
 # This file is part of mrgsolve.
 #
@@ -44,21 +44,23 @@ setClass("batch_mrgsims",contains="mrgsims",
 )
 
 
-##' Check if an object is mrgsim output
-##' 
-##' @param x any object
-##' 
-##' @return \code{TRUE} if \code{x} inherits \code{mrgsims}.
-##' 
-##' @export
+#' Check if an object is mrgsims output
+#' 
+#' @param x any object.
+#' 
+#' @return `TRUE` if `x` inherits `mrgsims`.
+#' 
+#' @md
+#' @export
 is.mrgsims <- function(x) inherits(x,"mrgsims")
 
 
-##' Coerce an mrgsims object to list
-##' 
-##' @param x an mrgsims object
-##' @param ... not used
-##' @export
+#' Coerce an mrgsims object to list
+#' 
+#' @param x an mrgsims object.
+#' @param ... not used.
+#' @md
+#' @export
 setMethod("as.list", "mrgsims", function(x, ...) {
   to_get <- slotNames("mrgsims") 
   out <- vector("list",length(to_get))

--- a/R/class_rx.R
+++ b/R/class_rx.R
@@ -1,4 +1,4 @@
-# Copyright (C) 2013 - 2023  Metrum Research Group
+# Copyright (C) 2013 - 2024  Metrum Research Group
 #
 # This file is part of mrgsolve.
 #
@@ -15,80 +15,80 @@
 # You should have received a copy of the GNU General Public License
 # along with mrgsolve.  If not, see <http://www.gnu.org/licenses/>.
 
-##' @include class_ev.R
-##' @include events.R
+#' @include class_ev.R
+#' @include events.R
 NULL
 
-##' Create intervention objects from Rx input
-##' 
-##' See details below for Rx specification. Actual parsing is done
-##' by [parse_rx()]; this function can be used to debug Rx inputs.
-##' 
-##' @param x a model object or `character` Rx input. 
-##' @param y `character` Rx input; see details.
-##' @param df if `TRUE` then a data frame is returned.
-##' @param ... not used at this time.
-##' 
-##' @section Rx specification:
-##' 
-##' - The dose is found at the start of the string by sequential digits; this 
-##'   may be integer, decimal, or specified in scientific notation
-##' - Use `in` to identify the dosing compartment number; must be integer
-##' - Use `q` to identify the dosing interval; must be integer or 
-##'   decimal number (but not scientific notation)
-##' - Use `over` to indicate an infusion and its duration; integer or 
-##'   decimal number
-##' - Use `x` to indicate total number of doses; must be integer
-##' - Use `then` or `,` to separate dosing periods
-##' - Use `after` to insert a lag in the start of a period; integer or 
-##'   decimal number (but not scientific notation)
-##' - Use `&` to implement multiple doses at the same time
-##' 
-##' @return The method dispatched on model object (`mrgmod`) returns another
-##' model object.  The `character` method returns an event object.  The
-##' `parse_rx` function return a list named with arguments for the event 
-##' object constructor [ev()].
-##' 
-##' @examples
-##' # example("ev_rx")
-##' 
-##' ev_rx("100")
-##' 
-##' ev_rx("100 in 2")
-##' 
-##' ev_rx("100 q12 x 3")
-##' 
-##' ev_rx("100 over 2")
-##' 
-##' ev_rx("100 q 24 x 3 then 50 q12 x 2")
-##' 
-##' ev_rx("100 then 50 q 24 after 12")
-##' 
-##' ev_rx("100.2E-2 q4")
-##' 
-##' ev_rx("100 over 2.23")
-##' 
-##' ev_rx("100 q 12 x 3")
-##' 
-##' ev_rx("100 in 1 & 200 in 2") 
-##' 
-##' parse_rx("100 mg q 24 then 200 mg q12")
-##' 
-##' @md
-##' @rdname ev_rx
-##' @export
+#' Create intervention objects from Rx input
+#' 
+#' See details below for Rx specification. Actual parsing is done
+#' by [parse_rx()]; this function can be used to debug Rx inputs.
+#' 
+#' @param x a model object or `character` Rx input. 
+#' @param y `character` Rx input; see details.
+#' @param df if `TRUE` then a data frame is returned.
+#' @param ... not used at this time.
+#' 
+#' @section Rx specification:
+#' 
+#' - The dose is found at the start of the string by sequential digits; this 
+#'   may be integer, decimal, or specified in scientific notation
+#' - Use `in` to identify the dosing compartment number; must be integer
+#' - Use `q` to identify the dosing interval; must be integer or 
+#'   decimal number (but not scientific notation)
+#' - Use `over` to indicate an infusion and its duration; integer or 
+#'   decimal number
+#' - Use `x` to indicate total number of doses; must be integer
+#' - Use `then` or `,` to separate dosing periods
+#' - Use `after` to insert a lag in the start of a period; integer or 
+#'   decimal number (but not scientific notation)
+#' - Use `&` to implement multiple doses at the same time
+#' 
+#' @return The method dispatched on model object (`mrgmod`) returns another
+#' model object.  The `character` method returns an event object.  The
+#' `parse_rx` function return a list named with arguments for the event 
+#' object constructor [ev()].
+#' 
+#' @examples
+#' # example("ev_rx")
+#' 
+#' ev_rx("100")
+#' 
+#' ev_rx("100 in 2")
+#' 
+#' ev_rx("100 q12 x 3")
+#' 
+#' ev_rx("100 over 2")
+#' 
+#' ev_rx("100 q 24 x 3 then 50 q12 x 2")
+#' 
+#' ev_rx("100 then 50 q 24 after 12")
+#' 
+#' ev_rx("100.2E-2 q4")
+#' 
+#' ev_rx("100 over 2.23")
+#' 
+#' ev_rx("100 q 12 x 3")
+#' 
+#' ev_rx("100 in 1 & 200 in 2") 
+#' 
+#' parse_rx("100 mg q 24 then 200 mg q12")
+#' 
+#' @md
+#' @rdname ev_rx
+#' @export
 setGeneric("ev_rx", function(x,y,...) {
   standardGeneric("ev_rx")
 })
 
-##' @rdname ev_rx
-##' @export
+#' @rdname ev_rx
+#' @export
 setMethod("ev_rx", signature=c("mrgmod", "character"), function(x,y,...) {
   ev(x,ev_rx(y))
 })
 
-##' @rdname ev_rx
-##' @export
+#' @rdname ev_rx
+#' @export
 setMethod("ev_rx", signature=c("character","missing"), function(x, df = FALSE, 
                                                                 ...) {
   x <- parse_rx(x)
@@ -102,8 +102,8 @@ setMethod("ev_rx", signature=c("character","missing"), function(x, df = FALSE,
   return(x)
 })
 
-##' @rdname ev_rx
-##' @export
+#' @rdname ev_rx
+#' @export
 parse_rx <- function(x) {
   x <- strsplit(x, "then|,", perl = TRUE)[[1]]
   x <- trimws(x)

--- a/R/class_tgrid.R
+++ b/R/class_tgrid.R
@@ -113,9 +113,6 @@ as_deslist <- function(data, descol="ID") {
 #' simtime objects allow the user to specify simulation start and end times, 
 #' along with the simulation time step.
 #'
-#' @rdname tgrid
-#' @name tgrid
-#'
 #' @param x tgrid object.
 #' @param start simulation start time.
 #' @param end simulation end time.

--- a/R/class_tgrid.R
+++ b/R/class_tgrid.R
@@ -15,9 +15,9 @@
 # You should have received a copy of the GNU General Public License
 # along with mrgsolve.  If not, see <http://www.gnu.org/licenses/>.
 
-##' @export
-##' @rdname stime
-##' @keywords internal
+#' @export
+#' @rdname stime
+#' @keywords internal
 setClass("tgrid", slots=c(start  = "numeric", 
                           end    = "numeric", 
                           delta  = "numeric", 
@@ -30,44 +30,45 @@ setClass("tgrid", slots=c(start  = "numeric",
                         offset = 0,
                         scale  = 1))
 
-##' @export
-##' @rdname stime
+#' @export
+#' @rdname stime
 setClass("tgrids", slots=c(data="list"))
 
 
-##' Create a list of designs from a data frame
-##' 
-##' @param data input data set; see details
-##' @param descol character column name to be used for design groups
-##' 
-##' @details
-##' The input data set must have a column with the same name as the value 
-##' of \code{descol}.  Other column names should be \code{start} (the time 
-##' of the first observation), \code{end} (the time of the last observation), 
-##' \code{delta} (the time steps to take between \code{start} and \code{end}), 
-##' and \code{add} (other, ad-hoc times).  Note that \code{add} might be 
-##' a \code{list-column} to get a vector of times for each time grid object.
-##' 
-##' @return The function returns a list of \code{tgrid} objects, 
-##' one for each unique value found in \code{descol}.
-##' 
-##' @examples
-##' idata <- tibble::tibble(ID=1:4, end=seq(24,96,24), delta=6,
-##' add=list(c(122,124,135),c(111), c(99),c(88)))
-##' 
-##' idata <- dplyr::mutate(idata, GRP = ID %%2)
-##' 
-##' idata
-##' 
-##' l <- as_deslist(idata,"GRP")
-##' 
-##' l
-##' 
-##' lapply(l,stime)
-##' 
-##' lapply(as_deslist(idata, "ID"),stime)
-##' 
-##' @export
+#' Create a list of designs from a data frame
+#' 
+#' @param data input data set; see **Details**.
+#' @param descol character column name to be used for design groups.
+#' 
+#' @details
+#' The input data set must have a column with the same name as the value 
+#' of `descol`.  Other column names should be `start` (the time 
+#' of the first observation), `end` (the time of the last observation), 
+#' `delta` (the time steps to take between `start` and `end`), 
+#' and `add` (other, ad-hoc times).  Note that `add` might be 
+#' a `list-column` to get a vector of times for each time grid object.
+#' 
+#' @return The function returns a list of `tgrid` objects, 
+#' one for each unique value found in `descol`.
+#' 
+#' @examples
+#' idata <- tibble::tibble(ID=1:4, end=seq(24,96,24), delta=6,
+#' add=list(c(122,124,135),c(111), c(99),c(88)))
+#' 
+#' idata <- dplyr::mutate(idata, GRP = ID %%2)
+#' 
+#' idata
+#' 
+#' l <- as_deslist(idata,"GRP")
+#' 
+#' l
+#' 
+#' lapply(l,stime)
+#' 
+#' lapply(as_deslist(idata, "ID"),stime)
+#' 
+#' @md
+#' @export
 as_deslist <- function(data, descol="ID") {
   
   if(!is.data.frame(data)) {
@@ -209,32 +210,32 @@ setMethod("c", "tgrids", function(x,...,recursive=FALSE) {
 })
 
 
-##' @param e1 tgrid or tgrids object
-##' @param e2 numeric value
-##' 
-##' @name tgrid_+_numeric
-##' @docType methods
-##' @aliases +,tgrid,numeric-method
-##' @rdname tgrid_ops
+#' @param e1 tgrid or tgrids object
+#' @param e2 numeric value
+#' 
+#' @name tgrid_+_numeric
+#' @docType methods
+#' @aliases +,tgrid,numeric-method
+#' @rdname tgrid_ops
 setMethod("+", c("tgrid","numeric"), function(e1,e2) {
   e1@offset <- e1@offset + e2
   e1
 })
 
-##' @name tgrid_*_numeric
-##' @docType methods
-##' @aliases *,tgrid,numeric-method
-##' @rdname tgrid_ops
+#' @name tgrid_*_numeric
+#' @docType methods
+#' @aliases *,tgrid,numeric-method
+#' @rdname tgrid_ops
 setMethod("*", c("tgrid", "numeric"), function(e1,e2) {
   e1@scale <- e2
   e1
 })
 
 
-##' @rdname tgrid_ops
-##' @name tgrids_+_numeric
-##' @docType methods
-##' @aliases +,tgrids,numeric-method
+#' @rdname tgrid_ops
+#' @name tgrids_+_numeric
+#' @docType methods
+#' @aliases +,tgrids,numeric-method
 setMethod("+", c("tgrids","numeric"), function(e1,e2) {
   e1@data <- lapply(e1@data, function(x) {
     x@offset <- x@offset + e2
@@ -243,10 +244,10 @@ setMethod("+", c("tgrids","numeric"), function(e1,e2) {
   e1
 })
 
-##' @rdname tgrid_ops
-##' @name tgrids_*_numeric
-##' @docType methods
-##' @aliases *,tgrids,numeric-method
+#' @rdname tgrid_ops
+#' @name tgrids_*_numeric
+#' @docType methods
+#' @aliases *,tgrids,numeric-method
 setMethod("*", c("tgrids","numeric"), function(e1,e2) {
   e1@data <- lapply(e1@data, function(x) {
     x@scale <- e2
@@ -255,10 +256,10 @@ setMethod("*", c("tgrids","numeric"), function(e1,e2) {
   e1
 })
 
-##' @rdname tgrid
-##' @param object passed to show
-##' @export
-##' @keywords internal
+#' @rdname tgrid
+#' @param object passed to show
+#' @export
+#' @keywords internal
 setMethod("show", "tgrid", function(object) {
   x <- stime(object)
   min <- min(x)
@@ -272,8 +273,8 @@ setMethod("show", "tgrid", function(object) {
 })
 
 
-##' @export
-##' @rdname tgrid
+#' @export
+#' @rdname tgrid
 setMethod("show", "tgrids", function(object) {
   lapply(object@data, function(x) {
     show(x)

--- a/R/class_tgrid.R
+++ b/R/class_tgrid.R
@@ -1,4 +1,4 @@
-# Copyright (C) 2013 - 2020  Metrum Research Group
+# Copyright (C) 2013 - 2024  Metrum Research Group
 #
 # This file is part of mrgsolve.
 #
@@ -107,41 +107,42 @@ as_deslist <- function(data, descol="ID") {
   structure(out, descol=descol)
 }
 
-##' Create a simtime object
-##'
-##' simtime objects allow the user to specify simulation start and end times, 
-##' along with the simulation time step.
-##'
-##' @rdname tgrid
-##' @name tgrid
-##'
-##' @param x tgrid object
-##' @param start simulation start time
-##' @param end simulation end time
-##' @param delta simulation time step
-##' @param add addition simulation times
-##' @param .offset the resulting set of times will be adjusted by this amount
-##' @param .scale the resulting set of times will be scaled by this factor
-##' @param ... passed on to other methods
-##' @export
-##' @examples
-##'
-##' peak <- tgrid(0,6,0.2)
-##' sparse <- tgrid(0,24,4)
-##'
-##' day1 <- c(peak,sparse)
-##'
-##' design <- c(day1, day1+72, day1+240)
-##' 
-##' \dontrun{
-##' mod <- mrgsolve::house()
-##'
-##' out <- mod %>% ev(amt=1000, ii=24, addl=10) %>% mrgsim(tgrid=design)
-##'
-##' plot(out,CP~., type='b')
-##' }
+#' Create a simtime object
+#'
+#' simtime objects allow the user to specify simulation start and end times, 
+#' along with the simulation time step.
+#'
+#' @rdname tgrid
+#' @name tgrid
+#'
+#' @param x tgrid object.
+#' @param start simulation start time.
+#' @param end simulation end time.
+#' @param delta simulation time step.
+#' @param add addition simulation times.
+#' @param .offset the resulting set of times will be adjusted by this amount.
+#' @param .scale the resulting set of times will be scaled by this factor.
+#' @param ... not used.
+#'
+#' @examples
+#' peak <- tgrid(0, 6, 0.2)
+#' sparse <- tgrid(0, 24, 4)
+#'
+#' day1 <- c(peak, sparse)
+#'
+#' design <- c(day1, day1+72, day1+240)
+#' 
+#' \dontrun{
+#' mod <- mrgsolve::house()
+#'
+#' out <- mod %>% ev(amt=1000, ii=24, addl=10) %>% mrgsim(tgrid=design)
+#'
+#' plot(out, CP ~ time, type = 'b')
+#' }
+#' @md
+#' @export
 tgrid <-  function(start=0,end=24,delta=1,add=numeric(0),
-                   .offset=0, .scale=1,...) {
+                   .offset=0, .scale=1, ...) {
   new("tgrid", start=start, end=end, delta=delta, 
       add=add, offset=.offset, scale=.scale)
 }
@@ -173,19 +174,20 @@ render_time <- function(x) {
   times
 }
 
-##' @rdname tgrid
-##' @export
+#' @rdname tgrid
+#' @export
 setMethod("stime", "numeric", function(x,...) {
   sort(unique(x))
 })
 
-##' Operations with tgrid objects
-##' 
-##' @param x mrgmod object
-##' @param recursive not used
-##' @param ... passed along to other methods
-##' @rdname tgrid_ops
-##' @export
+#' Operations with tgrid objects
+#' 
+#' @param x a tgrid object.
+#' @param ... additional tgrid objects. 
+#' @param recursive not used.
+#' @rdname tgrid_ops
+#' @md
+#' @export
 setMethod("c", "tgrid", function(x,..., recursive=FALSE) {
   
   x <- c(list(x), list(...))
@@ -200,8 +202,8 @@ setMethod("c", "tgrid", function(x,..., recursive=FALSE) {
 })
 
 
-##' @rdname tgrid_ops
-##' @export
+#' @rdname tgrid_ops
+#' @export
 setMethod("c", "tgrids", function(x,...,recursive=FALSE) {
   do.call("c",c(x@data, list(...)))
 })
@@ -278,10 +280,3 @@ setMethod("show", "tgrids", function(object) {
     cat("--------\n")
   })
 })
-
-
-
-
-
-
-

--- a/R/data_set.R
+++ b/R/data_set.R
@@ -546,28 +546,29 @@ ev_days <- function(ev=NULL,days="",addl=0,ii=168,unit=c("hours", "days"),...) {
 }
 
 
-##' Insert observations into a data set
-##' 
-##' @param data a data set or event object
-##' @param times a vector of observation times
-##' @param unique `logical`; if `TRUE` then values for `time` are 
-##' dropped if they are found anywhere in `data`
-##' @param obs_pos determines sorting order for observations; use `-1` (default)
-##' to put observations first; otherwise, use large integer to ensure 
-##' observations are placed after doses
-##'
-##' @details
-##' Non-numeric columns will be dropped with a warning.
-##' 
-##' @return 
-##' A data frame with additional rows for added observation records.
-##' 
-##' @examples
-##' data <- expand.ev(amt = c(100, 200, 300))
-##' 
-##' expand_observations(data, times = seq(0, 48, 2))
-##' 
-##' @export
+#' Insert observations into a data set
+#' 
+#' @param data a data set or event object.
+#' @param times a vector of observation times.
+#' @param unique `logical`; if `TRUE` then values for `time` are 
+#' dropped if they are found anywhere in `data`.
+#' @param obs_pos determines sorting order for observations; use `-1` (default)
+#' to put observations first; otherwise, use large integer to ensure 
+#' observations are placed after doses.
+#'
+#' @details
+#' Non-numeric columns will be dropped with a warning.
+#' 
+#' @return 
+#' A data frame with additional rows for added observation records.
+#' 
+#' @examples
+#' data <- expand.ev(amt = c(100, 200, 300))
+#' 
+#' expand_observations(data, times = seq(0, 48, 2))
+#' 
+#' @md
+#' @export
 expand_observations <- function(data, times, unique = FALSE, obs_pos = -1L) {
   
   data <- As_data_set(data)

--- a/R/data_set.R
+++ b/R/data_set.R
@@ -67,15 +67,15 @@
 #' 
 #' `EVID` is an integer value specifying the ID of an event record. Values
 #' include: 
-#'   - `0`: observation
-#'   - `1`:  dose event, either bolus or infusion
-#'   - `2`: other-type event; in mrgsolve, this functions like an observation 
+#'   - 0: observation
+#'   - 1:  dose event, either bolus or infusion
+#'   - 2: other-type event; in mrgsolve, this functions like an observation 
 #'     record, but a discontinuity is created in the simulation at the time of 
 #'     the event (i.e., the ODE solver will stop and restart at the time of the 
 #'     event)
-#'  - `3`: reset the system 
-#'  - `4`: reset the system and dose
-#'  - `8`: replace the amount in a compartment
+#'  - 3: reset the system 
+#'  - 4: reset the system and dose
+#'  - 8: replace the amount in a compartment
 #'  
 #' For all `EVID` greater than `0`, a discontinuity is created in the
 #' simulation, as described for `EVID 2`.  
@@ -142,20 +142,20 @@ setMethod("data_set",c("mrgmod", "data.frame"), function(x,data,.subset=TRUE,.se
   return(x)
 })
 
-##' @rdname data_set
-##' @export
+#' @rdname data_set
+#' @export
 setMethod("data_set",c("mrgmod", "ANY"), function(x, data, ...) {
   return(data_set(x, as.data.frame(data), ...))
 })
 
-##' @rdname data_set
-##' @export
+#' @rdname data_set
+#' @export
 setMethod("data_set", c("mrgmod", "ev"), function(x, data, ...) {
   return(data_set(x, As_data_set(data), ...))
 })
 
-##' @rdname data_set
-##' @export
+#' @rdname data_set
+#' @export
 setMethod("data_set", c("mrgmod", "missing"), function(x, object, ...) {
   object <- data_hooks(object=object,envir=x@envir,param=param(x),...)
   return(data_set(x, as.data.frame(object) ,...))
@@ -350,39 +350,35 @@ setMethod("as_data_set", "data.frame", function(x, ...) {
   as_data_set(x, ...)
 })
 
-##' Replicate a list of events into a data set
-##' 
-##' @param l list of event objects
-##' @param idata an idata set (one ID per row)
-##' @param evgroup the character name of the column in \code{idata} 
-##' that specifies event object to implement
-##' @param join if \code{TRUE}, join \code{idata} to the data set 
-##' before returning.
-##' 
-##' 
-##' @examples
-##' ev1 <- ev(amt = 100)
-##' ev2 <- ev(amt = 300, rate = 100, ii = 12, addl = 10)
-##' 
-##' idata <- data.frame(ID = seq(10)) 
-##' idata$arm <- 1+(idata$ID %%2)
-##' 
-##' ev_assign(list(ev1, ev2), idata, "arm", join = TRUE)
-##' 
-##' @details
-##' \code{ev_assign} connects events in a list passed in as the
-##' \code{l} argument to values in the data set identified in the 
-##' \code{evgroup} argument.  For making assignments, the unique 
-##' values in the \code{evgroup} column are first sorted so that 
-##' the first sorted unique value in \code{evgroup} is assigned 
-##' to the first event in \code{l}, the second sorted value in 
-##' \code{evgroup} column is assigned to the second event in 
-##' \code{l}, and so on.  This is a change from previous behavior, 
-##' which did not sort the unique values in \code{evgroup} prior to 
-##' making the assignments. 
-##' 
-##' 
-##' @export
+#' Replicate a list of events into a data set
+#' 
+#' @param l list of event objects.
+#' @param idata an idata set (one ID per row).
+#' @param evgroup the character name of the column in `idata` that specifies 
+#' event object to implement.
+#' @param join if `TRUE`, join `idata` to the data set before returning.
+#' 
+#' @details
+#' `ev_assign()` connects events in a list passed in as the `l` argument to 
+#' values in the data set identified in the `evgroup` argument.  For making 
+#' assignments, the unique values in the `evgroup` column are first sorted so 
+#' that the first sorted unique value in `evgroup` is assigned to the first 
+#' event in `l`, the second sorted value in `evgroup` column is assigned to the 
+#' second event in `l`, and so on.  This is a change from previous behavior, 
+#' which did not sort the unique values in `evgroup` prior to making the 
+#' assignments. 
+#' 
+#' @examples
+#' ev1 <- ev(amt = 100)
+#' ev2 <- ev(amt = 300, rate = 100, ii = 12, addl = 10)
+#' 
+#' idata <- data.frame(ID = seq(10)) 
+#' idata$arm <- 1+(idata$ID %%2)
+#' 
+#' ev_assign(list(ev1, ev2), idata, "arm", join = TRUE)
+#' 
+#' @md
+#' @export
 ev_assign <- function(l, idata, evgroup, join = FALSE) {
   
   idata <- as.data.frame(idata)
@@ -442,10 +438,11 @@ ev_assign <- function(l, idata, evgroup, join = FALSE) {
   return(x)
 }
 
-##' @param ... used to pass arguments from \code{assign_ev}
-##' to \code{ev_assign}
-##' @rdname ev_assign
-##' @export
+#' @param ... used to pass arguments from `assign_ev()`.
+#' to `ev_assign()`.
+#' @rdname ev_assign
+#' @md
+#' @export
 assign_ev <- function(...) ev_assign(...)
 
 #' Schedule dosing events on days of the week

--- a/R/data_set.R
+++ b/R/data_set.R
@@ -448,49 +448,50 @@ ev_assign <- function(l, idata, evgroup, join = FALSE) {
 ##' @export
 assign_ev <- function(...) ev_assign(...)
 
-##' Schedule dosing events on days of the week
-##' 
-##' This function lets you schedule doses on specific 
-##' days of the week, allowing you to create dosing 
-##' regimens on Monday/Wednesday/Friday, or Tuesday/Thursday,
-##' or every other day (however you want to define that) etc.
-##' 
-##' @param ev an event object
-##' @param days comma- or space-separated character string of valid days of the
-##' the week (see details)
-##' @param addl additional doses to administer
-##' @param ii inter-dose interval; intended use is to keep this at the 
-##' default value
-##' @param unit time unit; the function can only currently handle hours or days
-##' @param ... event objects named by one the valid days of the week (see details)
-##' 
-##' @details
-##' Valid names of the week are: 
-##' 
-##' \itemize{
-##' \item \code{m} for Monday
-##' \item \code{t} for Tuesday
-##' \item \code{w} for Wednesday
-##' \item \code{th} for Thursday
-##' \item \code{f} for Friday
-##' \item \code{sa} for Saturday
-##' \item \code{s} for Sunday
-##' }
-##' 
-##' The whole purpose of this function is to schedule doses on specific
-##' days of the week, in a repeating weekly schedule.  Please do use caution 
-##' when changing \code{ii} from it's default value.
-##' 
-##' @examples
-##' 
-##' # Monday, Wednesday, Friday x 4 weeks
-##' ev_days(ev(amt=100), days="m,w,f", addl=3)
-##' 
-##' # 50 mg Tuesdays, 100 mg Thursdays x 6 months
-##' ev_days(t=ev(amt=50), th=ev(amt=100), addl=23)
-##' 
-##' 
-##' @export
+#' Schedule dosing events on days of the week
+#' 
+#' This function lets you schedule doses on specific 
+#' days of the week, allowing you to create dosing 
+#' regimens on Monday/Wednesday/Friday, or Tuesday/Thursday,
+#' or every other day (however you want to define that) etc.
+#' 
+#' @param ev an event object.
+#' @param days comma- or space-separated character string of valid days of the
+#' the week (see details).
+#' @param addl additional doses to administer.
+#' @param ii inter-dose interval; intended use is to keep this at the 
+#' default value.
+#' @param unit time unit; the function can only currently handle hours or days.
+#' @param ... event objects named by one the valid days of the week 
+#' (see **Details**).
+#' 
+#' @details
+#' Valid names of the week are: 
+#' - `m` for Monday
+#' - `t` for Tuesday
+#' - `w` for Wednesday
+#' - `th` for Thursday
+#' - `f` for Friday
+#' - `sa` for Saturday
+#' - `s` for Sunday
+#' 
+#' 
+#' The whole purpose of this function is to schedule doses on specific
+#' days of the week, in a repeating weekly schedule.  Please do use caution 
+#' when changing `ii` from it's default value.
+#' 
+#' @examples
+#' 
+#' # Monday, Wednesday, Friday x 4 weeks
+#' e1 <- ev(amt = 100)
+#' ev_days(e1, days="m,w,f", addl = 3)
+#' 
+#' # 50 mg Tuesdays, 100 mg Thursdays x 6 months
+#' e2 <- ev(amt = 50)
+#' ev_days(t = e2, th = e1, addl = 23)
+#' 
+#' @md
+#' @export
 ev_days <- function(ev=NULL,days="",addl=0,ii=168,unit=c("hours", "days"),...) {
   
   unit <- match.arg(unit)

--- a/R/data_set.R
+++ b/R/data_set.R
@@ -459,7 +459,7 @@ assign_ev <- function(...) ev_assign(...)
 #' @param ii inter-dose interval; intended use is to keep this at the 
 #' default value.
 #' @param unit time unit; the function can only currently handle hours or days.
-#' @param ... event objects named by one the valid days of the week 
+#' @param ... event objects named by one of the valid days of the week 
 #' (see **Details**).
 #' 
 #' @details
@@ -475,7 +475,7 @@ assign_ev <- function(...) ev_assign(...)
 #' 
 #' The whole purpose of this function is to schedule doses on specific
 #' days of the week, in a repeating weekly schedule.  Please do use caution 
-#' when changing `ii` from it's default value.
+#' when changing `ii` from its default value.
 #' 
 #' @examples
 #' 

--- a/R/data_set.R
+++ b/R/data_set.R
@@ -1,4 +1,4 @@
-# Copyright (C) 2013 - 2022  Metrum Research Group
+# Copyright (C) 2013 - 2024  Metrum Research Group
 #
 # This file is part of mrgsolve.
 #
@@ -15,90 +15,106 @@
 # You should have received a copy of the GNU General Public License
 # along with mrgsolve.  If not, see <http://www.gnu.org/licenses/>.
 
-##' Select and modify a data set for simulation
-##' 
-##' The input data set (\code{data_set}) is a data frame that specifies
-##' observations, model events, and / or parameter values for a population
+#' Select and modify a data set for simulation
+#' 
+#' The input data set (`data_set`) is a data frame that specifies
+#' observations, model events, and / or parameter values for a population
 ##' of individuals. 
-##'
-##' @param x model object
-##' @param data data set
-##' @param .subset an unquoted expression passed to 
-##' \code{dplyr::filter}; retain only certain rows in the data set
-##' @param .select passed to \code{dplyr::select}; retain only certain 
-##' columns in the data set; this should be the result of a call to 
-##' \code{dplyr::vars()}
-##' @param object character name of an object existing in \code{$ENV} 
-##' to use for the data set
-##' @param need passed to \code{\link{inventory}}
-##' @param ... passed along
-##' 
-##' @details
-##' Input data sets are \code{R} data frames that can include columns 
-##' with any valid name, however columns with selected names are 
-##' treated specially by \code{mrgsolve} and incorporated into the 
-##' simulation.
-##'
-##' \code{ID} specifies the subject ID and is required for every 
-##' input data set.
-##'
-##' When columns have the same name as parameters (\code{$PARAM} in 
-##' the model specification file), the values in those columns will 
-##' be used to update the corresponding parameter as the simulation 
-##' progresses.
-##'
-##' Input data set may include the following columns related to 
-##' PK dosing events: \code{time}, \code{cmt}, \code{amt}, \code{rate},
-##' \code{ii}, \code{addl}, \code{ss}.  Along with \code{ID}, \code{time} 
-##' is a required column in the input data set unless \code{$PRED} is in 
-##' use.  Upper case PK dosing column names including
-##' \code{TIME}, \code{CMT}, \code{AMT}, \code{RATE}, \code{II},
-##' \code{ADDL}, \code{SS} are also recognized.  However, an 
-##' error will be generated if a mix of upper case and lower
-##' case columns in this family are found.
-##'  
-##' \code{time} is the observation or event time, \code{cmt} 
-##' is the compartment number (see \code{\link{init}}), \code{amt} 
-##' is the dosing amount, \code{rate} is the infusion rate, 
-##' \code{ii} is the dosing interval, \code{addl} specifies 
-##' additional doses to administer, and \code{ss} is a flag 
-##' for steady state dosing.  These column names operate 
-##' similarly to other non-linear mixed effects modeling 
-##' software. 
-##' 
-##' An error will be generated when mrgsolve detects that the data set
-##' is not sorted by \code{time} within an individual.  
-##' 
-##' Only numeric data can be brought in to the problem.  
-##' Any non-numeric data columns will be dropped with warning.  
-##' See \code{\link{numerics_only}}, which is used 
-##' to prepare the data set. 
-##' 
-##' An error will be generated if any parameter columns in the 
-##' input data set contain \code{NA}.  Likewise, and error will 
-##' be generated if missing values are found in the following
-##' columns: \code{ID}, \code{time}/\code{TIME}, \code{rate}/\code{RATE}. 
-##'
-##' See \code{\link{exdatasets}} for different example data sets.
-##' 
-##' @seealso \code{\link{idata_set}}, \code{\link{ev}}, 
-##' \code{\link{valid_data_set}}, \code{\link{valid_idata_set}}
-##'
-##' @examples
-##'
-##' mod <- mrgsolve::house()
-##' 
-##' data <- expand.ev(ID=seq(3), amt=c(10, 20))
-##'
-##' mod %>% data_set(data, ID > 1) %>% mrgsim()
-##' 
-##' data(extran1)
-##' head(extran1)
-##' 
-##' mod %>% data_set(extran1) %>% mrgsim()
-##' mod %>% mrgsim(data = extran1)
-##' 
-##' @export
+#'
+#' @param x a model object. 
+#' @param data input data set as a data frame.
+#' @param .subset an unquoted expression passed to 
+#' [dplyr::filter()]; retain only certain rows in the data set
+#' @param .select passed to [dplyr::select()]; retain only certain 
+#' columns in the data set; this should be the result of a call to 
+#' [dplyr::vars()].
+#' @param object character name of an object existing in `$ENV` 
+#' to use for the data set.
+#' @param need passed to [inventory()].
+#' @param ... other arguments passed along when `object` is a function.
+#' 
+#' @details
+#' Input data sets are `R` data frames that can include columns 
+#' with any valid name, however columns with selected names are 
+#' treated specially by mrgsolve and incorporated into the 
+#' simulation.
+#'
+#' `ID` specifies the subject ID and is required for every 
+#' input data set.
+#'
+#' When columns have the same name as parameters (`$PARAM` or `$INPUT` in 
+#' the model specification file), the values in those columns will 
+#' be used to update the corresponding parameter as the simulation 
+#' progresses.
+#'
+#' Input data set may include the following columns related to 
+#' PK dosing events: `TIME`, `CMT`, `AMT`, `RATE`, `II`, `ADDL`, `SS`.  
+#' Both `ID` and `TIME` are required columns in the input data set unless 
+#' `$PRED` is in use.  Lower case PK dosing column names including
+#' `time`, `cmt`, `amt`, `rate`, `ii`, `addl`, `ss` are also recognized.  
+#' However, an error will be generated if a mix of both upper case and lower
+#' case columns in this family are found. Use the functions [lctran()] and 
+#' [uctran()] to convert between upper and lower case naming for these 
+#' data items.
+#'  
+#' `TIME` is the observation or event time, `CMT` is the compartment number 
+#' (see [init()]), `AMT` is the dosing amount, `RATE` is the infusion rate, 
+#' `II` is the dosing interval, `ADDL` specifies additional doses to 
+#' administer, and `ss` is a flag indicating that the system should be advanced 
+#' to a pharmacokinetic steady state prior to administering the dose.  These 
+#' column names operate similarly to other non-linear mixed effects modeling 
+#' software. 
+#' 
+#' `EVID` is an integer value specifying the ID of an event record. Values
+#' include: 
+#'   - `0`: observation
+#'   - `1`:  dose event, either bolus or infusion
+#'   - `2`: other-type event; in mrgsolve, this functions like an observation 
+#'     record, but a discontinuity is created in the simulation at the time of 
+#'     the event (i.e., the ODE solver will stop and restart at the time of the 
+#'     event)
+#'  - `3`: reset the system 
+#'  - `4`: reset the system and dose
+#'  - `8`: replace the amount in a compartment
+#'  
+#' For all `EVID` greater than `0`, a discontinuity is created in the
+#' simulation, as described for `EVID 2`.  
+#'  
+#' An error will be generated when mrgsolve detects that the data set
+#' is not sorted by `time` within an individual. mrgsolve does **not** allow time
+#' to be reset to zero on records where `EVID` is set to 4 (reset and dose).
+#' 
+#' Only numeric data can be brought in to the problem. Any non-numeric data 
+#' columns will be dropped with warning. See [numerics_only()], which is used 
+#' to prepare the data set. 
+#' 
+#' An error will be generated if any parameter columns in the 
+#' input data set contain missing values (`NA`). Likewise, and error will 
+#' be generated if missing values are found in the following
+#' columns: `ID`, `time`/`TIME`, `rate`/`RATE`. 
+#'
+#' See [exdatasets] for several example data sets that are provided by 
+#' mrgsolve.
+#' 
+#' @seealso [idata_set()], [ev()], [valid_data_set()], [valid_idata_set()], 
+#' [lctran()], [uctran()].
+#'
+#' @examples
+#'
+#' mod <- mrgsolve::house()
+#' 
+#' data <- expand.ev(ID = seq(3), amt = c(10, 20))
+#'
+#' mod %>% data_set(data, ID > 1) %>% mrgsim()
+#' 
+#' data(extran1)
+#' head(extran1)
+#' 
+#' mod %>% data_set(extran1) %>% mrgsim()
+#' mod %>% mrgsim(data = extran1)
+#' 
+#' @md
+#' @export
 setGeneric("data_set", function(x,data,...) {
   standardGeneric("data_set")
 })

--- a/R/data_set.R
+++ b/R/data_set.R
@@ -183,13 +183,14 @@ setMethod("data_set", c("mrgmod", "missing"), function(x, object, ...) {
 #' If both lower and upper case versions of the name are present in the data 
 #' frame, no changes will be made. 
 #' 
-#' @param data a data set with nmtran-like format.
+#' @param data a data set with nmtran-like format or an event object.
 #' @param warn if `TRUE`, a warning will be issued when there are both upper
 #' and lower case versions of any nmtran-like column in the data frame.
 #' @param ... for potential future use.
 #' 
 #' @return 
-#' A data frame or event object with possibly renamed columns.
+#' A data frame or event object, with column names possibly converted to upper
+#' or lower case.
 #' 
 #' @examples
 #' data <- data.frame(TIME = 0, AMT = 5, II = 24, addl = 2, WT = 80)
@@ -204,9 +205,6 @@ setMethod("data_set", c("mrgmod", "missing"), function(x, object, ...) {
 #' # warning
 #' data <- data.frame(TIME = 1, time = 2, CMT = 5)
 #' lctran(data)
-#' 
-#' @return 
-#' The input data set, with select columns made lower case.
 #' 
 #' @md
 #' @export

--- a/R/env.R
+++ b/R/env.R
@@ -1,4 +1,4 @@
-# Copyright (C) 2013 - 2019  Metrum Research Group
+# Copyright (C) 2013 - 2024  Metrum Research Group
 #
 # This file is part of mrgsolve.
 #
@@ -16,33 +16,34 @@
 # along with mrgsolve.  If not, see <http://www.gnu.org/licenses/>.
 
 
-##' Re-evaluate the code in the ENV block
-##' 
-##' The \code{$ENV} block is a block of R code that can 
-##' realize any sort of R object that might be used in running 
-##' a model.
-##' 
-##' @seealso \code{\link{env_get}}, \code{\link{env_ls}}
-##' 
-##' @param x model object
-##' @param seed passed to \code{\link{set.seed}} if a numeric value is supplied
-##' 
-##' @export
+#' Re-evaluate the code in the ENV block
+#' 
+#' The `$ENV` block is a block of R code that can realize any sort of R object 
+#' that might be used in running a model.
+#' 
+#' @seealso [env_get()], [env_ls()]
+#' 
+#' @param x a model object.
+#' @param seed passed to [set.seed()] if a numeric value is supplied.
+#' 
+#' @md
+#' @export
 env_eval <- function(x,seed=NULL) {
   if(is.numeric(seed)) set.seed(seed)
   eval_ENV_block(x=x@envir$.code,where=project(x),envir=x@envir)
   return(invisible(x))
 }
 
-##' List objects in the model environment
-##' 
-##' Each model keeps an internal environment that allows the user 
-##' to carry any \code{R} object along.  Objects are coded in \code{$ENV}.
-##' 
-##' @param x model object
-##' @param ... passed to \code{\link{ls}}
-##' 
-##' @export
+#' List objects in the model environment
+#' 
+#' Each model keeps an internal environment that allows the user 
+#' to carry any `R` object along.  Objects are coded in `$ENV`.
+#' 
+#' @param x amodel object.
+#' @param ... passed to [ls()].
+#' 
+#' @md
+#' @export
 env_ls <- function(x,...) {
   objects <- ls(x@envir,...)
   cl <- sapply(objects,function(o) {
@@ -53,12 +54,13 @@ env_ls <- function(x,...) {
   arrange__(ans, .dots=c("class"))
 }
 
-##' Return model environment
-##' 
-##' @param x model object
-##' @param tolist should the environment be coerced to \code{list}?
-##' 
-##' @export
+#' Return model environment
+#' 
+#' @param x a model object.
+#' @param tolist should the environment be coerced to `list`?
+#' 
+#' @md
+#' @export
 env_get <- function(x,tolist=TRUE) {
   if(tolist) {
     return(as.list(x@envir))  
@@ -67,19 +69,20 @@ env_get <- function(x,tolist=TRUE) {
   }
 }
 
-##' @rdname env_get
-##' @export
+#' @rdname env_get
+#' @export
 env_get_env <- function(x) {
   x@envir 
 }
 
-##' Update objects in model environment
-##' 
-##' @param .x model object
-##' @param .dots list of objects to updated
-##' @param ... objects to update
-##' 
-##' @export
+#' Update objects in model environment
+#' 
+#' @param .x a model object.
+#' @param .dots list of objects to updated.
+#' @param ... objects to update.
+#' 
+#' @md
+#' @export
 env_update <- function(.x,...,.dots=list()) {
   right <- c(list(...),.dots)
   left <- as.list(.x@envir)
@@ -87,16 +90,17 @@ env_update <- function(.x,...,.dots=list()) {
   return(invisible(.x))
 }
 
-##' Run the model cama function
-##' 
-##' @param mod model object
-##' @param fn function name
-##' @param ... passed to update
-##' 
-##' @details \code{sah-mah}
-##' 
-##' @keywords internal
-##' @export
+#' Run the model cama function
+#' 
+#' @param mod a model object.
+#' @param fn function name.
+#' @param ... passed to update.
+#' 
+#' @details `sah-mah`
+#' 
+#' @keywords internal
+#' @md
+#' @export
 cama <- function(mod,fn="cama",...) {
   stop("this function is deprecated.")
   # object_exists(fn, mod@envir, "function", inherits=FALSE)

--- a/R/env.R
+++ b/R/env.R
@@ -39,7 +39,7 @@ env_eval <- function(x,seed=NULL) {
 #' Each model keeps an internal environment that allows the user 
 #' to carry any `R` object along.  Objects are coded in `$ENV`.
 #' 
-#' @param x amodel object.
+#' @param x a model object.
 #' @param ... passed to [ls()].
 #' 
 #' @md

--- a/R/events.R
+++ b/R/events.R
@@ -554,14 +554,13 @@ ev_repeat <- function(x, n, wait = 0, as.ev = FALSE) {
 #' Use this function when you want to schedule two or more event objects in time
 #' according the dosing interval (`ii`) and additional doses (`addl`).
 #' 
-#' @param ... Event objects or numeric arguments named `wait` or `ii` to 
-#' implement a period of no-dosing activity in the sequence (see details).
-#' @param ID Numeric vector of subject IDs.
-#' @param .dots A list of event objects that replaces `...`.
-#' @param id Deprecated; use `ID`.
+#' @param ... event objects or numeric arguments named `wait` or `ii` to 
+#' implement a period of no-dosing activity in the sequence (see **Details**).
+#' @param ID numeric vector of subject IDs.
+#' @param .dots a list of event objects that replaces `...`.
+#' @param id deprecated; use `ID`.
 #' 
 #' @details
-#' 
 #' Use the generic [seq()] when the first argument is an event object.  If a 
 #' waiting period (`wait` or `ii`) is the first event, you will need to use 
 #' [ev_seq()].  When an event object has multiple rows, the end time for that 
@@ -570,7 +569,7 @@ ev_repeat <- function(x, n, wait = 0, as.ev = FALSE) {
 #' 
 #' The doses for the next event line start after all of the doses from the 
 #' previous event line plus one dosing interval from the previous event line 
-#' (see examples).  
+#' (see **Examples**).  
 #' 
 #' When numerics named `wait` or `ii` are mixed in with the event objects, 
 #' a period with no dosing activity is incorporated into the sequence,
@@ -595,10 +594,9 @@ ev_repeat <- function(x, n, wait = 0, as.ev = FALSE) {
 #' warning if you use `.ii`. Please use `ii` instead.
 #' 
 #' Values for `time` in any event object act like a prefix time spacer wherever 
-#' that event occurs in the event sequence (see examples).
+#' that event occurs in the event sequence (see **Examples**).
 #' 
 #' @examples
-#' 
 #' e1 <- ev(amt = 100, ii = 12, addl = 1)
 #' 
 #' e2 <- ev(amt = 200)

--- a/R/events.R
+++ b/R/events.R
@@ -198,16 +198,30 @@ setMethod("ev", "ev", function(x, realize_addl = FALSE, ...) {
 
 #' Coerce an object to class ev
 #' 
+#' Use this function to convert a data frame to an event object.
+#' 
 #' @param x an object to coerce.
-#' @param keep_id if `TRUE`, `ID` column is retained if it exists.
+#' @param keep_id if `TRUE`, ID column is retained if it exists.
 #' @param clean if `TRUE`, only dosing or ID information is retained in
 #' the result.
 #' @param ... not used.
 #' 
+#' @details
+#' If `CMT` (or `cmt`) is missing from the input, it will be set to 1
+#' in the event object.
+#' 
+#' If `TIME` (or `time`) is missing from the input, it will be set to 
+#' 0 in the event object.
+#' 
+#' If `EVID` (or `evid`) is missing from the input, it will be set to 
+#' 1 in the event object.
+#' 
 #' @examples
-#' data <- data.frame(amt = 100) 
+#' data <- data.frame(AMT = 100) 
 #' 
 #' as.ev(data)
+#' 
+#' as.ev(data, clean = TRUE)
 #' 
 #' @return 
 #' An object with class ev.
@@ -491,6 +505,13 @@ ev_rep <- function(x, ID = 1, n = NULL, wait = 0, as.ev = FALSE, id = NULL) {
 #' 
 #' @return 
 #' See `as.ev` argument.
+#' 
+#' @examples
+#' e1 <- ev(amt = 100, ii = 24, addl = 20)
+#' e4 <- ev_repeat(e1, n = 4, wait = 168)
+#' mod <- mrgsolve::house()
+#' out <- mrgsim(mod, events = e4, end = 3200)
+#' plot(out, "CP")
 #' 
 #' @md
 #' @export

--- a/R/events.R
+++ b/R/events.R
@@ -198,11 +198,11 @@ setMethod("ev", "ev", function(x, realize_addl = FALSE, ...) {
 
 #' Coerce an object to class ev
 #' 
-#' @param x An object to coerce.
-#' @param keep_id If `TRUE`, `ID` column is retained if it exists.
-#' @param clean If `TRUE`, only dosing or ID information is retained in
+#' @param x an object to coerce.
+#' @param keep_id if `TRUE`, `ID` column is retained if it exists.
+#' @param clean if `TRUE`, only dosing or ID information is retained in
 #' the result.
-#' @param ... Not used.
+#' @param ... not used.
 #' 
 #' @examples
 #' data <- data.frame(amt = 100) 
@@ -437,14 +437,14 @@ add.ev <- function(e1, e2) {
 #' An event sequence can be replicated a certain number of
 #' times in a certain number of IDs.
 #' 
-#' @param x event object
-#' @param ID numeric vector if IDs
-#' @param n passed to \code{\link{ev_repeat}}
-#' @param wait passed to \code{\link{ev_repeat}}
-#' @param as.ev if \code{TRUE} an event object is returned
-#' @param id deprecated; use \code{ID} instead
+#' @param x event object.
+#' @param ID numeric vector if IDs.
+#' @param n passed to [ev_repeat()].
+#' @param wait passed to [ev_repeat()].
+#' @param as.ev if `TRUE` an event object is returned.
+#' @param id deprecated; use `ID` instead.
 #' 
-#' @seealso \code{\link{ev_repeat}}
+#' @seealso [ev_repeat()]
 #' 
 #' @examples
 #' 
@@ -454,8 +454,9 @@ add.ev <- function(e1, e2) {
 #' 
 #' @return
 #' A single data.frame or event object as 
-#' determined by the value of \code{as.ev}.
+#' determined by the value of [as.ev()].
 #' 
+#' @md
 #' @export
 ev_rep <- function(x, ID = 1, n = NULL, wait = 0, as.ev = FALSE, id = NULL) {
   if(!missing(id)) {
@@ -482,15 +483,16 @@ ev_rep <- function(x, ID = 1, n = NULL, wait = 0, as.ev = FALSE, id = NULL) {
 
 #' Repeat a block of dosing events
 #' 
-#' @param x event object or dosing data frame
-#' @param n number of times to repeat
-#' @param wait time to wait between repeats
-#' @param as.ev if \code{TRUE}, an event object is
-#' returned; otherwise a data.frame is returned
+#' @param x event object or dosing data frame.
+#' @param n number of times to repeat.
+#' @param wait time to wait between repeats.
+#' @param as.ev if `TRUE`, an event object is returned; otherwise a data.frame 
+#' is returned.
 #' 
 #' @return 
-#' See \code{as.ev} argument.
+#' See `as.ev` argument.
 #' 
+#' @md
 #' @export
 ev_repeat <- function(x, n, wait = 0, as.ev = FALSE) {
   if(!inherits(x, c("data.frame", "ev"))) {

--- a/R/generics.R
+++ b/R/generics.R
@@ -98,13 +98,23 @@ unloadso <- function(x,...) UseMethod("unloadso")
 ##' 
 setGeneric("stime", function(x,...) standardGeneric("stime"))
 
-##' Get model random effect variances and covariances
-##'
-##' @param x model object
-##' @param ... passed along
-##'
-##' @export
-##' @rdname revar
+#' Get model random effect variances and covariances
+#' 
+#' Use this function to extract both OMEGA and SIGMA matrices from a 
+#' model object. Typical use is for display on the R console.
+#'
+#' @param x model object.
+#' @param ... passed along.
+#' 
+#' @return A named list containing `omega` and `sigma` matrices.
+#' 
+#' @examples
+#' mod <- mrgsolve::house()
+#' revar(mod)
+#' 
+#' @rdname revar
+#' @md
+#' @export
 setGeneric("revar", function(x,...) standardGeneric("revar"))
 
 ##' Return the code blocks from a model specification file

--- a/R/generics.R
+++ b/R/generics.R
@@ -1,4 +1,4 @@
-# Copyright (C) 2013 - 2020  Metrum Research Group
+# Copyright (C) 2013 - 2024  Metrum Research Group
 #
 # This file is part of mrgsolve.
 #
@@ -15,15 +15,17 @@
 # You should have received a copy of the GNU General Public License
 # along with mrgsolve.  If not, see <http://www.gnu.org/licenses/>.
 
-##' Get the compartment number from a compartment name
-##'
-##' @param x model object
-##' @param ... passed along
-##'
-##' @examples
-##' mod <- mrgsolve::house()
-##' mod %>% cmtn("CENT")
-##' @export
+#' Get the compartment number from a compartment name
+#'
+#' @param x model object.
+#' @param ... not used.
+#'
+#' @examples
+#' mod <- mrgsolve::house()
+#' cmtn(mod, "CENT")
+#' 
+#' @md
+#' @export
 setGeneric("cmtn", function(x,...) standardGeneric("cmtn"))
 
 #' Print model code to the console
@@ -37,6 +39,7 @@ setGeneric("cmtn", function(x,...) standardGeneric("cmtn"))
 #' @param ... not used.
 #' @return `NULL` is returned invisibly when `raw` is `FALSE`; when `raw` is 
 #' set to `TRUE`, the model code is returned as a character vector.
+#' @md
 #' @export
 setGeneric("see", function(x,...) standardGeneric("see"))
 

--- a/R/generics.R
+++ b/R/generics.R
@@ -43,62 +43,67 @@ setGeneric("cmtn", function(x,...) standardGeneric("cmtn"))
 #' @export
 setGeneric("see", function(x,...) standardGeneric("see"))
 
-##' Load the model shared object
-##' 
-##' Once the model is compiled, the model object can be used to re-load
-##' the model shared object (the compiled code underlying the mode) when 
-##' the simulation is to be done in a different R process. 
-##'
-##' @param x the model object
-##' @param ... not used
-##' 
-##' @return The model object (invisibly).
-##' 
-##' 
-##' @details
-##' The `loadso` function most frequently needs to be used when parallelizing
-##' simulations across worker nodes.  The model can be run after calling 
-##' `loadso`, without requiring that it is re-compiled on worker nodes. It is 
-##' likely required that the model is built (and the shared object stored) in 
-##' a local directory off of the working R directory (see the second example).
-##' 
-##' @examples
-##' 
-##' \dontrun{ 
-##'   mod <- mread("pk1", modlib())
-##'   loadso(mod)
-##'   
-##'   mod2 <- mread("pk2", modlib(), soloc = "build")
-##'   loadso(mod2)
-##' }
-##' 
-##' @export
+#' Load the model shared object
+#' 
+#' Once the model is compiled, the model object can be used to re-load
+#' the model shared object (the compiled code underlying the mode) when 
+#' the simulation is to be done in a different R process. 
+#'
+#' @param x a model object.
+#' @param ... not used.
+#' 
+#' @return The model object (invisibly).
+#' 
+#' 
+#' @details
+#' The `loadso` function most frequently needs to be used when parallelizing
+#' simulations across worker nodes.  The model can be run after calling 
+#' `loadso`, without requiring that it is re-compiled on worker nodes. It is 
+#' likely required that the model is built (and the shared object stored) in 
+#' a local directory off of the working R directory (see the second example).
+#' 
+#' @examples
+#' \dontrun{ 
+#'   mod <- mread("pk1", modlib())
+#'   loadso(mod)
+#'   
+#'   mod2 <- mread("pk2", modlib(), soloc = "build")
+#'   loadso(mod2)
+#' }
+#' 
+#' @md
+#' @export
 loadso <- function(x,...) UseMethod("loadso")
 unloadso <- function(x,...) UseMethod("unloadso")
 
-##' Get the times at which the model will be evaluated
-##'
-##' @name stime
-##'
-##' @param x object of class mrgmod
-##' @param ... passed on
-##' @return a sorted vector of unique times
-##' @details
-##' Simulation times include the sequence of times created from 
-##' \code{start}, \code{end}, and \code{delta} and the vector of times
-##' found in \code{add}.  Making \code{end} negative will omit any 
-##' \code{start} / \code{end} / \code{delta} sequence.  Negative values 
-##' are discarded from the result.
-##' @export
-##' @examples
-##'
-##' ## example("stime", package="mrgsolve")
-##'
-##' mod <- mrgsolve::house(end=12, delta=2, add=c(11,13,15))
-##'
-##' stime(mod)
-##' 
-##' 
+#' Get the times at which the model will be evaluated
+#'
+#' @name stime
+#'
+#' @param x a model object or a mrgsims object.
+#' @param ... not used.
+#' 
+#' @return A sorted vector of unique simulation times from the time grid in 
+#' the model object.
+#' 
+#' @details
+#' Simulation times include the sequence of times created from 
+#' `start`, `end`, and `delta` and the vector of times found in `add`.  
+#' 
+#' Making `end` negative (e.g. -1) will omit the `start-end-delta`
+#' sequence.  Negative values are discarded from the result.
+#' 
+#' @examples
+#' ## example("stime", package="mrgsolve")
+#'
+#' mod <- mrgsolve::house(end = 12, delta = 2, add = c(11,13,15))
+#'
+#' stime(mod)
+#' 
+#' update(mod, end = -1) %>% stime()
+#' 
+#' @md
+#' @export
 setGeneric("stime", function(x,...) standardGeneric("stime"))
 
 #' Get model random effect variances and covariances

--- a/R/generics.R
+++ b/R/generics.R
@@ -26,13 +26,18 @@
 ##' @export
 setGeneric("cmtn", function(x,...) standardGeneric("cmtn"))
 
-##' Print model code to the console
-##'
-##' @param x model object
-##' @param raw return the raw code
-##' @param ... passed along
-##' @return invisible NULL
-##' @export
+#' Print model code to the console
+#' 
+#' This is a simple way to display the model code on the R console using 
+#' the model object. The `raw` argument will return the model code as a 
+#' character vector.
+#' 
+#' @param x model object. 
+#' @param raw return the raw code.
+#' @param ... not used.
+#' @return `NULL` is returned invisibly when `raw` is `FALSE`; when `raw` is 
+#' set to `TRUE`, the model code is returned as a character vector.
+#' @export
 setGeneric("see", function(x,...) standardGeneric("see"))
 
 ##' Load the model shared object

--- a/R/idata_set.R
+++ b/R/idata_set.R
@@ -1,4 +1,4 @@
-# Copyright (C) 2013 - 2020  Metrum Research Group
+# Copyright (C) 2013 - 2024  Metrum Research Group
 #
 # This file is part of mrgsolve.
 #
@@ -17,76 +17,76 @@
 
 
 
-##' Select and modify a idata set for simulation
-##' 
-##' The individual data set (\code{idata_set}) is a data frame with one 
-##' row for each individual in a population, specifying parameters and 
-##' other individual-level data.
-##'
-##' @param x model object
-##' @param data a data set that can be coerced to data.frame
-##' @param object character name of an object existing in \code{$ENV} 
-##' to use for the data set
-##' @param .subset an unquoted expression passed to 
-##' \code{dplyr::filter}; retain only certain rows in the data set
-##' @param .select passed to \code{dplyr::select}; retain only certain 
-##' columns in the data set; this should be the result of a call to 
-##' \code{dplyr::vars()}
-##' @param need passed to \code{\link{inventory}}
-##' @param ... passed along
-##' 
-##' @details
-##' The \code{idata_set} is a data.frame that specifies individual-level 
-##' data for the problem.  An  \code{ID} column is required and there 
-##' can be no more than one row in the data frame for each individual.  
-##' 
-##' In most cases, the columns in the \code{idata_set} have the same names
-##' as parameters in the \code{\link{param}} list.  When this is the case, 
-##' the parameter set is updated as the simulation proceeds once at the 
-##' start of each individual.  The `idata_set` can also be used to 
-##' set initial conditions for each individual: for a compartment called
-##' \code{CMT}, make a column in \code{idata_set} called \code{CMT_0} and 
-##' make the value the desired initial value for that compartment.  Note that 
-##' this initial condition will be over-ridden if you also set the \code{CMT_0} 
-##' in \code{$MAIN}.
-##' 
-##' The most common application of \code{idata_set} is to specify a population
-##' or batch of simulations to do.  We commonly use \code{idata_set} with an 
-##' event object (see \code{\link{ev}}).  In that case, the event gets applied
-##' to each individual in the \code{\link{idata_set}}.  
-##' 
-##' It is also possible to provide both a \code{data_set} and a \code{idata_set}.  
-##' In this case, the \code{idata_set} is used as a parameter lookup for \code{IDs}
-##' found in the \code{data_set}.  Remember in this case, it is the \code{data_set}
-##' (not the \code{idata_set}) that determines the number of individuals in the
-##' simulation.
-##' 
-##' An error will be generated if any parameter columns in the 
-##' input idata set contain \code{NA}.  
-##'  
-##' @examples
-##' mod <- mrgsolve::house()
-##' 
-##' data(exidata)
-##' 
-##' exidata
-##' 
-##' mod %>% 
-##'   idata_set(exidata, ID <= 2) %>% 
-##'   ev(amt = 100) %>%
-##'   mrgsim() %>% 
-##'   plot()
-##' 
-##' mod %>% 
-##'   idata_set(exidata) %>% 
-##'   ev(amt = 100) %>%
-##'   mrgsim()
-##' 
-##' mod %>% ev(amt = 100) %>% mrgsim(idata=exidata) 
-##' 
-##' @seealso \code{\link{data_set}}, \code{\link{ev}}
-##' 
-##' @export
+#' Select and modify a idata set for simulation
+#' 
+#' The individual data set (`idata_set`) is a data frame with one 
+#' row for each individual in a population, specifying parameters and 
+#' other individual-level data.
+#'
+#' @param x model object.
+#' @param data a data set that can be coerced to data.frame.
+#' @param object character name of an object existing in `$ENV` 
+#' to use for the data set.
+#' @param .subset an unquoted expression passed to [dplyr::filter()]; retain 
+#' only certain rows in the data set.
+#' @param .select passed to [dplyr::select()]; retain only certain columns in 
+#' the data set; this should be the result of a call to [dplyr::vars()].
+#' @param need passed to [inventory()].
+#' @param ... other arguments passed along when `object` is a function.
+#' 
+#' @details
+#' The `idata_set` is a data frame that specifies individual-level 
+#' data for the problem. An `ID` column is required and there 
+#' can be no more than one row in the data frame for each individual.  
+#' 
+#' In most cases, the columns in the `idata_set` have the same names
+#' as parameters in the [param()] list.  When this is the case, 
+#' the parameter set is updated as the simulation proceeds once at the 
+#' start of each individual.  The `idata_set` can also be used to 
+#' set initial conditions for each individual: for a compartment called
+#' `CMT`, make a column in `idata_set` called `CMT_0` and 
+#' make the value the desired initial value for that compartment.  Note that 
+#' this initial condition will be overridden if you also set the `CMT_0` 
+#' in `$MAIN` (`$PK`).
+#' 
+#' The most common application of `idata_set` is to specify a population
+#' or batch of simulations to do.  We commonly use `idata_set` with an 
+#' event object (see [ev()]).  In that case, the event gets applied
+#' to each individual in the `idata_set`.  
+#' 
+#' It is also possible to provide both a `data_set` and a `idata_set`.  
+#' In this case, the `idata_set` is used as a parameter lookup for `IDs`
+#' found in the `data_set`.  Remember in this case, it is the `data_set`
+#' (not the `idata_set`) that determines the number of individuals in the
+#' simulation.
+#' 
+#' An error will be generated if any parameter columns in the 
+#' input idata set contain `NA`.  
+#'  
+#' @examples
+#' mod <- mrgsolve::house()
+#' 
+#' data(exidata)
+#' 
+#' exidata
+#' 
+#' mod %>% 
+#'   idata_set(exidata, ID <= 2) %>% 
+#'   ev(amt = 100) %>%
+#'   mrgsim() %>% 
+#'   plot()
+#' 
+#' mod %>% 
+#'   idata_set(exidata) %>% 
+#'   ev(amt = 100) %>%
+#'   mrgsim()
+#' 
+#' mod %>% ev(amt = 100) %>% mrgsim(idata=exidata) 
+#' 
+#' @seealso [data_set()], [ev()]
+#' 
+#' @md
+#' @export
 setGeneric("idata_set", function(x,data,...) {
   standardGeneric("idata_set")
 })

--- a/R/init.R
+++ b/R/init.R
@@ -1,4 +1,4 @@
-# Copyright (C) 2013 - 2020  Metrum Research Group
+# Copyright (C) 2013 - 2024  Metrum Research Group
 #
 # This file is part of mrgsolve.
 #
@@ -16,50 +16,55 @@
 # along with mrgsolve.  If not, see <http://www.gnu.org/licenses/>.
 
 
-##' Methods for working with the model compartment list
-##'
-##' Calling \code{init} with the model object as the first argument 
-##' will return the model initial conditions as a \code{numericlist} 
-##' object. See \code{\link{numericlist}} for methods to  deal with 
-##' \code{cmt_list} objects.
-##'
-##' @aliases init 
-##' @param .x the model object
-##' @param .y list to be merged into parameter list
-##' @param .pat a regular expression (character) to be applied as 
-##' a filter when printing compartments to the screen
-##' @param ... passed along
-##' @return an object of class \code{cmt_list} (see 
-##' \code{\link{numericlist}})
-##' @details
-##' Can be used to either get a compartment list object from a 
-##' \code{mrgmod} model object or to update the compartment initial 
-##' conditions in a model object.  For both uses, the return value 
-##' is a \code{cmt_list} object. For the former use, \code{init} 
-##' is usually called to print the compartment initial conditions 
-##' to the screen, but the \code{cmt_list} object can also be coerced 
-##' to a list or numeric R object.
-##'
-##' @examples
-##' ## example("init")
-##' mod <- mrgsolve::house()
-##'
-##' init(mod)
-##' init(mod, .pat="^C") ## may be useful for large models
-##'
-##' class(init(mod))
-##'
-##' init(mod)$CENT
-##'
-##' as.list(init(mod))
-##' as.data.frame(init(mod))
-
-##' @export
+#' Methods for working with the model compartment list
+#'
+#' Calling `init()` with the model object as the first argument 
+#' will return the model initial conditions as a [numericlist] 
+#' object. See [numericlist] for methods to  deal with 
+#' `cmt_list` objects.
+#'
+#' @aliases init 
+#' @param .x the model object.
+#' @param .y list to be merged into parameter list.
+#' @param .pat a regular expression (character) to be applied as 
+#' a filter when printing compartments to the screen.
+#' @param ... `name = value` assignments to update the initial conditions list.
+#' 
+#' @return An object of class `cmt_list` (see [numericlist]).
+#' 
+#' @details
+#' Can be used to either get a compartment list object from a 
+#' `mrgmod` model object or to update the compartment initial 
+#' conditions in a model object.  For both uses, the return value 
+#' is a `cmt_list` object. For the former use, `init()` 
+#' is usually called to print the compartment initial conditions 
+#' to the screen, but the `cmt_list` object can also be coerced 
+#' to a list or numeric R object.
+#'
+#' @examples
+#' ## example("init")
+#' mod <- mrgsolve::house()
+#'
+#' init(mod)
+#' 
+#' init(mod, .pat="^C") ## may be useful for large models
+#'
+#' class(init(mod))
+#'
+#' init(mod)$CENT
+#'
+#' as.list(init(mod))
+#' 
+#' as.data.frame(init(mod))
+#' 
+#' 
+#' @md
+#' @export
 setGeneric("init", function(.x,...) standardGeneric("init"))
 
 
-##' @export
-##' @rdname init
+#' @export
+#' @rdname init
 setMethod("init", "mrgmod", function(.x,.y=list(),..., .pat="*") {
   
   args <- c(as.list(.y),list(...))
@@ -80,26 +85,26 @@ setMethod("init", "mrgmod", function(.x,.y=list(),..., .pat="*") {
   return(.x@init)
 })
 
-##' @rdname init
-##' @export
+#' @rdname init
+#' @export
 setMethod("init", "mrgsims", function(.x,...) {
   init(mod(.x),...)
 }) 
 
-##' @rdname init
-##' @export
+#' @rdname init
+#' @export
 setMethod("init", "missing", function(...) {
   init(list(...))
 })
 
-##' @rdname init
-##' @export
+#' @rdname init
+#' @export
 setMethod("init", "list", function(.x,...) {
   create_numeric_list(.x,"cmt_list",...)
 })
 
-##' @rdname init
-##' @export
+#' @rdname init
+#' @export
 setMethod("init", "ANY", function(.x,...) {
   init(as.list(.x),...)
 })

--- a/R/inven.R
+++ b/R/inven.R
@@ -1,4 +1,4 @@
-# Copyright (C) 2013 - 2020  Metrum Research Group
+# Copyright (C) 2013 - 2024  Metrum Research Group
 #
 # This file is part of mrgsolve.
 #
@@ -15,27 +15,39 @@
 # You should have received a copy of the GNU General Public License
 # along with mrgsolve.  If not, see <http://www.gnu.org/licenses/>.
 
-#' Check whether all required parameters needed in a model are present in an object
-#' @param x model object
-#' @param obj data.frame to pass to \code{\link{idata_set}} or \code{\link{data_set}}
-#' @param ... capture dplyr-style parameter requirements
+#' Check whether all required parameters needed in a model are present in an 
+#' object
+#' 
+#' This function has largely been superseded by [check_data_names()].
+#' 
+#' @param x model object.
+#' @param obj data.frame to pass to [idata_set()] or [data_set()].
+#' @param ... capture dplyr-style parameter requirements.
 #' @param .strict whether to stop execution if all requirements are present
-#'  (\code{TRUE}) 
-#' or just warn (\code{FALSE}); see details
-#' @examples \dontrun{
-#' inventory(mod, idata, CL:V) # parameters defined, inclusively, CL through Volume 
-#' inventory(mod, idata, everything()) # all parameters
-#' inventory(mod, idata, contains("OCC")) # all parameters containing OCC
-#' inventory(mod, idata, -F) # all parameters except F
+#'  (`TRUE`) or just warn (`FALSE`); see **Details**.
+#' 
+#' 
+#' @examples 
+#' \dontrun{
+#'   inventory(mod, idata, CL:V) # parameters defined, inclusively, CL through Volume 
+#'   inventory(mod, idata, everything()) # all parameters
+#'   inventory(mod, idata, contains("OCC")) # all parameters containing OCC
+#'   inventory(mod, idata, -F) # all parameters except F
 #' }
-#' @return original mrgmod
+#' 
+#' @return `x` is returned invisibly.
+#' 
 #' @details 
 #' If parameter requirements are not explicitly stated, the requirement defaults to 
-#' all parameter names in \code{x}.  Note that, by default,
-#' the inventory is not \code{.strict} unless the user explicitly
+#' all parameter names in `x`.  Note that, by default,
+#' the inventory is not `.strict` unless the user explicitly
 #' states the parameter requirement. That is, if parameter requirements are explicitly 
-#' stated, \code{.strict} will be set to \code{TRUE} if a value \code{.strict} was not
+#' stated, `.strict` will be set to `TRUE` if a value `.strict` was not
 #' passed in the call.
+#' 
+#' @seealso [check_data_names()]
+#' 
+#' @md
 #' @export
 inventory <- function(x, obj, ..., .strict = FALSE) {
   
@@ -254,7 +266,7 @@ check_data_names <- function(data, x, check_covariates = TRUE,
 #' you call [check_data_names()]. User-defined tags are also possible, but you 
 #' will need to alert [check_data_names()] to look for them.
 #' 
-#' **Examples**
+#' **Model Specification Examples**
 #' 
 #' You can use the `$INPUT` block to add the `input` tag on these parameters
 #' 
@@ -277,7 +289,7 @@ check_data_names <- function(data, x, check_covariates = TRUE,
 #' ```
 #' 
 #' @examples
-#' mod <- house()
+#' mod <- mrgsolve::house()
 #' 
 #' param_tags(mod)
 #'

--- a/R/matlist.R
+++ b/R/matlist.R
@@ -33,7 +33,7 @@
 #' @seealso [smat()], [dmat()], [bmat()], [cmat()]
 #' 
 #' @examples
-#' ## example("omega")
+#' # example("omega")
 #' mat1 <- matrix(1)
 #' mat2 <- diag(c(1,2,3))
 #' mat3 <- matrix(c(0.1, 0.002, 0.002, 0.5), 2,2)
@@ -41,30 +41,14 @@
 #'
 #' omat(mat1)
 #' omat(mat1, mat2, mat3)
-#' omat(A=mat1, B=mat2, C=mat3)
+#' omat(A = mat1, B = mat2, C = mat3)
 #'
 #' mod <- mrgsolve::house() %>% omat(mat4)
 #'
 #' omat(mod)
-#' omat(mod, make=TRUE)
+#' omat(mod, make = TRUE)
+#' as.matrix(omat(mod))
 #'
-#'
-#' \dontrun{
-#'
-#' $OMEGA
-#' 1 2 3
-#'
-#' $OMEGA \@block
-#' 1 0.1 2
-#'
-#' $OMEGA \@cor
-#' \@ prefix ETA_
-#' \@ labels CL VC KA
-#' 0.1
-#' 0.67 0.2
-#' 0 0 0.3
-#'
-#' }
 #' @name omega
 #' @rdname omega
 #' @aliases omat  OMEGA

--- a/R/matlist.R
+++ b/R/matlist.R
@@ -1,4 +1,4 @@
-# Copyright (C) 2013 - 2022  Metrum Research Group
+# Copyright (C) 2013 - 2024  Metrum Research Group
 #
 # This file is part of mrgsolve.
 #
@@ -16,56 +16,60 @@
 # along with mrgsolve.  If not, see <http://www.gnu.org/licenses/>.
 
 
-##' Manipulate OMEGA matrices
-##'
-##' The primary function is \code{omat} that can be used to both get the 
-##' \code{$OMEGA} matrices out of a model object and to update \code{$OMEGA} 
-##' matrices in a model object.
-##'
-##' @param .x a matrix, list of matrices or \code{matlist} object
-##' @param x  \code{matlist} object
-##' @param labels character vector of names for \code{$OMEGA} elements; must 
-##' be equal to number of rows/columns in the matrix
-##' @param open passed to \code{\link{merge.list}}
-##' @param make logical; if TRUE, matrix list is rendered into a single matrix
-##' @param ... passed to other functions, including \code{\link{modMATRIX}}
-##' @export
-##' @name omega
-##' @rdname omega
-##' @aliases omat  OMEGA
-##' @examples
-##' ## example("omega")
-##' mat1 <- matrix(1)
-##' mat2 <- diag(c(1,2,3))
-##' mat3 <- matrix(c(0.1, 0.002, 0.002, 0.5), 2,2)
-##' mat4 <- dmat(0.1, 0.2, 0.3, 0.4)
-##'
-##' omat(mat1)
-##' omat(mat1, mat2, mat3)
-##' omat(A=mat1, B=mat2, C=mat3)
-##'
-##' mod <- mrgsolve::house() %>% omat(mat4)
-##'
-##' omat(mod)
-##' omat(mod, make=TRUE)
-##'
-##'
-##' \dontrun{
-##'
-##' $OMEGA
-##' 1 2 3
-##'
-##' $OMEGA \@block
-##' 1 0.1 2
-##'
-##' $OMEGA \@cor
-##' \@ prefix ETA_
-##' \@ labels CL VC KA
-##' 0.1
-##' 0.67 0.2
-##' 0 0 0.3
-##'
-##' }
+#' Manipulate OMEGA matrices
+#'
+#' The primary function is `omat()` that can be used to both get the 
+#' `$OMEGA` matrices out of a model object and to update `$OMEGA` 
+#' matrices in a model object.
+#'
+#' @param .x a matrix, list of matrices or `matlist` object.
+#' @param x  `matlist` object.
+#' @param labels character vector of names for `$OMEGA` elements; must 
+#' be equal to number of rows/columns in the matrix.
+#' @param open passed to [merge.list()].
+#' @param make logical; if `TRUE`, matrix list is rendered into a single matrix.
+#' @param ... passed to other functions, including [modMATRIX()].
+#' 
+#' @seealso [smat()], [dmat()], [bmat()], [cmat()]
+#' 
+#' @examples
+#' ## example("omega")
+#' mat1 <- matrix(1)
+#' mat2 <- diag(c(1,2,3))
+#' mat3 <- matrix(c(0.1, 0.002, 0.002, 0.5), 2,2)
+#' mat4 <- dmat(0.1, 0.2, 0.3, 0.4)
+#'
+#' omat(mat1)
+#' omat(mat1, mat2, mat3)
+#' omat(A=mat1, B=mat2, C=mat3)
+#'
+#' mod <- mrgsolve::house() %>% omat(mat4)
+#'
+#' omat(mod)
+#' omat(mod, make=TRUE)
+#'
+#'
+#' \dontrun{
+#'
+#' $OMEGA
+#' 1 2 3
+#'
+#' $OMEGA \@block
+#' 1 0.1 2
+#'
+#' $OMEGA \@cor
+#' \@ prefix ETA_
+#' \@ labels CL VC KA
+#' 0.1
+#' 0.67 0.2
+#' 0 0 0.3
+#'
+#' }
+#' @name omega
+#' @rdname omega
+#' @aliases omat  OMEGA
+#' @md
+#' @export
 
 setGeneric("omat",function(.x,...) standardGeneric("omat"))
 ##' @export
@@ -116,42 +120,44 @@ setMethod("omat", "mrgsims", function(.x,make=FALSE,...) {
   as.matrix(mod(.x)@omega)
 })
 
-##' Manipulate SIGMA matrices
-##'
-##' The primary function is \code{smat} that can be used to both get the 
-##' \code{$SIGMA} matrices out of a model object and to update \code{$SIGMA} 
-##' matrices in a model object.
-##'
-##' @param .x a matrix, list of matrices or \code{matlist} object
-##' @param x  \code{matlist} object
-##' @param labels character vector of names for \code{$SIGMA} elements; must be
-##' equal 
-##' to number of rows/columns in the matrix
-##' @param make logical; if TRUE, matrix list is rendered into a single matrix
-##' @param ... passed to other functions, including \code{\link{modMATRIX}}
-##' @param open passed to \code{\link{merge.list}}
-##' 
-##' @name sigma
-##' @rdname sigma
-##' 
-##' @aliases smat SIGMA
-##' 
-##' @examples
-##' ## example("sigma")
-##' mat1 <- matrix(1)
-##' mat2 <- diag(c(1,2))
-##' mat3 <- matrix(c(0.1, 0.002, 0.002, 0.5), 2,2)
-##' mat4 <- dmat(0.1, 0.2, 0.3, 0.4)
-##'
-##' smat(mat1)
-##' smat(mat1, mat2, mat3)
-##' smat(A=mat1, B=mat2, C=mat3)
-##'
-##' mod <- mrgsolve::house() %>% smat(mat1)
-##'
-##' smat(mod)
-##' smat(mod, make=TRUE)
-##' @export
+#' Manipulate SIGMA matrices
+#'
+#' The primary function is `smat()` which can be used to both get the 
+#' `$SIGMA` matrices out of a model object and to update `$SIGMA` 
+#' matrices in a model object.
+#'
+#' @param .x a matrix, list of matrices or `matlist` object.
+#' @param x  `matlist` object.
+#' @param labels character vector of names for `$SIGMA` elements; must be
+#' equal to number of rows/columns in the matrix.
+#' @param make logical; if `TRUE`, matrix list is rendered into a single matrix.
+#' @param ... passed to other functions, including [modMATRIX()].
+#' @param open passed to [merge.list()].
+#' 
+#' 
+#' @seealso [dmat()], [bmat()], [cmat()]
+#' 
+#' @examples
+#' ## example("sigma")
+#' mat1 <- matrix(1)
+#' mat2 <- diag(c(1,2))
+#' mat3 <- matrix(c(0.1, 0.002, 0.002, 0.5), 2,2)
+#' mat4 <- dmat(0.1, 0.2, 0.3, 0.4)
+#'
+#' smat(mat1)
+#' smat(mat1, mat2, mat3)
+#' smat(A=mat1, B=mat2, C=mat3)
+#'
+#' mod <- mrgsolve::house() %>% smat(mat1)
+#'
+#' smat(mod)
+#' smat(mod, make=TRUE)
+#' 
+#' @name sigma
+#' @rdname sigma
+#' @aliases smat SIGMA
+#' @md
+#' @export
 setGeneric("smat",function(.x,...) standardGeneric("smat"))
 
 ##' @export
@@ -202,17 +208,16 @@ setMethod("smat", "mrgsims", function(.x,make=FALSE,...) {
 
 #' Zero out random effects in a model object
 #' 
-#' Sets all elements of the OMEGA or SIGMA matrix to zero
+#' Sets all elements of the OMEGA or SIGMA matrix to zero.
 #' 
-#' @param .x a model object
+#' @param .x a model object.
 #' @param ... which matrix to zero out; pass `omega` to just zero out `omega`, 
-#' `sigma` to just zero out `sigma`; passing nothing will zero out both
+#' `sigma` to just zero out `sigma`; passing nothing will zero out both.
 #' 
 #' @return 
-#' An updated object with elements of OMEGA and / or SIGMA set to zero..
+#' An updated object with elements of OMEGA and/or SIGMA set to zero.
 #' 
 #' @examples
-#' 
 #' mod <- house()
 #' revar(mod)
 #' mod <- zero_re(mod)

--- a/R/matlist.R
+++ b/R/matlist.R
@@ -249,8 +249,8 @@ setMethod("zero_re", "mrgmod", function(.x, ...) {
 
 #' Methods for working with matrix-list objects
 #'
-#' @param x a matlist object
-#' @param ... passed through to other methods
+#' @param x a matlist object.
+#' @param ... passed through to other methods.
 #'
 #' @name matlist
 #' @rdname matlist
@@ -259,7 +259,7 @@ NULL
 #' @param detailed if `TRUE`, then a simple list of matrices is returned; 
 #' otherwise, then entire `matlist` object data is returned along with the 
 #' name of the `class` (e.g. either `omegalist` or `sigmalist`) as well 
-#' as the `names` of the matrices
+#' as the `names` of the matrices.
 #' @md
 #' @rdname matlist
 #' @export
@@ -381,10 +381,10 @@ setMethod("c", "matlist", function(x,...,recursive=FALSE) {
 #' updated, usually making it easier. This "collapsing" of the matrix list 
 #' is irreversible. 
 #' 
-#' @param x a `mrgmod` object
+#' @param x a model object.
 #' @param name a new name for the collapsed matrix; note that this is the 
 #' matrix name, not the labels which alias `ETA(n)` or `EPS(n)`; specifying a 
-#' name will only alter how this matrix is potentially updated in the future
+#' name will only alter how this matrix is potentially updated in the future.
 #' @param range numeric vector of length 2 specifying the range of matrices 
 #' to collapse in case there are more than 2. The second element may be `NA` 
 #' to indicate the length of the list of matrices. 
@@ -406,8 +406,8 @@ setMethod("c", "matlist", function(x,...,recursive=FALSE) {
 #' A model object with updated `OMEGA` or `SIGMA` matrix lists.
 #' 
 #' @seealso [collapse_matrix()]
-#' @md
 #' @rdname collapse_matrices
+#' @md
 #' @export
 collapse_omega <- function(x, range = NULL, name = NULL) {
   stopifnot(is.mrgmod(x))
@@ -442,7 +442,7 @@ collapse_sigma <- function(x, range = NULL, name = NULL) {
 #' @inheritParams collapse_omega
 #' @param x an object that inherits from `matlist`; this object is most
 #' frequently extracted from a model object using [omat()] or [smat()] for 
-#' `OMEGA` and `SIGMA`, respectively
+#' `OMEGA` and `SIGMA`, respectively.
 #' 
 #' @examples
 #' omega <- omat(list(dmat(1, 2), dmat(3, 4, 5)))

--- a/R/matrix.R
+++ b/R/matrix.R
@@ -1,4 +1,4 @@
-# Copyright (C) 2013 - 2021  Metrum Research Group
+# Copyright (C) 2013 - 2024  Metrum Research Group
 # This file is part of mrgsolve.
 #
 # mrgsolve is free software: you can redistribute it and/or modify it
@@ -131,30 +131,37 @@ Diag <- function(x) {
   diag(x, nrow=length(x),ncol=length(x))
 }
 
-##' Create matrices from vector input
-##'
-##' @param ... matrix data
-##' @param correlation logical; if TRUE, off-diagonal elements are assumed 
-##' to be correlations and converted to covariances
-##' @param digits if greater than zero, matrix is passed to signif (along 
-##' with digits) prior to returning
-##' @details
-##' \code{bmat} makes a block matrix.  \code{cmat} makes a correlation matrix. 
-##' \code{dmat} makes a diagonal matrix.
-##' 
-##' @seealso \code{\link{as_bmat}}
-##' 
-##' @examples
-##'
-##' dmat(1,2,3)/10
-##'
-##' bmat(0.5,0.01,0.2)
-##'
-##' cmat(0.5, 0.87,0.2)
-##' 
-##' @rdname matrix_helpers
-##' @name matrix_helpers
-##' @export
+#' Create matrices from vector input
+#' 
+#' These functions are simple utilities for creating diagonal, block or 
+#' correlation matrices. 
+#' 
+#' @param ... matrix data.
+#' @param correlation logical; if `TRUE`, off-diagonal elements are assumed 
+#' to be correlations and converted to covariances.
+#' @param digits if greater than zero, matrix is passed to [signif()] (along 
+#' with digits) prior to returning.
+#' 
+#' @details
+#' `bmat()` makes a block matrix. `cmat()` makes a correlation matrix. 
+#' `dmat()` makes a diagonal matrix.
+#' 
+#' @return A matrix.
+#' 
+#' @seealso [as_bmat()], [as_dmat()]
+#' 
+#' @examples
+#'
+#' dmat(1,2,3)/10
+#'
+#' bmat(0.5,0.01,0.2)
+#'
+#' cmat(0.5, 0.87,0.2)
+#' 
+#' @rdname matrix_helpers
+#' @name matrix_helpers
+#' @md
+#' @export
 bmat <- function(...,correlation=FALSE, digits=-1) {
   x <- lower2matrix(unlist(list(...)),context="bmat")
   if(correlation) decorr(x)
@@ -162,15 +169,14 @@ bmat <- function(...,correlation=FALSE, digits=-1) {
   return(x)
 }
 
-##' @rdname matrix_helpers
-##' @export
+#' @rdname matrix_helpers
+#' @export
 cmat <- function(...,digits=-1) {
   bmat(...,digits=digits,correlation=TRUE)
 }
 
-##' @rdname matrix_helpers
-##' @seealso \code{\link{as_dmat}}
-##' @export
+#' @rdname matrix_helpers
+#' @export
 dmat <- function(...) {
   Diag(as.numeric(unlist(list(...))))
 }

--- a/R/matrix.R
+++ b/R/matrix.R
@@ -181,68 +181,70 @@ dmat <- function(...) {
   Diag(as.numeric(unlist(list(...))))
 }
 
-##' Coerce R objects to block or diagonal matrices
-##' 
-##' These are simple functions that may be helpful to create the matrix objects
-##' that mrgsolve expects.  Functions are named based on whether they create a
-##' diagonal matrix (\code{d}), a block matrix (\code{b}), or a a correlation
-##' matrix (\code{c}).
-##' 
-##'
-##' @param x data frame or list 
-##' @param pat regular expression, character
-##' @param cols column names to use instead of \code{pat}
-##' @param ... arguments passed to \code{\link{dmat}} or \code{\link{bmat}}
-##' @return A numeric matrix for list and numeric methods.  For data.frames, 
-##' a list of matrices are returned.
-##' @seealso \code{\link{bmat}}, \code{\link{dmat}}, \code{\link{cmat}}
-##' 
-##' @details
-##' Use \code{as_dmat} to create a diagonal matrix, \code{as_bmat}
-##' to create a block matrix, and \code{as_cmat} to create a block 
-##' matrix where off-diagonal elements are understood to be correlations
-##' rather than covariances. \code{as_cmat} uses \code{as_bmat} to 
-##' form the matrix and then converts off-diagonal elements to 
-##' covariances before returning.
-##' 
-##' The methods for \code{data.frame} will work down the rows
-##' of the data frame and make the appropriate matrix from 
-##' the data in each row.  The result is a list of matrices. 
-##' 
-##' @examples
-##'
-##' df <- data.frame(
-##'   OMEGA1.1 = c(1,2),
-##'   OMEGA2.1 = c(11,22),
-##'   OMEGA2.2 = c(3,4),
-##'   SIGMA1.1 = 1,
-##'   FOO=-1
-##' )
-##'
-##' as_bmat(df, "OMEGA")
-##' as_dmat(df,"SIGMA")
-##' as_dmat(df[1,],"OMEGA")
-##'
-##' @rdname matrix_converters
-##' 
-##' @export
+#' Coerce R objects to block or diagonal matrices
+#' 
+#' These are simple functions that may be helpful to create the matrix objects
+#' that mrgsolve expects.  Functions are named based on whether they create a
+#' diagonal matrix (`d`), a block matrix (`b`), or a a correlation
+#' matrix (`c`).
+#' 
+#'
+#' @param x data frame or list. 
+#' @param pat regular expression, character.
+#' @param cols column names to use instead of `pat`.
+#' @param ... arguments passed to [dmat()] or [cmat()].
+#' 
+#' @return A numeric matrix for list and numeric methods.  For data.frames, 
+#' a list of matrices are returned.
+#' 
+#' @seealso [bmat()], [dmat()], [cmat()]
+#' 
+#' @details
+#' Use `as_dmat()` to create a diagonal matrix, `as_bmat()`
+#' to create a block matrix, and `as_cmat()` to create a block 
+#' matrix where off-diagonal elements are understood to be correlations
+#' rather than covariances. `as_cmat()` uses `as_bmat()` to 
+#' form the matrix and then converts off-diagonal elements to 
+#' covariances before returning.
+#' 
+#' The methods for `data.frame` will work down the rows
+#' of the data frame and make the appropriate matrix from 
+#' the data in each row.  The result is a list of matrices. 
+#' 
+#' @examples
+#' df <- data.frame(
+#'   OMEGA1.1 = c(1,2),
+#'   OMEGA2.1 = c(11,22),
+#'   OMEGA2.2 = c(3,4),
+#'   SIGMA1.1 = 1,
+#'   FOO=-1
+#' )
+#'
+#' as_bmat(df, "OMEGA")
+#' as_dmat(df,"SIGMA")
+#' as_dmat(df[1,],"OMEGA")
+#'
+#' @rdname matrix_converters
+#' 
+#' @md
+#' @export
 setGeneric("as_bmat", function(x,...) standardGeneric("as_bmat"))
 
-##' @rdname matrix_converters
-##' @export
+#' @rdname matrix_converters
+#' @export
 setMethod("as_bmat", "list", function(x,...) {
   as_bmat(unlist(x),...)
 })
 
-##' @rdname matrix_converters
-##' @export
+#' @rdname matrix_converters
+#' @export
 setMethod("as_bmat", "numeric", function(x,pat="*",...) {
   x <- grepn(x,pat, !missing(pat))
   do.call("bmat", list(x,...))
 })
 
-##' @rdname matrix_converters
-##' @export
+#' @rdname matrix_converters
+#' @export
 setMethod("as_bmat", "data.frame", function(x,pat="*",cols=NULL, ...) {
   if(is.character(cols)) {
     cols <- cvec_cs(cols)
@@ -257,37 +259,37 @@ setMethod("as_bmat", "data.frame", function(x,pat="*",cols=NULL, ...) {
   lapply(seq_len(nrow(x)), function(i) bmat(unlist(x[i,],use.names=FALSE),...))
 })
 
-##' @rdname matrix_converters
-##' @export
+#' @rdname matrix_converters
+#' @export
 setMethod("as_bmat", "ANY", function(x,...) {
   as_bmat(as.data.frame(x),...)
 })
 
-##' @rdname matrix_converters
-##' @export
+#' @rdname matrix_converters
+#' @export
 setGeneric("as_dmat", function(x,...) standardGeneric("as_dmat"))
 
-##' @rdname matrix_converters
-##' @export
+#' @rdname matrix_converters
+#' @export
 setMethod("as_dmat", "list", function(x,...) {
   as_dmat(unlist(x),...)
 })
 
-##' @rdname matrix_converters
-##' @export
+#' @rdname matrix_converters
+#' @export
 setMethod("as_dmat", "ANY", function(x,...) {
   as_dmat(as.data.frame(x),...)
 })
 
-##' @rdname matrix_converters
-##' @export
+#' @rdname matrix_converters
+#' @export
 setMethod("as_dmat", "numeric", function(x,pat="*",...) {
   x <- grepn(x,pat, !missing(pat))
   do.call("dmat", list(x,...))
 })
 
-##' @rdname matrix_converters
-##' @export
+#' @rdname matrix_converters
+#' @export
 setMethod("as_dmat", "data.frame", function(x,pat="*",cols=NULL, ...) {
   if(is.character(cols)) {
     cols <- cvec_cs(cols)
@@ -302,8 +304,8 @@ setMethod("as_dmat", "data.frame", function(x,pat="*",cols=NULL, ...) {
   lapply(seq_len(nrow(x)), function(i) dmat(unlist(x[i,],use.names=FALSE),...))
 })
 
-##' @rdname matrix_converters
-##' @export
+#' @rdname matrix_converters
+#' @export
 as_cmat <- function(x,...) {
   x <- as_bmat(x,...)
   decorr(x)

--- a/R/mcode.R
+++ b/R/mcode.R
@@ -1,4 +1,4 @@
-# Copyright (C) 2013 - 2019  Metrum Research Group, LLC
+# Copyright (C) 2013 - 2024  Metrum Research Group
 #
 # This file is part of mrgsolve.
 #
@@ -16,41 +16,43 @@
 # along with mrgsolve.  If not, see <http://www.gnu.org/licenses/>.
 
 
-##' Write, compile, and load model code
-##'
-##' This is a convenience function that ultimately calls \code{\link{mread}}.
-##' Model code is written to a file and read back in using \code{\link{mread}}.
-##'
-##' @param model model name
-##' @param project project name
-##' @param code character string specifying a \code{mrgsolve} model
-##' @param ... passed to \code{\link{mread}}; see that help topic for other
-##' arguments that can be set
-##' @details
-##' Note that the arguments are in slightly different order than 
-##' \code{\link{mread}}.  The default \code{project} is \code{tempdir()}.
-##' 
-##' See the \code{\link{mread}} help topic for discussion about caching
-##' compilation results with \code{mcode_cache}.  
-##'
-##' @examples
-##'
-##' \dontrun{ 
-##' code <- '
-##' $CMT DEPOT CENT
-##' $PKMODEL ncmt=1, depot=TRUE
-##' $MAIN
-##' double CL = 1;
-##' double V = 20;
-##' double KA = 1;
-##' '
-##'
-##' mod <- mcode("example",code)
-##' }
-##' 
-##' @seealso \code{\link{mread}}, \code{\link{mread_cache}}
-##' 
-##' @export
+#' Write, compile, and load model code
+#'
+#' This is a convenience function that ultimately calls [mread()].
+#' Model code is written to a file and read back in using [mread()].
+#'
+#' @param model model name.
+#' @param project project directory for the model.
+#' @param code character string specifying a `mrgsolve` model.
+#' @param ... passed to [mread()]; see that help topic for other arguments 
+#' that can be set.
+#' 
+#' @details
+#' Note that the arguments are in slightly different order than 
+#' [mread()].  The default `project` is [tempdir()].
+#' 
+#' See the [mread()] help topic for discussion about caching
+#' compilation results with [mcode_cache()].  
+#'
+#' @examples
+#'
+#' \dontrun{ 
+#' code <- '
+#' $CMT DEPOT CENT
+#' $PKMODEL ncmt=1, depot=TRUE
+#' $MAIN
+#' double CL = 1;
+#' double V = 20;
+#' double KA = 1;
+#' '
+#'
+#' mod <- mcode("example", code)
+#' }
+#' 
+#' @seealso [mread()], [mread_cache()]
+#' 
+#' @md
+#' @export
 mcode <- function(
   model, code, project = getOption("mrgsolve.project", tempdir()), ...) {
   mread(model=model, project=project, code=code, ...)

--- a/R/mcode.R
+++ b/R/mcode.R
@@ -35,7 +35,6 @@
 #' compilation results with [mcode_cache()].  
 #'
 #' @examples
-#'
 #' \dontrun{ 
 #' code <- '
 #' $CMT DEPOT CENT
@@ -46,7 +45,7 @@
 #' double KA = 1;
 #' '
 #'
-#' mod <- mcode("example", code)
+#' mod <- mcode("example", code, compile = FALSE)
 #' }
 #' 
 #' @seealso [mread()], [mread_cache()]
@@ -58,8 +57,8 @@ mcode <- function(
   mread(model=model, project=project, code=code, ...)
 }
 
-##' @rdname mcode
-##' @export
+#' @rdname mcode
+#' @export
 mcode_cache <- function(
   model, code, project = getOption("mrgsolve.project", tempdir()),  ...) {
   mread_cache(model, project, code = code, ...)

--- a/R/modlib.R
+++ b/R/modlib.R
@@ -306,21 +306,24 @@ NULL
 NULL
 
 
-##' Extract the code from a model
-##' 
-##' This function is currently not exported, so be sure to call it with 
-##' `mrgsolve:::code(...)`.
-##' 
-##' @param x an mrgsolve model object
-##' 
-##' @examples
-##' mod <- mrgsolve::house()
-##' mrgsolve:::code(mod)
-##' 
-##' @return 
-##' A character vector of model code.
-##' 
-##' @md
+#' Extract the code from a model
+#' 
+#' This function is currently not exported, so be sure to call it with 
+#' `mrgsolve:::code(...)`.
+#' 
+#' @param x a model object.
+#' 
+#' @examples
+#' mod <- mrgsolve::house()
+#' mrgsolve:::code(mod)
+#' 
+#' # Alternative
+#' as.list(mod)$code
+#' 
+#' @return 
+#' A character vector of model code.
+#' 
+#' @md
 code <- function(x) {
   stopifnot(is.mrgmod(x))
   what <- try(x@code, silent=TRUE)

--- a/R/modlib.R
+++ b/R/modlib.R
@@ -18,6 +18,11 @@
 
 #' Internal model library
 #' 
+#' Pre-coded models are included in the mrgsolve installation; these can be 
+#' compiled and loaded with `modlib()`. These models are usually most useful 
+#' for exploratory simulation or learning mrgsolve. Production simulation work 
+#' is typically accomplished by a custom-coded model.
+#' 
 #' @param model `character` name of a model in the library.
 #' @param ... passed to [mread_cache()].
 #' @param list logical; if `TRUE`, a list of available models is returned.

--- a/R/modlib.R
+++ b/R/modlib.R
@@ -16,52 +16,50 @@
 # along with mrgsolve.  If not, see <http://www.gnu.org/licenses/>.
 
 
-##' Internal model library
-##' 
-##' @param model \code{character} name of a model in the library
-##' @param ... passed to \code{\link{mread_cache}}
-##' @param list list available models
-##' @export
-##' 
-##' @details
-##' See \code{\link{modlib_details}}, \code{\link{modlib_pk}}, 
-##' \code{\link{modlib_pkpd}}, 
-##' \code{\link{modlib_tmdd}}, \code{\link{modlib_viral}} for details.
-##' 
-##' Call \code{modlib("<modelname>")} to compile and load a mode from the 
-##' library.
-##' 
-##' Call \code{modlib(list=TRUE)} to list available models.  Once the model 
-##' is loaded (see examples below), call \code{as.list(mod)$code} to see
-##' model code and equations.
-##' 
-##' 
-##' @examples
-##' \dontrun{
-##' mod <- mread("pk1cmt", modlib())
-##' mod <- mread("pk2cmt", modlib()) 
-##' mod <- mread("pk3cmt", modlib()) 
-##' mod <- mread("pk1",    modlib())
-##' mod <- mread("pk2",    modlib())
-##' mod <- mread("popex",  modlib())
-##' mod <- mread("irm1",   modlib()) 
-##' mod <- mread("irm2",   modlib()) 
-##' mod <- mread("irm3",   modlib()) 
-##' mod <- mread("irm4",   modlib())
-##' mod <- mread("emax",   modlib())
-##' mod <- mread("effect", modlib())
-##' mod <- mread("tmdd",   modlib())
-##' mod <- mread("viral1", modlib())
-##' mod <- mread("viral2", modlib())
-##' mod <- mread("pred1",  modlib())
-##' mod <- mread("pbpk",   modlib())
-##' mod <- mread("1005",   modlib())  # embedded NONMEM result
-##' mod <- mread("nm-like", modlib()) # model with nonmem-like syntax
-##' mod <- mread("evtools", modlib())
-##' 
-##' mrgsolve:::code(mod)
-##' }
-##' 
+#' Internal model library
+#' 
+#' @param model `character` name of a model in the library.
+#' @param ... passed to [mread_cache()].
+#' @param list logical; if `TRUE`, a list of available models is returned.
+#' 
+#' @details
+#' See [modlib_details], [modlib_pk], [modlib_pkpd], [modlib_tmdd], 
+#' [modlib_viral] for details.
+#' 
+#' Call `modlib("<modelname>")` to compile and load a mode from the 
+#' library.
+#' 
+#' Call `modlib(list=TRUE)` to list available models.  Once the model 
+#' is loaded (see examples below), call `as.list(mod)$code` to extract
+#' model code and equations.
+#' 
+#' @examples
+#' \dontrun{
+#' mod <- mread("pk1cmt", modlib())
+#' mod <- mread("pk2cmt", modlib()) 
+#' mod <- mread("pk3cmt", modlib()) 
+#' mod <- mread("pk1",    modlib())
+#' mod <- mread("pk2",    modlib())
+#' mod <- mread("popex",  modlib())
+#' mod <- mread("irm1",   modlib()) 
+#' mod <- mread("irm2",   modlib()) 
+#' mod <- mread("irm3",   modlib()) 
+#' mod <- mread("irm4",   modlib())
+#' mod <- mread("emax",   modlib())
+#' mod <- mread("effect", modlib())
+#' mod <- mread("tmdd",   modlib())
+#' mod <- mread("viral1", modlib())
+#' mod <- mread("viral2", modlib())
+#' mod <- mread("pred1",  modlib())
+#' mod <- mread("pbpk",   modlib())
+#' mod <- mread("1005",   modlib())  # embedded NONMEM result
+#' mod <- mread("nm-like", modlib()) # model with nonmem-like syntax
+#' mod <- mread("evtools", modlib())
+#' 
+#' as.list(mod)$code
+#' }
+#' @md
+#' @export
 modlib <- function(model = NULL,...,list=FALSE)  {
   if(list) {
     return(modlib_list())

--- a/R/mread.R
+++ b/R/mread.R
@@ -1,4 +1,4 @@
-# Copyright (C) 2013 - 2023 Metrum Research Group
+# Copyright (C) 2013 - 2024 Metrum Research Group
 #
 # This file is part of mrgsolve.
 #
@@ -20,97 +20,97 @@ NULL
 
 #' Read a model specification file
 #' 
-#' \code{mread} reads and parses the \code{mrgsolve} model specification file,
+#' `mread()` reads and parses the mrgsolve model specification file,
 #' builds the model, and returns a model object for simulation. 
-#' \code{mread_cache} does the same, but caches the compilation result for 
-#' later use. 
+#' `mread_cache()` does the same, but caches the compilation result for 
+#' later use. `mread_file()` can be used for convenience, taking the model 
+#' file name as the first argument. 
 #' 
 #'
-#' @param model model name
+#' @param model model name.
 #' @param project location of the model specification file an any 
 #' headers to be included; see also the discussion about model; this argument
-#' can be set via \code{options()}
-#' library under details as well as the \code{\link{modlib}} help topic
+#' can be set via [options()].
+#' library under details as well as the [modlib()] help topic.
 #' @param file the full file name (with extension, but without path)
-#' where the model is specified
+#' where the model is specified.
 #' @param soloc the directory location where the model shared object is built
-#' and stored; see details; this argument can be set via \code{options()}; 
-#' if the directory does not exist, `mread` will attempt to create it.
+#' and stored; see details; this argument can be set via [options()]; 
+#' if the directory does not exist, `mread()` will attempt to create it.
 #' @param code a character string with model specification code to be 
-#' used instead of a model file
-#' @param ignore.stdout passed to system call for compiling model
-#' @param raw if TRUE, return a list of raw output
-#' @param compile logical; if \code{TRUE}, the model will be built
-#' @param check.bounds check boundaries of parameter list
-#' @param audit check the model specification file for errors
-#' @param warn logical; if \code{TRUE}, print warning messages that may arise
-#' @param udll use unique name for shared object
-#' @param quiet don't print messages when compiling
-#' @param preclean logical; if \code{TRUE}, compilation artifacts are 
-#' cleaned up first
-#' @param recover if \code{TRUE}, a list of build will be returned in case
+#' used instead of a model file.
+#' @param ignore.stdout passed to system call when compiling the model; set this
+#' to `FALSE` to print output to the R console. 
+#' @param raw if `TRUE`, return model content as a list, bypassing the compile
+#' step; this argument is typically used for debugging problems with the 
+#' model build. 
+#' @param compile logical; if `TRUE`, the model will be built.
+#' @param check.bounds check boundaries of parameter list.
+#' @param audit check the model specification file for errors.
+#' @param warn logical; if `TRUE`, print warning messages that may arise while
+#' building the model.
+#' @param udll use unique name for shared object.
+#' @param quiet don't print messages when compiling.
+#' @param preclean logical; if `TRUE`, compilation artifacts are 
+#' cleaned up first.
+#' @param recover if `TRUE`, a list of build will be returned in case
 #' the model shared object fails to compile; use this option to and 
-#' the returned object to collect information assist in debugging
+#' the returned object to collect information assist in debugging.
 #' @param capture a character vector or comma-separated string of additional 
 #' model variables to capture; these variables will be added to the capture 
-#' list for the current call to \code{\link{mread}} only
-#' @param ... passed to \code{\link[mrgsolve]{update}}; also arguments passed
-#' to mread from \code{\link{mread_cache}}.
+#' list for the current call to `mread()` only.
+#' @param ... passed to [mrgsolve::update()]; also arguments passed
+#' to `mread()` from `mread_cache()`.
 #' 
 #' @details
-#' The \code{model} argument is required.  For typical use, 
-#' the \code{file} argument is omitted and the value 
-#' for \code{file} is generated from the value for \code{model}.
-#' To determine the source file name, \code{mrgsolve} will look for 
-#' a file extension in \code{model}.  A file extension is 
+#' The `model` argument is required.  For typical use, 
+#' the `file` argument is omitted and the value 
+#' for `file` is generated from the value for `model`.
+#' To determine the source file name, mrgsolve will look for 
+#' a file extension in `model`.  A file extension is 
 #' assumed when it finds a period followed by one to three alpha-numeric 
-#' characters at the end of the string (e.g. \code{mymodel.txt} but not 
-#' \code{my.model}).  If no file extension is found, the extension \code{.cpp} 
-#' is assumed (e.g. \code{file} is \code{<model-name>.cpp}).  If a file 
-#' extension is found, \code{file} is \code{<model-name>}.    
+#' characters at the end of the string (e.g. `mymodel.txt` but not 
+#' `my.model`).  If no file extension is found, the extension `.cpp` 
+#' is assumed (e.g. `file` is `<model-name>.cpp`).  If a file 
+#' extension is found, `file` is `<model-name>`.    
 #' 
-#' Best practice is to avoid using \code{.} in \code{model} unless
-#' you are using \code{model} to point to the model specification 
-#' file name. Otherwise, use \code{\link{mread_file}}. 
+#' Best practice is to avoid using `.` in `model` unless
+#' you are using `model` to point to the model specification 
+#' file name. Otherwise, use `mread_file()`. 
 #' 
-#' Use the \code{soloc} argument to specify a directory location for building
+#' Use the `soloc` argument to specify a directory location for building
 #' the model.  This is the location where the model shared object will be 
 #' stored on disk.  The default is a temporary directory, so compilation 
 #' artifacts are lost when R restarts when the default is used.  Changing
-#' \code{soloc} to a persistent directory location will preserve those 
+#' `soloc` to a persistent directory location will preserve those 
 #' artifacts across R restarts.  Also, if simulation from a single model is 
 #' being done in separate processes on separate compute nodes, it might be 
 #' necessary to store these compilation artifacts in a local directory 
-#' to make them accessible to the different nodes. If the \code{soloc} 
-#' directory does not exist, `mread` will attempt to create it.
+#' to make them accessible to the different nodes. If the `soloc` 
+#' directory does not exist, `mread()` will attempt to create it.
 #' 
-#' Similarly, using \code{mread_cache} will cache results in the temporary 
+#' Similarly, using `mread_cache()` will cache results in the temporary 
 #' directory and the cache cannot be accessed after the R process is 
 #' restarted.
 #' 
 #' @section Model Library:
 #' 
-#' \code{mrgsolve} comes bundled with several precoded PK, PK/PD, and 
-#' other systems models that are accessible via the \code{mread} interface.  
+#' mrgsolve comes bundled with several precoded PK, PK/PD, and 
+#' other systems models that are accessible via the `mread()` interface.  
 #' 
 #' Models available in the library include:
 #' 
-#' \itemize{
-#'   \item PK models: \code{pk1cmt}, \code{pk2cmt}, \code{pk3cmt},
-#'                    \code{pk1}, \code{pk2}, \code{popex}, \code{tmdd}
-#'   \item PKPD models: \code{irm1}, \code{irm2}, \code{irm3}, \code{irm4},
-#'                       \code{emax}, \code{effect}
-#'   \item Other models: \code{viral1}, \code{viral2}
-#' }
+#' * PK models: `pk1cmt`, `pk2cmt`, `pk3cmt`, `pk1`, `pk2`, `popex`, `tmdd`
+#' * PKPD models: `irm1`, `irm2`, `irm3`, `irm4`, `emax`, `effect`
+#' * Other models: `viral1`, `viral2`
 #' 
-#' When the library model is accessed, \code{mrgsolve} will compile and load
+#' When the library model is accessed, mrgsolve will compile and load
 #' the model as you would for any other model.  It is only necessary to 
-#' reference the correct model name and point the \code{project} argument
-#' to the \code{mrgsolve} model library location via \code{\link{modlib}}.
+#' reference the correct model name and point the `project` argument
+#' to the mrgsolve model library location via [modlib()].
 #' 
-#' For more details, see \code{\link{modlib_pk}}, \code{\link{modlib_pkpd}}, 
-#' \code{\link{modlib_tmdd}}, \code{\link{modlib_viral}}, and 
-#' \code{\link{modlib_details}} for more information about the state 
+#' For more details, see [modlib_pk], [modlib_pkpd], [modlib_tmdd], 
+#' [modlib_viral], and [modlib_details] for more information about the state 
 #' variables and parameters in each model.
 #' 
 #' @examples
@@ -146,8 +146,9 @@ NULL
 #' 
 #' }
 #' 
-#' @seealso \code{\link{mcode}}, \code{\link{mcode_cache}}
+#' @seealso [mcode()], [mcode_cache()]
 #' 
+#' @md
 #' @export
 mread <- function(model, project = getOption("mrgsolve.project", getwd()), 
                   code = NULL, file = NULL, 

--- a/R/mread.R
+++ b/R/mread.R
@@ -83,7 +83,7 @@ NULL
 #' stored on disk.  The default is a temporary directory, so compilation 
 #' artifacts are lost when R restarts when the default is used.  Changing
 #' `soloc` to a persistent directory location will preserve those 
-#' artifacts across R restarts.  Also, if simulation from a single model is 
+#' artifacts across R restarts. Also, if simulation from a single model is 
 #' being done in separate processes on separate compute nodes, it might be 
 #' necessary to store these compilation artifacts in a local directory 
 #' to make them accessible to the different nodes. If the `soloc` 
@@ -95,7 +95,7 @@ NULL
 #' 
 #' @section Model Library:
 #' 
-#' mrgsolve comes bundled with several precoded PK, PK/PD, and 
+#' mrgsolve comes bundled with several pre-coded PK, PK/PD, and 
 #' other systems models that are accessible via the `mread()` interface.  
 #' 
 #' Models available in the library include:
@@ -123,15 +123,11 @@ NULL
 #' '
 #'
 #' mod <- mcode("ex_mread", code)
-#'
 #' mod
 #'
-#' mod %>% init(CENT=1000) %>% mrgsim %>% plot
+#' mod %>% init(CENT=1000) %>% mrgsim() %>% plot()
 #'
-#' 
 #' mod <- mread("irm3", modlib())
-#' 
-#' mod
 #' 
 #' # if the model is in the file mymodel.cpp
 #' mod <- mread("mymodel")
@@ -142,8 +138,6 @@ NULL
 #' or
 #' 
 #' mod <- mread_file("mymodel.txt")
-#' 
-#' 
 #' }
 #' 
 #' @seealso [mcode()], [mcode_cache()]

--- a/R/mread.R
+++ b/R/mread.R
@@ -50,7 +50,7 @@ NULL
 #' @param warn logical; if `TRUE`, print warning messages that may arise while
 #' building the model.
 #' @param udll use unique name for shared object.
-#' @param quiet don't print messages when compiling.
+#' @param quiet don't print messages from mrgsolve when compiling.
 #' @param preclean logical; if `TRUE`, compilation artifacts are 
 #' cleaned up first.
 #' @param recover if `TRUE`, a list of build will be returned in case

--- a/R/mrgindata.R
+++ b/R/mrgindata.R
@@ -43,15 +43,16 @@ numeric_data_matrix <- function(x, quiet = FALSE) {
   x
 }
 
-##' Prepare data.frame for input to mrgsim
-##' 
-##' @param x a input data set
-##' @param quiet logical indicating whether or not warnings 
-##' should be printed
-##' @param convert_lgl if \code{TRUE}, convert logical 
-##' columns with \code{\link{as.integer}}
-##' 
-##' @export
+#' Prepare data.frame for input to mrgsim()
+#' 
+#' @param x a input data set.
+#' @param quiet logical indicating whether or not warnings 
+#' should be printed.
+#' @param convert_lgl if `TRUE`, convert logical 
+#' columns with [as.integer()].
+#' 
+#' @md
+#' @export
 numerics_only <- function(x, quiet = FALSE, convert_lgl = FALSE) {
   if(convert_lgl) {
     if(any(vapply(x,is.logical,TRUE))) {
@@ -101,43 +102,43 @@ check_dropped_cols <- function(dm, x, check, context) {
   )
 }
 
-##' Validate and prepare data sets for simulation
-##'
-##' This function is called by [mrgsim()] and friends to check and prepare 
-##' input data sets for simulation.  Users may also call this function to 
-##' pre-validate data when the same data set is used for repeated simulation.
-##'
-##' @param x data.frame or matrix.
-##' @param m a model object.
-##' @param verbose logical.
-##' @param quiet if `TRUE`, messages will be suppressed.
-##' 
-##' @details
-##' An error will be issued when
-##' - non-numeric data is found in columns sharing names with model parameters
-##' - non-numeric data is found in reserved data items related to dosing 
-##'   (see `mrgsolve:::GLOBALS$CARRY_TRAN`)
-##' - a column is found that is "internally classed", including columns that 
-##'   inherit from `integer64` (see [is.object()])
-##' 
-##' @return A matrix with non-numeric columns dropped; if x is a 
-##' data.frame with character `cmt` column comprised of valid 
-##' compartment names and `m` is a model object,
-##' the `cmt` column will be converted to the corresponding 
-##' compartment number.
-##' 
-##' @seealso [valid_idata_set()], [idata_set()], [data_set()]
-##' 
-##' @examples
-##' 
-##' mod <- mrgsolve::house()
-##' 
-##' data(exTheoph)
-##' 
-##' d <- valid_data_set(exTheoph, mod)
-##' 
-##' @md
-##' @export
+#' Validate and prepare data sets for simulation
+#'
+#' This function is called by [mrgsim()] and friends to check and prepare 
+#' input data sets for simulation.  Users may also call this function to 
+#' pre-validate data when the same data set is used for repeated simulation.
+#'
+#' @param x data.frame or matrix.
+#' @param m a model object.
+#' @param verbose logical.
+#' @param quiet if `TRUE`, messages will be suppressed.
+#' 
+#' @details
+#' An error will be issued when
+#' - non-numeric data is found in columns sharing names with model parameters
+#' - non-numeric data is found in reserved data items related to dosing 
+#'   (see `mrgsolve:::GLOBALS$CARRY_TRAN`)
+#' - a column is found that is "internally classed", including columns that 
+#'   inherit from `integer64` (see [is.object()])
+#' 
+#' @return A matrix with non-numeric columns dropped; if x is a 
+#' data.frame with character `cmt` column comprised of valid 
+#' compartment names and `m` is a model object,
+#' the `cmt` column will be converted to the corresponding 
+#' compartment number.
+#' 
+#' @seealso [valid_idata_set()], [idata_set()], [data_set()]
+#' 
+#' @examples
+#' 
+#' mod <- mrgsolve::house()
+#' 
+#' data(exTheoph)
+#' 
+#' d <- valid_data_set(exTheoph, mod)
+#' 
+#' @md
+#' @export
 valid_data_set <- function(x, m = NULL, verbose = FALSE, quiet = FALSE) {
   
   if(is.valid_data_set(x)) return(x)
@@ -223,26 +224,26 @@ valid_data_set <- function(x, m = NULL, verbose = FALSE, quiet = FALSE) {
   dm
 }
 
-##' Validate and prepare idata data sets for simulation
-##' 
-##' This function is called by [mrgsim()] and friends to check and prepare 
-##' input data sets for simulation.  Users may also call this function to 
-##' pre-validate data when the same data set is used for repeated simulation.
-##' 
-##' @return A numeric matrix with class `valid_idata_set`.
-##' 
-##' @inheritParams valid_data_set
-##' 
-##' @seealso [valid_data_set()], [idata_set()], [data_set()]
-##' 
-##' @details
-##' An error will be issued when
-##' - non-numeric data is found in columns sharing names with model parameters
-##' - a column is found that is internally classed, including columns that 
-##'   inherit from `integer64` (see [is.object()])
-##' 
-##' @md
-##' @export
+#' Validate and prepare idata data sets for simulation
+#' 
+#' This function is called by [mrgsim()] and friends to check and prepare 
+#' input data sets for simulation.  Users may also call this function to 
+#' pre-validate data when the same data set is used for repeated simulation.
+#' 
+#' @return A numeric matrix with class `valid_idata_set`.
+#' 
+#' @inheritParams valid_data_set
+#' 
+#' @seealso [valid_data_set()], [idata_set()], [data_set()]
+#' 
+#' @details
+#' An error will be issued when
+#' - non-numeric data is found in columns sharing names with model parameters
+#' - a column is found that is internally classed, including columns that 
+#'   inherit from `integer64` (see [is.object()])
+#' 
+#' @md
+#' @export
 valid_idata_set <- function(x, m, verbose = FALSE, quiet = FALSE) {
   
   if(verbose) quiet <- FALSE

--- a/R/mrgsim_q.R
+++ b/R/mrgsim_q.R
@@ -1,4 +1,4 @@
-# Copyright (C) 2013 - 2020  Metrum Research Group
+# Copyright (C) 2013 - 2024  Metrum Research Group
 #
 # This file is part of mrgsolve.
 #

--- a/R/mrgsim_q.R
+++ b/R/mrgsim_q.R
@@ -17,82 +17,87 @@
 
 
 
-##' Simulate from a model object with quicker turnaround
-##' 
-##' Use the function when you would usually use \code{\link{mrgsim_d}}, 
-##' but you need a quicker turnaround time.  The timing differences 
-##' might be difficult to detect for a single simulation run
-##' but could become appreciable with repeated simulation.  See
-##' \code{details} for important differences in how \code{\link{mrgsim_q}}
-##' is invoked compared to \code{\link{mrgsim}} and \code{\link{mrgsim_d}}.  
-##' This function should always be used for benchmarking simulation time with
-##' mrgsolve.
-##' 
-##' 
-##' @param x a model object.
-##' @param data a simulation data set.
-##' @param recsort record sorting flag.
-##' @param stime a numeric vector of observation times; these observation
-##' times will only be added to the output if there are no observation
-##' records in \code{data}.
-##' @param skip_init_calc don't use \code{$MAIN} to calculate initial conditions.
-##' @param output output data type; if \code{mrgsims}, then the default output
-##' object is returned; if \code{"df"} then a data frame is returned.
-##' @param simcall not used; only the default value of 0 is allowed. 
-##' @param etasrc source for ETA() values in the model; values can include: 
-##' "omega", `"data"`, `"data.all"`, `"idata"`, or `"idata.all"`; see 
-##' 'Details' in [mrgsim()]. 
-##' 
-##' @details
-##' 
-##' This function does not support the piped simulation workflow.  All
-##' arguments must be passed into the function except for \code{x}.  
-##' 
-##' A data set is required for this simulation workflow.  The 
-##' data set can have only dosing records or doses with observations.
-##' When the data set only includes doses, a single numeric vector of 
-##' observation times should be passed in.  
-##' 
-##' This simulation workflow does not support \code{Req} (request) 
-##' functionality.  All compartments and captured variables will 
-##' always be returned in the simulation output.
-##' 
-##' This simulation workflow does not support carry-out functionality.
-##' 
-##' This simulation workflow does not accept arguments to be passed
-##' to \code{\link[mrgsolve]{update}}. This must be done by a separate
-##' call to \code{\link[mrgsolve]{update}}.
-##' 
-##' This simulation workflow does not support use of event objects.  If 
-##' an event object is needed, it should be converted to a data set 
-##' prior to the simulation run (see \code{as_data_set} or 
-##' \code{\link{as.data.frame.ev}}.
-##' 
-##' This simulation workflow does not support idata sets or any 
-##' feature enabled by idata set use.  Individual level parameters
-##' should be joined onto the data set prior to simulation.  Otherwise
-##' \code{\link{mrgsim_i}} or \code{\link{mrgsim_ei}} should be used.
-##' 
-##' By default, a mrgsims object is returned (as with \code{\link{mrgsim}}). 
-##' Use the \code{output="df"} argument to request a plain 
-##' data.frame of simulated data on return.
-##' 
-##' @return
-##' By default, an object of class `mrgsims`. Use `output = "df"` to return 
-##' a data frame.
-##' 
-##' @examples
-##' 
-##' mod <- mrgsolve::house()
-##' 
-##' data <- expand.ev(amt = c(100, 300, 1000))
-##' 
-##' out <- mrgsim_q(mod, data)
-##' 
-##' out
-##' 
-##' @seealso \code{\link{mrgsim}}, \code{\link{mrgsim_variants}}, \code{\link{qsim}}
-##' @export
+#' Simulate from a model object with quicker turnaround
+#' 
+#' Use the function when you would usually use [mrgsim_d()], 
+#' but you need a quicker turnaround time.  The timing differences 
+#' might be difficult to detect for a single simulation run
+#' but could become appreciable with repeated simulation.  See
+#' **Details** for important differences in how `mrgsim_q()`
+#' is invoked compared to [mrgsim()] and [mrgsim_d()].  
+#' This function should always be used for benchmarking simulation time with
+#' mrgsolve.
+#' 
+#' 
+#' @param x a model object.
+#' @param data a simulation data set.
+#' @param recsort record sorting flag.
+#' @param stime a numeric vector of observation times; these observation
+#' times will only be added to the output if there are no observation
+#' records in `data`.
+#' @param skip_init_calc don't use `$MAIN` to calculate initial conditions.
+#' @param output output data type; if `"mrgsims", then the default output
+#' object is returned; if `"df"` then a data frame is returned.
+#' @param simcall not used; only the default value of 0 is allowed. 
+#' @param etasrc source for ETA() values in the model; values can include: 
+#' "omega", `"data"`, `"data.all"`, `"idata"`, or `"idata.all"`; see 
+#' 'Details' in [mrgsim()]. 
+#' 
+#' @details
+#' `mrgsim_q()` mainly cuts some of the overhead from the simulation. So, the 
+#' primary efficiency gain from using `mrgsim_q()` comes when the simulation 
+#' executes very quickly. It is unlikely you will see a big performance
+#' difference between `mrgsim_q()` and [mrgsim()] when the model is difficult to 
+#' solve or if there is a large input data set. 
+#' 
+#' This function does not support the piped simulation workflow.  All
+#' arguments must be passed into the function except for `x`.  
+#' 
+#' A data set is required for this simulation workflow.  The 
+#' data set can have only dosing records or doses with observations.
+#' When the data set only includes doses, a single numeric vector of 
+#' observation times should be passed in.  
+#' 
+#' This simulation workflow does not support `Req` (request) 
+#' functionality.  All compartments and captured variables will 
+#' always be returned in the simulation output.
+#' 
+#' This simulation workflow does not support carry-out functionality.
+#' 
+#' This simulation workflow does not accept arguments to be passed
+#' to [mrgsolve::update()]. This must be done by a separate
+#' call to [mrgsolve::update()].
+#' 
+#' This simulation workflow does not support use of event objects.  If 
+#' an event object is needed, it should be converted to a data set 
+#' prior to the simulation run (see [as_data_set()] or 
+#' [as.data.frame()]).
+#' 
+#' This simulation workflow does not support idata sets or any 
+#' feature enabled by `idata` set use.  Individual level parameters
+#' should be joined onto the data set prior to simulation.  Otherwise
+#' [mrgsim_i()] or [mrgsim_ei()] should be used.
+#' 
+#' By default, a mrgsims object is returned (as with [mrgsim()]). 
+#' Use the `output = "df"` argument to request a plain 
+#' data.frame of simulated data on return.
+#' 
+#' @return
+#' By default, an object of class `mrgsims`. Use `output = "df"` to return 
+#' a data frame.
+#' 
+#' @examples
+#' mod <- mrgsolve::house()
+#' 
+#' data <- expand.ev(amt = c(100, 300, 1000))
+#' 
+#' out <- mrgsim_q(mod, data)
+#' 
+#' out
+#' 
+#' @seealso [mrgsim()], [mrgsim_variants], [qsim()]
+#' @md
+#' @export
 mrgsim_q <- function(x,
                      data,
                      recsort = 1,

--- a/R/mrgsims.R
+++ b/R/mrgsims.R
@@ -1,4 +1,4 @@
-# Copyright (C) 2013 - 2020  Metrum Research Group
+# Copyright (C) 2013 - 2024  Metrum Research Group
 #
 # This file is part of mrgsolve.
 #
@@ -16,72 +16,70 @@
 # along with mrgsolve.  If not, see <http://www.gnu.org/licenses/>.
 
 
-##' Methods for working with \code{mrgsims} objects
-##'
-##' These methods help the user view simulation output and extract 
-##' simulated data to work with further.  The methods listed here 
-##' for the most part have generics defined by R or other R packages.  
-##' See the \code{seealso} section for other methods defined 
-##' by \code{mrgsolve} that have their own documentation pages.
-##'
-##' @details
-##' Most methods should behave as expected according to other method 
-##' commonly used in R (e.g. head, tail, as.data.frame, etc ...)
-##'
-##' \itemize{
-##'   \item{\code{$}} selects a column in the simulated data and 
-##'   returns numeric
-##'   \item{\code{head}} see \code{\link{head.matrix}}; returns 
-##'   simulated data
-##'   \item{\code{tail}} see \code{\link{tail.matrix}}; returns 
-##'   simulated data
-##'   \item{\code{dim}, \code{nrow}, \code{ncol}} returns dimensions, 
-##'   number of rows, and number of columns in simulated data
-##'   \item{\code{as.data.frame}} coerces simulated data to data.frame 
-##'   and returns the data.frame
-##'   \item{\code{as.matrix}} returns matrix of simulated data
-##'   \item{\code{summary}} coerces simulated data to data.frame 
-##'   and passes to \code{\link{summary.data.frame}}
-##'   \item{\code{plot}} plots simulated data; see \code{\link{plot_mrgsims}}
-##' }
-##' @param x mrgsims object
-##' @param ... passed to other functions
-##' @aliases mrgsims
-##' @seealso  \code{\link{stime}}
-##' @name mrgsims
-##' @rdname mrgsims
-##' @examples
-##'
-##' ## example("mrgsims")
-##'
-##' mod <- mrgsolve::house() %>% init(GUT=100)
-##'
-##' out <- mrgsim(mod)
-##' 
-##' class(out)
-##'
-##' \dontrun{
-##' out
-##' }
-##' head(out)
-##' tail(out)
-##'
-##'
-##' dim(out)
-##' names(out)
-##'
-##' mat <- as.matrix(out)
-##' df <- as.data.frame(out)
-##' 
-##' \dontrun{
-##' out$CP
-##' }
-##'
-##' plot(out)
-##' \dontrun{
-##' plot(out, CP~.)
-##' plot(out, CP+RESP~time, scales="same", xlab="Time", main="Model sims")
-##' }
+#' Methods for working with `mrgsims` objects
+#'
+#' These methods help the user view simulation output and extract 
+#' simulated data to work with further.  The methods listed here 
+#' for the most part have generics defined by R or other R packages.  
+#' See the **See Also** section for other methods defined 
+#' by mrgsolve that have their own documentation pages.
+#'
+#' @details
+#' Most methods should behave as expected according to other method 
+#' commonly used in R (e.g. head, tail, as.data.frame, etc ...)
+#'
+#' - `$` selects a column in the simulated data and 
+#'   returns numeric
+#' - `head()` see [head.matrix()]; returns simulated data
+#' - `tail()` see [tail.matrix()]; returns simulated data
+#' - `dim()`, `nrow()`, `ncol()` returns dimensions, 
+#'   number of rows, and number of columns in simulated data
+#' - `as.data.frame()` coerces simulated data to data.frame 
+#' - `as.matrix()` returns matrix of simulated data
+#' - `summary()` coerces simulated data to data.frame and passes to 
+#'   [summary.data.frame()]
+#' - [plot()] plots simulated data; see [plot_mrgsims]
+#'   
+#' @param x mrgsims object.
+#' @param ... passed to other functions.
+#' @aliases mrgsims
+#' @seealso  [stime()]
+#' @name mrgsims
+#' @rdname mrgsims
+#' @examples
+#'
+#' ## example("mrgsims")
+#'
+#' mod <- mrgsolve::house() %>% init(GUT=100)
+#'
+#' out <- mrgsim(mod)
+#' 
+#' class(out)
+#'
+#' \dontrun{
+#' out
+#' }
+#' head(out)
+#' tail(out)
+#'
+#'
+#' dim(out)
+#' names(out)
+#'
+#' mat <- as.matrix(out)
+#' df <- as.data.frame(out)
+#' 
+#' \dontrun{
+#' out$CP
+#' }
+#'
+#' plot(out)
+#' 
+#' \dontrun{
+#' plot(out, CP~.)
+#' plot(out, CP+RESP~time, scales="same", xlab="Time", main="Model sims")
+#' }
+#' @md
 NULL
 
 
@@ -260,8 +258,8 @@ as.tbl.mrgsims <- function(x,...) {
 #' These functions modify the simulated data in an mrgsims object and return 
 #' the modified object.  Contrast with the functions in [mrgsims_dplyr].
 #' 
-#' @param .data a mrgsims object
-#' @param ... other arguments passed to the `dplyr` functions
+#' @param .data a mrgsims object.
+#' @param ... other arguments passed to the `dplyr` functions.
 #' 
 #' @examples
 #' 
@@ -309,10 +307,11 @@ filter_sims <- function(.data, ... ) {
   .data
 }
 
-##' @rdname mrgsims
-##' @param row.names passed to \code{\link{as.data.frame}}
-##' @param optional passed to \code{\link{as.data.frame}}
-##' @export
+#' @rdname mrgsims
+#' @param row.names passed to [as.data.frame()].
+#' @param optional passed to [as.data.frame()].
+#' @md
+#' @export
 setMethod("as.data.frame", "mrgsims", function(x,row.names=NULL, optional=FALSE,...) {
   return(as.data.frame(x@data,row.names,optional,...))
 })
@@ -325,9 +324,9 @@ setMethod("as.matrix", "mrgsims", function(x,...) {
   return(as.matrix(x@data))
 })
 
-##' @param object passed to show
-##' @rdname mrgsims
-##' @export
+#' @param object passed to show.
+#' @rdname mrgsims
+#' @export
 summary.mrgsims <- function(object,...) {
   summary(as.data.frame(object))
 }

--- a/R/mrgsolve.R
+++ b/R/mrgsolve.R
@@ -785,23 +785,23 @@ do_mrgsim <- function(x,
 #' Basic, simple simulation from model object
 #' 
 #' This is just a lighter version of [mrgsim()], with fewer options.  
-#' See `Details`.  
+#' See **Details**.  
 #' 
 #' @inheritParams mrgsim
 #' 
-#' @param data can be either event object or data set
+#' @param data can be either event object or data set.
 #' @param output output data type; the default is `mrgsims`, which returns the 
 #' default output object; other options include `df` (for data.frame) or 
-#' `matrix`
+#' `matrix`.
 #' @param outvars output items to request; if missing, then only captured items 
-#' will be returned in the output
-#' @param Req synonym for outvars
+#' will be returned in the output.
+#' @param Req synonym for `outvars`.
 #' 
 #' @details
 #' There is no pipeline interface for this function; all configuration options 
-#' (see `Arguments`) must be passed as formal arguments to the function.  
+#' (see **Arguments**) must be passed as formal arguments to the function.  
 #' You can't `carry_out`, `Request` specific columns, or pass items in for update.  
-#' Some other limitations, but only convenience-related.  See `Arguments` for 
+#' Some other limitations, but only convenience-related.  See **Arguments** for 
 #' available options.  Specifically, there is no `...` argument for this function.
 #' Use the [mrgsolve::update()] method to update the model object. 
 #' 
@@ -816,7 +816,6 @@ do_mrgsim <- function(x,
 #' @seealso [mrgsim_q()], [mrgsim()], [mrgsim_variants]
 #' 
 #' @md
-#' 
 #' @export
 qsim <- function(x,
                  data,

--- a/R/mrgsolve.R
+++ b/R/mrgsolve.R
@@ -1,4 +1,4 @@
-# Copyright (C) 2013 - 2020  Metrum Research Group
+# Copyright (C) 2013 - 2024  Metrum Research Group
 #
 # This file is part of mrgsolve.
 #
@@ -114,42 +114,42 @@ tgrid_id <- function(col,idata) {
 #' [mrgsim_variants] for other mrgsim-like functions that have more focused 
 #' inputs. `mrgsim_df` coerces output to data.frame prior to returning.
 #'
-#' @param x the model object
-#' @param data NMTRAN-like data set (see [data_set()])
+#' @param x the model object.
+#' @param data NMTRAN-like data set (see [data_set()]).
 #' @param idata a matrix or data frame of model parameters, 
-#' one parameter per row (see [idata_set()])
-#' @param events an event object
+#' one parameter per row (see [idata_set()]).
+#' @param events an event object.
 #' @param nid integer number of individuals to simulate; only used if 
-#' idata and data are missing
+#' idata and data are missing.
 #' @param ... passed to [mrgsolve::update()] and 
-#' [do_mrgsim()]
+#' [do_mrgsim()].
 #' 
-#' @return An object of class [mrgsims]
+#' @return An object of class [mrgsims].
 #' 
 #' 
 #' @details
 #' 
 #' - Use [mrgsim_df()] to return a data frame rather than 
-#' `mrgsims` object
+#' `mrgsims` object.
 #' 
 #' - Both `data` and `idata` will be coerced to numeric matrix
 #' 
 #' - `carry_out` can be used to insert data columns into the output 
 #' data set. This is partially dependent on the nature of the data brought 
-#' into the problem
+#' into the problem.
 #' 
 #' - When using `data` and `idata` together, an error is 
 #' generated if an  ID occurs in `data` but not `idata`.  
 #' Also, when looking up data in `idata`, ID in `idata` is 
 #' assumed to be uniquely keyed to ID in `data`.  No error is 
 #' generated if ID is duplicated in `data`; parameters will be used 
-#' from the first occurrence found in `idata`
+#' from the first occurrence found in `idata`.
 #'  
 #' - `carry_out`: `idata` is assumed to be individual-level and variables that 
 #' are carried from `idata` are repeated throughout the individual's simulated 
 #' data.  Variables carried from `data` are carried via last-observation carry 
 #' forward.  `NA` is returned from observations that are inserted into 
-#' simulated output that occur prior to the first record in `data`
+#' simulated output that occur prior to the first record in `data`.
 #' 
 #' - `recover`: this is similar to `carry_out` with respect to 
 #' end result, but it uses a different process.  Columns to be recovered are 

--- a/R/mrgsolve.R
+++ b/R/mrgsolve.R
@@ -784,8 +784,8 @@ do_mrgsim <- function(x,
 
 #' Basic, simple simulation from model object
 #' 
-#' This is just a lighter version of [mrgsim()], with fewer options.  
-#' See **Details**.  
+#' This is just a lighter version of [mrgsim()], with fewer options but with 
+#' better efficiency in certain cases.  See **Details**.  
 #' 
 #' @inheritParams mrgsim
 #' 
@@ -798,12 +798,19 @@ do_mrgsim <- function(x,
 #' @param Req synonym for `outvars`.
 #' 
 #' @details
+#' `qsim()` mainly cuts some of the overhead from the simulation. So, the 
+#' primary efficiency gain from using `qsim()` comes when the simulation 
+#' executes very quickly. It is unlikely you will see a big performance
+#' difference between `qsim()` and [mrgsim()] when the model is difficult to 
+#' solve or if there is a large input data set. 
+#' 
 #' There is no pipeline interface for this function; all configuration options 
 #' (see **Arguments**) must be passed as formal arguments to the function.  
 #' You can't `carry_out`, `Request` specific columns, or pass items in for update.  
 #' Some other limitations, but only convenience-related.  See **Arguments** for 
 #' available options.  Specifically, there is no `...` argument for this function.
 #' Use the [mrgsolve::update()] method to update the model object. 
+#' 
 #' 
 #' @examples
 #' 

--- a/R/nmxml.R
+++ b/R/nmxml.R
@@ -16,60 +16,60 @@
 # along with mrgsolve.  If not, see <http://www.gnu.org/licenses/>.
 
 
-##' Import model estimates from a NONMEM xml file
-##'
-##' @param run run number
-##' @param project project directory
-##' @param path the complete path to the \code{run.xml} file
-##' @param file deprecated; use \code{path} instead
-##' @param root the directory that `path` and `project` are relative to; this is
-##' currently limited to the `working` directory or `cppdir`, the directory 
-##' where the model file is located
-##' @param theta logical; if TRUE, the \code{$THETA} vector is returned
-##' @param omega logical; if TRUE, the \code{$OMEGA} matrix is returned
-##' @param sigma logical; if TRUE, the \code{$SIGMA} matrix is returned
-##' @param olabels labels for \code{$OMEGA}
-##' @param slabels labels for \code{$SIGMA}
-##' @param oprefix prefix for \code{$OMEGA} labels
-##' @param sprefix prefix for \code{$SIGMA} labels
-##' @param tname name for \code{$THETA}
-##' @param oname name for \code{$OMEGA}
-##' @param sname name for \code{$SIGMA}
-##' @param index the estimation number to return;  "last" will return the 
-##' last estimation results; otherwise, pass an integer indicating which 
-##' estimation results to return
-##' @param xpath xml path containing run results; if the default doesn't work, 
-##' consider using \code{.//estimation} as an alternative; see details
-##' @param env internal
-##' @aliases NMXML
-##' @details
-##' If \code{run} and \code{project} are supplied, the .xml file is 
-##' assumed to be located in \code{run.xml}, in directory \code{run} 
-##' off the \code{project} directory.  If \code{file} is supplied, 
-##' \code{run} and \code{project} arguments are ignored.
-##' 
-##' This function requires that the \code{xml2} package 
-##' be installed and loadable.  If \code{requireNamespace("xml2")}
-##' fails, an error will be generated. 
-##' 
-##' \code{nmxml} usually expects to find run results in the xpath called
-##' \code{.//nm:estimation}.  Occasionally, the run results are not stored in 
-##' this namespace but no namespaces are found in the xml file.  In this case, 
-##' the user can specify the xpath containing run results.  Consider trying 
-##' \code{.//estimation} as an alternative if the default fails. 
-##' 
-##' @return A list with theta, omega and sigma elements, 
-##' depending on what was requested
-##'  
-##' @seealso nmext
-##'  
-##' @examples
-##' 
-##' if(requireNamespace("xml2")) {
-##'   proj <- system.file("nonmem", package = "mrgsolve")
-##'   mrgsolve:::nmxml(run = 1005, project = proj)
-##' }
-##' 
+#' Import model estimates from a NONMEM xml file
+#'
+#' @param run run number.
+#' @param project project directory.
+#' @param path the complete path to the `run.xml` file.
+#' @param file deprecated; use `path` instead.
+#' @param root the directory that `path` and `project` are relative to; this is
+#' currently limited to the `working` directory or `cppdir`, the directory 
+#' where the model file is located.
+#' @param theta logical; if TRUE, the `$THETA` vector is returned.
+#' @param omega logical; if TRUE, the `$OMEGA` matrix is returned.
+#' @param sigma logical; if TRUE, the `$SIGMA` matrix is returned.
+#' @param olabels labels for `$OMEGA`.
+#' @param slabels labels for `$SIGMA`.
+#' @param oprefix prefix for `$OMEGA` labels.
+#' @param sprefix prefix for `$SIGMA` labels.
+#' @param tname name for `$THETA`.
+#' @param oname name for `$OMEGA`.
+#' @param sname name for `$SIGMA`.
+#' @param index the estimation number to return;  "last" will return the 
+#' last estimation results; otherwise, pass an integer indicating which 
+#' estimation results to return.
+#' @param xpath xml path containing run results; if the default doesn't work, 
+#' consider using `.//estimation` as an alternative; see details.
+#' @param env internal use only.
+#' @aliases NMXML
+#' @details
+#' If `run` and `project` are supplied, the `.xml` file is 
+#' assumed to be located in `run.xml`, in directory `run` 
+#' off the `project` directory.  If `file` is supplied, 
+#' `run` and `project` arguments are ignored.
+#' 
+#' This function requires that the xml2 package 
+#' be installed and loadable.  If `requireNamespace("xml2")`
+#' fails, an error will be generated. 
+#' 
+#' `nmxml` usually expects to find run results in the xpath called
+#' `.//nm:estimation`.  Occasionally, the run results are not stored in 
+#' this namespace but no namespaces are found in the xml file.  In this case, 
+#' the user can specify the xpath containing run results.  Consider trying 
+#' `.//estimation` as an alternative if the default fails. 
+#' 
+#' @return A list with theta, omega and sigma elements, depending on what was 
+#' requested.
+#'  
+#' @seealso nmext
+#'  
+#' @examples
+#' 
+#' if(requireNamespace("xml2")) {
+#'   proj <- system.file("nonmem", package = "mrgsolve")
+#'   mrgsolve:::nmxml(run = 1005, project = proj)
+#' }
+#' @md
 nmxml <- function(run = numeric(0), project = character(0),
                   file = character(0), path = character(0),
                   root = c("working", "cppfile"), 
@@ -219,8 +219,8 @@ nmxml <- function(run = numeric(0), project = character(0),
 #' Import model estimates from a NONMEM ext file
 #' 
 #' @inheritParams nmxml
-#' @param path full path to NONMEM `ext` file
-#' @param read_fun function to use when reading the `ext` file
+#' @param path full path to NONMEM `ext` file.
+#' @param read_fun function to use when reading the `ext` file.
 #' 
 #' @seealso [nmxml()], [read_nmext()]
 #' 
@@ -331,43 +331,43 @@ nm_xml_matrix <- function(x) {
   m
 }
 
-##' Extract estimates from NONMEM ext file
-##' 
-##' This function retrieves NONMEM estimates for use in the mrgsolve model when 
-##' `$NMEXT` is invoked. See [nmext()].
-##' 
-##' @param run a run number or run identifier
-##' @param project the NONMEM project directory
-##' @param file the `ext` file name
-##' @param path full path and file name for `ext` file
-##' @param read_fun function to read the `ext` file; [data.table::fread()] will 
-##' be used if available; otherwise [utils::read.table()] is used. 
-##' @param index selects the table number whose results will be returned;
-##' use value "last" to select the last table in the `.ext` file; or pass an 
-##' integer specifying the table number; in case there is exactly
-##' one table in the `.ext` file, pass the value "single" to bypass parsing 
-##' the file to look for sub tables (this might be useful when BAYES analysis 
-##' was performed as the only estimation method and there are 10000s of 
-##' posterior samples in the file)
-##' 
-##' @return A list with param, omega, and sigma in a format ready to be used to 
-##' update a model object.
-##' 
-##' @examples
-##' project <- system.file("nonmem", package = "mrgsolve")
-##' 
-##' est <- read_nmext(1005, project = project)
-##' 
-##' est$param
-##' 
-##' est$omega
-##' 
-##' est$sigma
-##' 
-##' est <- read_nmext(2005, project = project, index = 3)
-##' 
-##' @md
-##' @export 
+#' Extract estimates from NONMEM ext file
+#' 
+#' This function retrieves NONMEM estimates for use in the mrgsolve model when 
+#' `$NMEXT` is invoked. See [nmext()].
+#' 
+#' @param run a run number or run identifier.
+#' @param project the NONMEM project directory.
+#' @param file the `ext` file name.
+#' @param path full path and file name for `ext` file.
+#' @param read_fun function to read the `ext` file; [data.table::fread()] will 
+#' be used if available; otherwise [utils::read.table()] is used. 
+#' @param index selects the table number whose results will be returned;
+#' use value "last" to select the last table in the `.ext` file; or pass an 
+#' integer specifying the table number; in case there is exactly
+#' one table in the `.ext` file, pass the value "single" to bypass parsing 
+#' the file to look for sub tables (this might be useful when BAYES analysis 
+#' was performed as the only estimation method and there are 10000s of 
+#' posterior samples in the file).
+#' 
+#' @return A list with param, omega, and sigma in a format ready to be used to 
+#' update a model object.
+#' 
+#' @examples
+#' project <- system.file("nonmem", package = "mrgsolve")
+#' 
+#' est <- read_nmext(1005, project = project)
+#' 
+#' est$param
+#' 
+#' est$omega
+#' 
+#' est$sigma
+#' 
+#' est <- read_nmext(2005, project = project, index = 3)
+#' 
+#' @md
+#' @export 
 read_nmext <- function(run = NA_real_, 
                        project = getwd(), 
                        file = paste0(run,".ext"), 

--- a/R/nmxml.R
+++ b/R/nmxml.R
@@ -1,4 +1,4 @@
-# Copyright (C) 2013 - 2023  Metrum Research Group
+# Copyright (C) 2013 - 2024  Metrum Research Group
 #
 # This file is part of mrgsolve.
 #

--- a/R/realize_addl.R
+++ b/R/realize_addl.R
@@ -1,4 +1,4 @@
-# Copyright (C) 2013 - 2022  Metrum Research Group
+# Copyright (C) 2013 - 2024  Metrum Research Group
 #
 # This file is part of mrgsolve.
 #
@@ -22,14 +22,14 @@
 ##' include one record for every dose. In the result, no record with have 
 ##' `ii` or `addl` set to non-zero value.
 ##' 
-##' @param x a `data_set` data frame or an event object (see details)
+##' @param x a `data_set` data frame or an event object (see details).
 ##' @param warn if `TRUE` a warning is issued if no `ADDL` or
-##' `addl` column is found
-##' @param mark_new if `TRUE`, a flag is added to indicate new columns
+##' `addl` column is found.
+##' @param mark_new if `TRUE`, a flag is added to indicate new columns.
 ##' @param fill specifies how to handle non-dose related data columns
 ##' in new data set records; this option is critical when handling 
-##' data sets with time-varying, non-dose-related data items; see details
-##' @param ... not used
+##' data sets with time-varying, non-dose-related data items; see **Details**.
+##' @param ... not used.
 ##' 
 ##' @examples
 ##' e <- ev(amt = 100, ii = 12, addl = 3)
@@ -59,7 +59,7 @@
 ##' 
 ##' Use caution when passing in data that has non-dose-related data 
 ##' columns that vary within a subject and pay special attention
-##' to the `fill` argument. By definition, `realize_addl`
+##' to the `fill` argument. By definition, `realize_addl()`
 ##' will add new rows to your data frame and it is not obvious 
 ##' how the non-dose-related data should be handled in these new 
 ##' rows.  When `inherit` is chosen, the new records have

--- a/R/realize_addl.R
+++ b/R/realize_addl.R
@@ -22,7 +22,7 @@
 ##' include one record for every dose. In the result, no record with have 
 ##' `ii` or `addl` set to non-zero value.
 ##' 
-##' @param x a `data_set` data frame or an event object (see details).
+##' @param x a `data_set` data frame or an event object (see **Details**).
 ##' @param warn if `TRUE` a warning is issued if no `ADDL` or
 ##' `addl` column is found.
 ##' @param mark_new if `TRUE`, a flag is added to indicate new columns.

--- a/R/realize_addl.R
+++ b/R/realize_addl.R
@@ -16,75 +16,75 @@
 # along with mrgsolve.  If not, see <http://www.gnu.org/licenses/>.
 
 
-##' Make addl doses explicit in an event object or data set
-##' 
-##' When doses are scheduled with `ii` and `addl`, the object is expanded to 
-##' include one record for every dose. In the result, no record with have 
-##' `ii` or `addl` set to non-zero value.
-##' 
-##' @param x a `data_set` data frame or an event object (see **Details**).
-##' @param warn if `TRUE` a warning is issued if no `ADDL` or
-##' `addl` column is found.
-##' @param mark_new if `TRUE`, a flag is added to indicate new columns.
-##' @param fill specifies how to handle non-dose related data columns
-##' in new data set records; this option is critical when handling 
-##' data sets with time-varying, non-dose-related data items; see **Details**.
-##' @param ... not used.
-##' 
-##' @examples
-##' e <- ev(amt = 100, ii = 12, addl = 3)
-##' 
-##' realize_addl(e)
-##' 
-##' a <- ev(amt = 100, ii = 12, addl = 2, WT = 69)
-##' b <- ev(amt = 200, ii = 24, addl = 2, WT = 70)
-##' c <- ev(amt =  50, ii =  6, addl = 2, WT = 71) 
-##' 
-##' e <- ev_seq(a,b,c)
-##' realize_addl(e, mark_new = TRUE)
-##' 
-##' @return 
-##' A `data_set` data.frame or event object, consistent with the type of `x`.
-##' The `ii` and `addl` columns will all be set to zero. The result is always
-##' ungrouped.
-##' 
-##' @details
-##' 
-##' If no `addl` column is found the data frame is returned and 
-##' a warning is issued if `warn` is true. If `ii`, 
-##' `time`, or `evid` are missing, an error is generated.
-##' 
-##' If a grouped data.frame (via [dplyr::group_by()]) is passed, it will be
-##' ungrouped.
-##' 
-##' Use caution when passing in data that has non-dose-related data 
-##' columns that vary within a subject and pay special attention
-##' to the `fill` argument. By definition, `realize_addl()`
-##' will add new rows to your data frame and it is not obvious 
-##' how the non-dose-related data should be handled in these new 
-##' rows.  When `inherit` is chosen, the new records have
-##' non-dose-related data that is identical to the originating 
-##' dose record. This should be fine when these data items are not 
-##' varying with time, but will present a problem when the data
-##' are varying with time.  When `locf` is chosen, 
-##' the missing data are filled in with `NA` and an
-##' last observation carry forward operation is applied to 
-##' **every** column in the data set.  This may not be what 
-##' you want if you already had missing values in the input 
-##' data set and want to preserve that missingness. When `na`
-##' is chosen, the missing data are filled in with `NA` and 
-##' no `locf` operation is applied.  But note that these
-##' missing values may be problematic for a mrgsolve simulation 
-##' run. If you have any time-varying columns or missing data
-##' in your data set, be sure to check that the output from 
-##' this function is what you were expecting. 
-##' 
-##' @md 
-##' @export
+#' Make addl doses explicit in an event object or data set
+#' 
+#' When doses are scheduled with `ii` and `addl`, the object is expanded to 
+#' include one record for every dose. In the result, no record with have 
+#' `ii` or `addl` set to non-zero value.
+#' 
+#' @param x a `data_set` data frame or an event object (see **Details**).
+#' @param warn if `TRUE` a warning is issued if no `ADDL` or
+#' `addl` column is found.
+#' @param mark_new if `TRUE`, a flag is added to indicate new columns.
+#' @param fill specifies how to handle non-dose related data columns
+#' in new data set records; this option is critical when handling 
+#' data sets with time-varying, non-dose-related data items; see **Details**.
+#' @param ... not used.
+#' 
+#' @examples
+#' e <- ev(amt = 100, ii = 12, addl = 3)
+#' 
+#' realize_addl(e)
+#' 
+#' a <- ev(amt = 100, ii = 12, addl = 2, WT = 69)
+#' b <- ev(amt = 200, ii = 24, addl = 2, WT = 70)
+#' c <- ev(amt =  50, ii =  6, addl = 2, WT = 71) 
+#' 
+#' e <- ev_seq(a,b,c)
+#' realize_addl(e, mark_new = TRUE)
+#' 
+#' @return 
+#' A data.frame or event object, consistent with the type of `x`.
+#' The `ii` and `addl` columns will all be set to zero. The result is always
+#' ungrouped.
+#' 
+#' @details
+#' 
+#' If no `addl` column is found the data frame is returned and 
+#' a warning is issued if `warn` is true. If `ii`, 
+#' `time`, or `evid` are missing, an error is generated.
+#' 
+#' If a grouped data.frame (via [dplyr::group_by()]) is passed, it will be
+#' ungrouped.
+#' 
+#' Use caution when passing in data that has non-dose-related data 
+#' columns that vary within a subject and pay special attention
+#' to the `fill` argument. By definition, `realize_addl()`
+#' will add new rows to your data frame and it is not obvious 
+#' how the non-dose-related data should be handled in these new 
+#' rows.  When `inherit` is chosen, the new records have
+#' non-dose-related data that is identical to the originating 
+#' dose record. This should be fine when these data items are not 
+#' varying with time, but will present a problem when the data
+#' are varying with time.  When `locf` is chosen, 
+#' the missing data are filled in with `NA` and an
+#' last observation carry forward operation is applied to 
+#' **every** column in the data set.  This may not be what 
+#' you want if you already had missing values in the input 
+#' data set and want to preserve that missingness. When `na`
+#' is chosen, the missing data are filled in with `NA` and 
+#' no `locf` operation is applied.  But note that these
+#' missing values may be problematic for a mrgsolve simulation 
+#' run. If you have any time-varying columns or missing data
+#' in your data set, be sure to check that the output from 
+#' this function is what you were expecting. 
+#' 
+#' @md 
+#' @export
 realize_addl <- function(x,...) UseMethod("realize_addl")
 
-##' @rdname realize_addl
-##' @export
+#' @rdname realize_addl
+#' @export
 realize_addl.data.frame <- function(x, warn = FALSE, mark_new = FALSE, 
                                     fill = c("inherit", "na", "locf"), 
                                     ...) {
@@ -185,8 +185,8 @@ realize_addl.data.frame <- function(x, warn = FALSE, mark_new = FALSE,
   as.data.frame(df)
 }
 
-##' @rdname realize_addl
-##' @export
+#' @rdname realize_addl
+#' @export
 realize_addl.ev <- function(x,...) {
   x@data <- realize_addl(x@data,...)
   return(x)

--- a/R/utils.R
+++ b/R/utils.R
@@ -374,9 +374,9 @@ build_path <- function(x) {
   return(x)
 }
 
-##' Set RNG to use L'Ecuyer-CMRG
-##'
-##' @export
+#' Set RNG to use L'Ecuyer-CMRG
+#'
+#' @export
 mcRNG <- function() base::RNGkind("L'Ecuyer-CMRG")
 
 as_character_args <- function(x) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -330,28 +330,28 @@ cvec.character <- as.cvec
 ##' @keywords internal
 s_ <- function(...) as.character(match.call(expand.dots=TRUE))[-1] #nocov
 
-##' Access or clear arguments for calls to mrgsim
-##' 
-##' As a model object navigates a pipeline prior to simulation, arguments are
-##' collected to eventually be passed to [mrgsim()]. `simargs` lets you 
-##' intercept and possibly clear those arguments.
-##'
-##' @param x model object
-##' @param clear logical indicating whether or not to clear `args` from 
-##' the model object
-##' @param which character with length 1 naming a single arg to get
-##' @param ... passed along
-##' 
-##' @return If `clear` is `TRUE`, the argument list is 
-##' cleared and the model object is returned.  Otherwise, the argument 
-##' list is returned.
-##' 
-##' @examples
-##' mod <- mrgsolve::house()
-##' mod %>% Req(CP, RESP) %>% carry_out(evid, WT, FLAG) %>% simargs()
-##' 
-##' @md
-##' @export
+#' Access or clear arguments for calls to mrgsim()
+#' 
+#' As a model object navigates a pipeline prior to simulation, arguments are
+#' collected to eventually be passed to [mrgsim()]. `simargs()` lets you 
+#' intercept and possibly clear those arguments.
+#'
+#' @param x model object.
+#' @param clear logical indicating whether or not to clear `args` from 
+#' the model object.
+#' @param which character with length 1 naming a single arg to get.
+#' @param ... not used. 
+#' 
+#' @return If `clear` is `TRUE`, the argument list is 
+#' cleared and the model object is returned.  Otherwise, the argument 
+#' list is returned.
+#' 
+#' @examples
+#' mod <- mrgsolve::house()
+#' mod %>% Req(CP, RESP) %>% carry_out(evid, WT, FLAG) %>% simargs()
+#' 
+#' @md
+#' @export
 simargs <- function(x, which = NULL, clear = FALSE,...) {
   
   if(clear) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,4 +1,4 @@
-# Copyright (C) 2013 - 2023  Metrum Research Group
+# Copyright (C) 2013 - 2024  Metrum Research Group
 #
 # This file is part of mrgsolve.
 #
@@ -212,19 +212,28 @@ my_str_split <- function(string,pattern,n=3,fixed=FALSE,collapse=pattern) {
 #' Create template data sets for simulation
 #' 
 #' These functions expand all combinations of arguments using 
-#' [expand.grid()]. The result always has only one row for one individual.
-#' Use [expand.evd()] or [evd_expand()] to convert nmtran names (e.g. AMT
-#' or CMT) to upper case (see [uctran()]).
+#' [expand.grid()]. `expand.idata()` generates an `idata` set; the others 
+#' generate a full data set. The result always has only one row for one 
+#' individual. Use `expand.evd()` or `evd_expand()` to render NMTRAN names 
+#' (e.g. `AMT` or `CMT`) in upper case.
 #'
-#' @param ... passed to [expand.grid()]
+#' @param ... passed to [expand.grid()].
 #' 
 #' @details
-#' An ID column is added as `seq(nrow(ans))` if not supplied by the user. For 
-#' `expand.ev`, defaults also added include `cmt = 1`, `time = 0`, `evid = 1`.  
-#' If `total` is included, then `addl` is derived as `total` - 1. If `tinf` is 
-#' included, then an infusion rate is derived for row where `tinf` is greater 
-#' than zero.
-#'
+#' An ID column is added as if not supplied by the user. In the output data 
+#' frame, ID is always re-written as the row number.
+#' 
+#' For `expand.ev()`, defaults also added include `cmt = 1`, `time = 0`, 
+#' `evid = 1`. If `total` is included, then `addl` is derived as `total-1`. 
+#' If `tinf` is included, then an infusion rate is derived for row where 
+#' `tinf` is greater than zero.
+#' 
+#' `ev_expand()` is a synonym for `expand.ev()` and `evd_expand()` is a 
+#' synonym for `expand.evd()`. 
+#' 
+#' @return A data frame containing one row for each combination of the items
+#' passed in `...`. The result always has ID set to the row number. 
+#' 
 #' @examples
 #' idata <- expand.idata(CL = c(1,2,3), VC = c(10,20,30))
 #'

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,7 +1,7 @@
 template:
   bootstrap: 5
 title: mrgsolve
-url: https://github.com/metrumresearchgroup/mrgsolve
+url: https://mrgsolve.org
 # navbar:
 #   right:
 #   - icon: fa-github fa-lg

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,7 +1,7 @@
 template:
   bootstrap: 5
 title: mrgsolve
-url: https://mrgsolve.org
+url: https://mrgsolve.org/docs
 # navbar:
 #   right:
 #   - icon: fa-github fa-lg

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,6 +1,7 @@
 template:
   bootstrap: 5
 title: mrgsolve
+url: https://github.com/metrumresearchgroup/mrgsolve
 # navbar:
 #   right:
 #   - icon: fa-github fa-lg

--- a/man/Req.Rd
+++ b/man/Req.Rd
@@ -13,31 +13,31 @@ req(x, ...)
 \method{req}{mrgmod}(x, ...)
 }
 \arguments{
-\item{x}{model object}
+\item{x}{model object.}
 
-\item{...}{unquoted names of compartments or tabled items}
+\item{...}{unquoted names of compartments or tabled items.}
 }
 \description{
-Use this function to select, by name, either compartments or derived 
-variables that have been captured (see \code{\link{CAPTURE}}) into
+Use this function to select, by name, either compartments or derived
+variables that have been captured (see \link{CAPTURE}) into
 the simulated output.
 }
 \details{
-There is also a \code{Req} argument to \code{\link{mrgsim}} that can 
-be set to accomplish the same thing as a call to \code{Req} in 
+There is also a \code{Req} argument to \code{\link[=mrgsim]{mrgsim()}} that can
+be set to accomplish the same thing as a call to \code{Req} in
 the pipeline.
 
-Note the difference between \code{req} and \code{Req}: the former only 
-selects compartments to appear in output while the latter selects both 
+Note the difference between \code{req} and \code{Req}: the former only
+selects compartments to appear in output while the latter selects both
 compartments and captured items.  Also, when there are items are explicitly
 listed in \code{Req}, all other compartments or captured items not listed
 there are ignored.  But when compartments are selected with \code{req}
-all of the captured items are returned.  Remember that \code{req} is 
+all of the captured items are returned.  Remember that \code{req} is
 strictly for compartments.
 }
 \examples{
 mod <- mrgsolve::house()
 
-mod \%>\% Req(CP,RESP) \%>\% ev(amt=1000) \%>\%  mrgsim
+mod \%>\% Req(CP,RESP) \%>\% ev(amt=1000) \%>\%  mrgsim()
 
 }

--- a/man/Req.Rd
+++ b/man/Req.Rd
@@ -29,7 +29,7 @@ the pipeline.
 
 Note the difference between \code{req} and \code{Req}: the former only
 selects compartments to appear in output while the latter selects both
-compartments and captured items.  Also, when there are items are explicitly
+compartments and captured items.  Also, when there are items explicitly
 listed in \code{Req}, all other compartments or captured items not listed
 there are ignored.  But when compartments are selected with \code{req}
 all of the captured items are returned.  Remember that \code{req} is

--- a/man/as.ev.Rd
+++ b/man/as.ev.Rd
@@ -17,7 +17,7 @@ as.ev(x, ...)
 
 \item{...}{not used.}
 
-\item{keep_id}{if \code{TRUE}, \code{ID} column is retained if it exists.}
+\item{keep_id}{if \code{TRUE}, ID column is retained if it exists.}
 
 \item{clean}{if \code{TRUE}, only dosing or ID information is retained in
 the result.}
@@ -26,11 +26,23 @@ the result.}
 An object with class ev.
 }
 \description{
-Coerce an object to class ev
+Use this function to convert a data frame to an event object.
+}
+\details{
+If \code{CMT} (or \code{cmt}) is missing from the input, it will be set to 1
+in the event object.
+
+If \code{TIME} (or \code{time}) is missing from the input, it will be set to
+0 in the event object.
+
+If \code{EVID} (or \code{evid}) is missing from the input, it will be set to
+1 in the event object.
 }
 \examples{
-data <- data.frame(amt = 100) 
+data <- data.frame(AMT = 100) 
 
 as.ev(data)
+
+as.ev(data, clean = TRUE)
 
 }

--- a/man/as.ev.Rd
+++ b/man/as.ev.Rd
@@ -13,13 +13,13 @@ as.ev(x, ...)
 \S4method{as.ev}{ev}(x, ...)
 }
 \arguments{
-\item{x}{An object to coerce.}
+\item{x}{an object to coerce.}
 
-\item{...}{Not used.}
+\item{...}{not used.}
 
-\item{keep_id}{If \code{TRUE}, \code{ID} column is retained if it exists.}
+\item{keep_id}{if \code{TRUE}, \code{ID} column is retained if it exists.}
 
-\item{clean}{If \code{TRUE}, only dosing or ID information is retained in
+\item{clean}{if \code{TRUE}, only dosing or ID information is retained in
 the result.}
 }
 \value{

--- a/man/as.list-mrgmod-method.Rd
+++ b/man/as.list-mrgmod-method.Rd
@@ -10,7 +10,7 @@
 \item{x}{a model object.}
 
 \item{deep}{if \code{TRUE}, extra information is returned in the output list
-(see details).}
+(see \strong{Details}).}
 
 \item{...}{not used.}
 }

--- a/man/as.list-mrgmod-method.Rd
+++ b/man/as.list-mrgmod-method.Rd
@@ -7,21 +7,23 @@
 \S4method{as.list}{mrgmod}(x, deep = FALSE, ...)
 }
 \arguments{
-\item{x}{mrgmod object}
+\item{x}{a model object.}
 
-\item{deep}{if \code{TRUE}, extra information is returned
+\item{deep}{if \code{TRUE}, extra information is returned in the output list
 (see details).}
 
-\item{...}{not used}
+\item{...}{not used.}
+}
+\value{
+A named list containing formatted contents from \code{x}.
 }
 \description{
 Coerce a model object to list
 }
 \details{
-If \code{deep} is \code{TRUE}, then the values for
-\code{trans},\code{advan}, and \code{mindt} are
-returned as well as a summary of internal model
-functions (with a call to \code{mrgsolve:::funset}).
+If \code{deep} is \code{TRUE}, then the values for \code{trans}, \code{advan}, and \code{mindt} are
+returned as well as a summary of internal model functions (with a call to
+\code{mrgsolve:::funset()}).
 }
 \section{Slots}{
 
@@ -77,3 +79,8 @@ to compiling
 }
 }
 
+\examples{
+mod <- mrgsolve::house()
+l <- as.list(mod)
+
+}

--- a/man/as.list-mrgsims-method.Rd
+++ b/man/as.list-mrgsims-method.Rd
@@ -7,9 +7,9 @@
 \S4method{as.list}{mrgsims}(x, ...)
 }
 \arguments{
-\item{x}{an mrgsims object}
+\item{x}{an mrgsims object.}
 
-\item{...}{not used}
+\item{...}{not used.}
 }
 \description{
 Coerce an mrgsims object to list

--- a/man/as_deslist.Rd
+++ b/man/as_deslist.Rd
@@ -7,23 +7,23 @@
 as_deslist(data, descol = "ID")
 }
 \arguments{
-\item{data}{input data set; see details}
+\item{data}{input data set; see \strong{Details}.}
 
-\item{descol}{character column name to be used for design groups}
+\item{descol}{character column name to be used for design groups.}
 }
 \value{
-The function returns a list of \code{tgrid} objects, 
+The function returns a list of \code{tgrid} objects,
 one for each unique value found in \code{descol}.
 }
 \description{
 Create a list of designs from a data frame
 }
 \details{
-The input data set must have a column with the same name as the value 
-of \code{descol}.  Other column names should be \code{start} (the time 
-of the first observation), \code{end} (the time of the last observation), 
-\code{delta} (the time steps to take between \code{start} and \code{end}), 
-and \code{add} (other, ad-hoc times).  Note that \code{add} might be 
+The input data set must have a column with the same name as the value
+of \code{descol}.  Other column names should be \code{start} (the time
+of the first observation), \code{end} (the time of the last observation),
+\code{delta} (the time steps to take between \code{start} and \code{end}),
+and \code{add} (other, ad-hoc times).  Note that \code{add} might be
 a \code{list-column} to get a vector of times for each time grid object.
 }
 \examples{

--- a/man/cama.Rd
+++ b/man/cama.Rd
@@ -7,11 +7,11 @@
 cama(mod, fn = "cama", ...)
 }
 \arguments{
-\item{mod}{model object}
+\item{mod}{a model object.}
 
-\item{fn}{function name}
+\item{fn}{function name.}
 
-\item{...}{passed to update}
+\item{...}{passed to update.}
 }
 \description{
 Run the model cama function

--- a/man/carry_out.Rd
+++ b/man/carry_out.Rd
@@ -10,22 +10,21 @@ carry_out(x, ...)
 carry.out(x, ...)
 }
 \arguments{
-\item{x}{model object}
+\item{x}{model object.}
 
-\item{...}{passed along}
+\item{...}{unquoted names of data items to copy into the simulated output.}
 }
 \description{
-When items named in this function are found in the input data set (either 
-\code{\link{data_set}} or \code{\link{idata_set}}), they are copied
+When items named in this function are found in the input data set (either
+\code{\link[=data_set]{data_set()}} or \code{\link[=idata_set]{idata_set()}}), they are copied
 into the simulated output.  Special items like \code{evid} or \code{amt} or
 the like are not copied from the data set per se, but they are copied from
 \code{datarecord} objects that are created during the simulation.
 }
 \details{
-There is also a \code{carry.out} argument to \code{\link{mrgsim}} that can 
-be set to accomplish the same thing as a call to \code{carry_out} in 
+There is also a \code{carry_out} argument to \code{\link[=mrgsim]{mrgsim()}} that can
+be set to accomplish the same thing as a call to \code{carry_out} in
 the pipeline.
 
-\code{carry.out} and \code{carry_out}.  Using the underscore version is 
-now preferred.
+\code{carry.out} and carry_out`.  Using the underscore version is now preferred.
 }

--- a/man/carry_out.Rd
+++ b/man/carry_out.Rd
@@ -28,3 +28,13 @@ accomplish the same thing as a call to \code{carry_out} in the pipeline.
 \code{carry.out} and \code{carry_out} both do the same thing; using the underscore
 version is now preferred.
 }
+\examples{
+mod <- mrgsolve::house()
+
+e <- ev(amt = 100, ii = 6, addl = 3, WT = 70, dose = amt)
+
+out <- mod \%>\% carry_out(amt, dose, WT)
+
+head(out)
+
+}

--- a/man/carry_out.Rd
+++ b/man/carry_out.Rd
@@ -33,7 +33,7 @@ mod <- mrgsolve::house()
 
 e <- ev(amt = 100, ii = 6, addl = 3, WT = 70, dose = amt)
 
-out <- mod \%>\% carry_out(amt, dose, WT)
+out <- mod \%>\% ev(e) \%>\% carry_out(amt, dose, WT) \%>\% mrgsim()
 
 head(out)
 

--- a/man/carry_out.Rd
+++ b/man/carry_out.Rd
@@ -22,9 +22,9 @@ the like are not copied from the data set per se, but they are copied from
 \code{datarecord} objects that are created during the simulation.
 }
 \details{
-There is also a \code{carry_out} argument to \code{\link[=mrgsim]{mrgsim()}} that can
-be set to accomplish the same thing as a call to \code{carry_out} in
-the pipeline.
+There is also a \code{carry_out} argument to \code{\link[=mrgsim]{mrgsim()}} that can be set to
+accomplish the same thing as a call to \code{carry_out} in the pipeline.
 
-\code{carry.out} and carry_out`.  Using the underscore version is now preferred.
+\code{carry.out} and \code{carry_out} both do the same thing; using the underscore
+version is now preferred.
 }

--- a/man/cmtn.Rd
+++ b/man/cmtn.Rd
@@ -10,16 +10,17 @@ cmtn(x, ...)
 \S4method{cmtn}{mrgmod}(x, tag, ...)
 }
 \arguments{
-\item{x}{model object}
+\item{x}{model object.}
 
-\item{...}{passed along}
+\item{...}{not used.}
 
-\item{tag}{compartment name}
+\item{tag}{compartment name.}
 }
 \description{
 Get the compartment number from a compartment name
 }
 \examples{
 mod <- mrgsolve::house()
-mod \%>\% cmtn("CENT")
+cmtn(mod, "CENT")
+
 }

--- a/man/code.Rd
+++ b/man/code.Rd
@@ -7,7 +7,7 @@
 code(x)
 }
 \arguments{
-\item{x}{an mrgsolve model object}
+\item{x}{a model object.}
 }
 \value{
 A character vector of model code.
@@ -19,5 +19,8 @@ This function is currently not exported, so be sure to call it with
 \examples{
 mod <- mrgsolve::house()
 mrgsolve:::code(mod)
+
+# Alternative
+as.list(mod)$code
 
 }

--- a/man/collapse_matrices.Rd
+++ b/man/collapse_matrices.Rd
@@ -10,7 +10,7 @@ collapse_omega(x, range = NULL, name = NULL)
 collapse_sigma(x, range = NULL, name = NULL)
 }
 \arguments{
-\item{x}{a \code{mrgmod} object}
+\item{x}{a model object.}
 
 \item{range}{numeric vector of length 2 specifying the range of matrices
 to collapse in case there are more than 2. The second element may be \code{NA}
@@ -18,7 +18,7 @@ to indicate the length of the list of matrices.}
 
 \item{name}{a new name for the collapsed matrix; note that this is the
 matrix name, not the labels which alias \code{ETA(n)} or \code{EPS(n)}; specifying a
-name will only alter how this matrix is potentially updated in the future}
+name will only alter how this matrix is potentially updated in the future.}
 }
 \value{
 A model object with updated \code{OMEGA} or \code{SIGMA} matrix lists.

--- a/man/collapse_matrix.Rd
+++ b/man/collapse_matrix.Rd
@@ -9,7 +9,7 @@ collapse_matrix(x, range = NULL, name = NULL)
 \arguments{
 \item{x}{an object that inherits from \code{matlist}; this object is most
 frequently extracted from a model object using \code{\link[=omat]{omat()}} or \code{\link[=smat]{smat()}} for
-\code{OMEGA} and \code{SIGMA}, respectively}
+\code{OMEGA} and \code{SIGMA}, respectively.}
 
 \item{range}{numeric vector of length 2 specifying the range of matrices
 to collapse in case there are more than 2. The second element may be \code{NA}
@@ -17,7 +17,7 @@ to indicate the length of the list of matrices.}
 
 \item{name}{a new name for the collapsed matrix; note that this is the
 matrix name, not the labels which alias \code{ETA(n)} or \code{EPS(n)}; specifying a
-name will only alter how this matrix is potentially updated in the future}
+name will only alter how this matrix is potentially updated in the future.}
 }
 \value{
 An update \code{matlist} object (either \code{omegalist} or \code{sigmalist}).

--- a/man/data_set.Rd
+++ b/man/data_set.Rd
@@ -27,23 +27,23 @@ data_set(x, data, ...)
 \S4method{data_set}{mrgmod,missing}(x, object, ...)
 }
 \arguments{
-\item{x}{model object}
+\item{x}{a model object.}
 
-\item{data}{data set}
+\item{data}{input data set as a data frame.}
 
-\item{...}{passed along}
+\item{...}{other arguments passed along when \code{object} is a function.}
 
-\item{.subset}{an unquoted expression passed to 
-\code{dplyr::filter}; retain only certain rows in the data set}
+\item{.subset}{an unquoted expression passed to
+\code{\link[dplyr:filter]{dplyr::filter()}}; retain only certain rows in the data set}
 
-\item{.select}{passed to \code{dplyr::select}; retain only certain 
-columns in the data set; this should be the result of a call to 
-\code{dplyr::vars()}}
+\item{.select}{passed to \code{\link[dplyr:select]{dplyr::select()}}; retain only certain
+columns in the data set; this should be the result of a call to
+\code{\link[dplyr:vars]{dplyr::vars()}}.}
 
-\item{object}{character name of an object existing in \code{$ENV} 
-to use for the data set}
+\item{object}{character name of an object existing in \verb{$ENV}
+to use for the data set.}
 
-\item{need}{passed to \code{\link{inventory}}}
+\item{need}{passed to \code{\link[=inventory]{inventory()}}.}
 }
 \description{
 The input data set (\code{data_set}) is a data frame that specifies
@@ -51,58 +51,75 @@ observations, model events, and / or parameter values for a population
 of individuals.
 }
 \details{
-Input data sets are \code{R} data frames that can include columns 
-with any valid name, however columns with selected names are 
-treated specially by \code{mrgsolve} and incorporated into the 
+Input data sets are \code{R} data frames that can include columns
+with any valid name, however columns with selected names are
+treated specially by mrgsolve and incorporated into the
 simulation.
 
-\code{ID} specifies the subject ID and is required for every 
+\code{ID} specifies the subject ID and is required for every
 input data set.
 
-When columns have the same name as parameters (\code{$PARAM} in 
-the model specification file), the values in those columns will 
-be used to update the corresponding parameter as the simulation 
+When columns have the same name as parameters (\verb{$PARAM} or \verb{$INPUT} in
+the model specification file), the values in those columns will
+be used to update the corresponding parameter as the simulation
 progresses.
 
-Input data set may include the following columns related to 
-PK dosing events: \code{time}, \code{cmt}, \code{amt}, \code{rate},
-\code{ii}, \code{addl}, \code{ss}.  Along with \code{ID}, \code{time} 
-is a required column in the input data set unless \code{$PRED} is in 
-use.  Upper case PK dosing column names including
-\code{TIME}, \code{CMT}, \code{AMT}, \code{RATE}, \code{II},
-\code{ADDL}, \code{SS} are also recognized.  However, an 
-error will be generated if a mix of upper case and lower
-case columns in this family are found.
- 
-\code{time} is the observation or event time, \code{cmt} 
-is the compartment number (see \code{\link{init}}), \code{amt} 
-is the dosing amount, \code{rate} is the infusion rate, 
-\code{ii} is the dosing interval, \code{addl} specifies 
-additional doses to administer, and \code{ss} is a flag 
-for steady state dosing.  These column names operate 
-similarly to other non-linear mixed effects modeling 
-software. 
+Input data set may include the following columns related to
+PK dosing events: \code{TIME}, \code{CMT}, \code{AMT}, \code{RATE}, \code{II}, \code{ADDL}, \code{SS}.
+Both \code{ID} and \code{TIME} are required columns in the input data set unless
+\verb{$PRED} is in use.  Lower case PK dosing column names including
+\code{time}, \code{cmt}, \code{amt}, \code{rate}, \code{ii}, \code{addl}, \code{ss} are also recognized.
+However, an error will be generated if a mix of both upper case and lower
+case columns in this family are found. Use the functions \code{\link[=lctran]{lctran()}} and
+\code{\link[=uctran]{uctran()}} to convert between upper and lower case naming for these
+data items.
+
+\code{TIME} is the observation or event time, \code{CMT} is the compartment number
+(see \code{\link[=init]{init()}}), \code{AMT} is the dosing amount, \code{RATE} is the infusion rate,
+\code{II} is the dosing interval, \code{ADDL} specifies additional doses to
+administer, and \code{ss} is a flag indicating that the system should be advanced
+to a pharmacokinetic steady state prior to administering the dose.  These
+column names operate similarly to other non-linear mixed effects modeling
+software.
+
+\code{EVID} is an integer value specifying the ID of an event record. Values
+include:
+\itemize{
+\item \code{0}: observation
+\item \code{1}:  dose event, either bolus or infusion
+\item \code{2}: other-type event; in mrgsolve, this functions like an observation
+record, but a discontinuity is created in the simulation at the time of
+the event (i.e., the ODE solver will stop and restart at the time of the
+event)
+\item \code{3}: reset the system
+\item \code{4}: reset the system and dose
+\item \code{8}: replace the amount in a compartment
+}
+
+For all \code{EVID} greater than \code{0}, a discontinuity is created in the
+simulation, as described for \verb{EVID 2}.
 
 An error will be generated when mrgsolve detects that the data set
-is not sorted by \code{time} within an individual.  
+is not sorted by \code{time} within an individual. mrgsolve does \strong{not} allow time
+to be reset to zero on records where \code{EVID} is set to 4 (reset and dose).
 
-Only numeric data can be brought in to the problem.  
-Any non-numeric data columns will be dropped with warning.  
-See \code{\link{numerics_only}}, which is used 
-to prepare the data set. 
+Only numeric data can be brought in to the problem. Any non-numeric data
+columns will be dropped with warning. See \code{\link[=numerics_only]{numerics_only()}}, which is used
+to prepare the data set.
 
-An error will be generated if any parameter columns in the 
-input data set contain \code{NA}.  Likewise, and error will 
+An error will be generated if any parameter columns in the
+input data set contain missing values (\code{NA}). Likewise, and error will
 be generated if missing values are found in the following
-columns: \code{ID}, \code{time}/\code{TIME}, \code{rate}/\code{RATE}. 
+columns: \code{ID}, \code{time}/\code{TIME}, \code{rate}/\code{RATE}.
 
-See \code{\link{exdatasets}} for different example data sets.
+See \link{exdatasets} for several example data sets that are provided by
+mrgsolve.
 }
 \examples{
 
 mod <- mrgsolve::house()
 
-data <- expand.ev(ID=seq(3), amt=c(10, 20))
+data <- expand.ev(ID = seq(3), amt = c(10, 20))
 
 mod \%>\% data_set(data, ID > 1) \%>\% mrgsim()
 
@@ -114,6 +131,6 @@ mod \%>\% mrgsim(data = extran1)
 
 }
 \seealso{
-\code{\link{idata_set}}, \code{\link{ev}}, 
-\code{\link{valid_data_set}}, \code{\link{valid_idata_set}}
+\code{\link[=idata_set]{idata_set()}}, \code{\link[=ev]{ev()}}, \code{\link[=valid_data_set]{valid_data_set()}}, \code{\link[=valid_idata_set]{valid_idata_set()}},
+\code{\link[=lctran]{lctran()}}, \code{\link[=uctran]{uctran()}}.
 }

--- a/man/data_set.Rd
+++ b/man/data_set.Rd
@@ -85,15 +85,15 @@ software.
 \code{EVID} is an integer value specifying the ID of an event record. Values
 include:
 \itemize{
-\item \code{0}: observation
-\item \code{1}:  dose event, either bolus or infusion
-\item \code{2}: other-type event; in mrgsolve, this functions like an observation
+\item 0: observation
+\item 1:  dose event, either bolus or infusion
+\item 2: other-type event; in mrgsolve, this functions like an observation
 record, but a discontinuity is created in the simulation at the time of
 the event (i.e., the ODE solver will stop and restart at the time of the
 event)
-\item \code{3}: reset the system
-\item \code{4}: reset the system and dose
-\item \code{8}: replace the amount in a compartment
+\item 3: reset the system
+\item 4: reset the system and dose
+\item 8: replace the amount in a compartment
 }
 
 For all \code{EVID} greater than \code{0}, a discontinuity is created in the

--- a/man/env_eval.Rd
+++ b/man/env_eval.Rd
@@ -7,15 +7,14 @@
 env_eval(x, seed = NULL)
 }
 \arguments{
-\item{x}{model object}
+\item{x}{a model object.}
 
-\item{seed}{passed to \code{\link{set.seed}} if a numeric value is supplied}
+\item{seed}{passed to \code{\link[=set.seed]{set.seed()}} if a numeric value is supplied.}
 }
 \description{
-The \code{$ENV} block is a block of R code that can 
-realize any sort of R object that might be used in running 
-a model.
+The \verb{$ENV} block is a block of R code that can realize any sort of R object
+that might be used in running a model.
 }
 \seealso{
-\code{\link{env_get}}, \code{\link{env_ls}}
+\code{\link[=env_get]{env_get()}}, \code{\link[=env_ls]{env_ls()}}
 }

--- a/man/env_get.Rd
+++ b/man/env_get.Rd
@@ -10,7 +10,7 @@ env_get(x, tolist = TRUE)
 env_get_env(x)
 }
 \arguments{
-\item{x}{model object}
+\item{x}{a model object.}
 
 \item{tolist}{should the environment be coerced to \code{list}?}
 }

--- a/man/env_ls.Rd
+++ b/man/env_ls.Rd
@@ -7,11 +7,11 @@
 env_ls(x, ...)
 }
 \arguments{
-\item{x}{model object}
+\item{x}{amodel object.}
 
-\item{...}{passed to \code{\link{ls}}}
+\item{...}{passed to \code{\link[=ls]{ls()}}.}
 }
 \description{
-Each model keeps an internal environment that allows the user 
-to carry any \code{R} object along.  Objects are coded in \code{$ENV}.
+Each model keeps an internal environment that allows the user
+to carry any \code{R} object along.  Objects are coded in \verb{$ENV}.
 }

--- a/man/env_ls.Rd
+++ b/man/env_ls.Rd
@@ -7,7 +7,7 @@
 env_ls(x, ...)
 }
 \arguments{
-\item{x}{amodel object.}
+\item{x}{a model object.}
 
 \item{...}{passed to \code{\link[=ls]{ls()}}.}
 }

--- a/man/env_update.Rd
+++ b/man/env_update.Rd
@@ -7,11 +7,11 @@
 env_update(.x, ..., .dots = list())
 }
 \arguments{
-\item{.x}{model object}
+\item{.x}{a model object.}
 
-\item{...}{objects to update}
+\item{...}{objects to update.}
 
-\item{.dots}{list of objects to updated}
+\item{.dots}{list of objects to updated.}
 }
 \description{
 Update objects in model environment

--- a/man/ev_assign.Rd
+++ b/man/ev_assign.Rd
@@ -10,33 +10,30 @@ ev_assign(l, idata, evgroup, join = FALSE)
 assign_ev(...)
 }
 \arguments{
-\item{l}{list of event objects}
+\item{l}{list of event objects.}
 
-\item{idata}{an idata set (one ID per row)}
+\item{idata}{an idata set (one ID per row).}
 
-\item{evgroup}{the character name of the column in \code{idata} 
-that specifies event object to implement}
+\item{evgroup}{the character name of the column in \code{idata} that specifies
+event object to implement.}
 
-\item{join}{if \code{TRUE}, join \code{idata} to the data set 
-before returning.}
+\item{join}{if \code{TRUE}, join \code{idata} to the data set before returning.}
 
-\item{...}{used to pass arguments from \code{assign_ev}
-to \code{ev_assign}}
+\item{...}{used to pass arguments from \code{assign_ev()}.
+to \code{ev_assign()}.}
 }
 \description{
 Replicate a list of events into a data set
 }
 \details{
-\code{ev_assign} connects events in a list passed in as the
-\code{l} argument to values in the data set identified in the 
-\code{evgroup} argument.  For making assignments, the unique 
-values in the \code{evgroup} column are first sorted so that 
-the first sorted unique value in \code{evgroup} is assigned 
-to the first event in \code{l}, the second sorted value in 
-\code{evgroup} column is assigned to the second event in 
-\code{l}, and so on.  This is a change from previous behavior, 
-which did not sort the unique values in \code{evgroup} prior to 
-making the assignments.
+\code{ev_assign()} connects events in a list passed in as the \code{l} argument to
+values in the data set identified in the \code{evgroup} argument.  For making
+assignments, the unique values in the \code{evgroup} column are first sorted so
+that the first sorted unique value in \code{evgroup} is assigned to the first
+event in \code{l}, the second sorted value in \code{evgroup} column is assigned to the
+second event in \code{l}, and so on.  This is a change from previous behavior,
+which did not sort the unique values in \code{evgroup} prior to making the
+assignments.
 }
 \examples{
 ev1 <- ev(amt = 100)

--- a/man/ev_days.Rd
+++ b/man/ev_days.Rd
@@ -14,29 +14,29 @@ ev_days(
 )
 }
 \arguments{
-\item{ev}{an event object}
+\item{ev}{an event object.}
 
 \item{days}{comma- or space-separated character string of valid days of the
-the week (see details)}
+the week (see details).}
 
-\item{addl}{additional doses to administer}
+\item{addl}{additional doses to administer.}
 
-\item{ii}{inter-dose interval; intended use is to keep this at the 
-default value}
+\item{ii}{inter-dose interval; intended use is to keep this at the
+default value.}
 
-\item{unit}{time unit; the function can only currently handle hours or days}
+\item{unit}{time unit; the function can only currently handle hours or days.}
 
-\item{...}{event objects named by one the valid days of the week (see details)}
+\item{...}{event objects named by one the valid days of the week
+(see \strong{Details}).}
 }
 \description{
-This function lets you schedule doses on specific 
-days of the week, allowing you to create dosing 
+This function lets you schedule doses on specific
+days of the week, allowing you to create dosing
 regimens on Monday/Wednesday/Friday, or Tuesday/Thursday,
 or every other day (however you want to define that) etc.
 }
 \details{
-Valid names of the week are: 
-
+Valid names of the week are:
 \itemize{
 \item \code{m} for Monday
 \item \code{t} for Tuesday
@@ -48,16 +48,17 @@ Valid names of the week are:
 }
 
 The whole purpose of this function is to schedule doses on specific
-days of the week, in a repeating weekly schedule.  Please do use caution 
+days of the week, in a repeating weekly schedule.  Please do use caution
 when changing \code{ii} from it's default value.
 }
 \examples{
 
 # Monday, Wednesday, Friday x 4 weeks
-ev_days(ev(amt=100), days="m,w,f", addl=3)
+e1 <- ev(amt = 100)
+ev_days(e1, days="m,w,f", addl = 3)
 
 # 50 mg Tuesdays, 100 mg Thursdays x 6 months
-ev_days(t=ev(amt=50), th=ev(amt=100), addl=23)
-
+e2 <- ev(amt = 50)
+ev_days(t = e2, th = e1, addl = 23)
 
 }

--- a/man/ev_days.Rd
+++ b/man/ev_days.Rd
@@ -26,7 +26,7 @@ default value.}
 
 \item{unit}{time unit; the function can only currently handle hours or days.}
 
-\item{...}{event objects named by one the valid days of the week
+\item{...}{event objects named by one of the valid days of the week
 (see \strong{Details}).}
 }
 \description{
@@ -49,7 +49,7 @@ Valid names of the week are:
 
 The whole purpose of this function is to schedule doses on specific
 days of the week, in a repeating weekly schedule.  Please do use caution
-when changing \code{ii} from it's default value.
+when changing \code{ii} from its default value.
 }
 \examples{
 

--- a/man/ev_dplyr.Rd
+++ b/man/ev_dplyr.Rd
@@ -13,9 +13,9 @@
 \method{filter}{ev}(.data, ...)
 }
 \arguments{
-\item{.data}{the event object}
+\item{.data}{the event object.}
 
-\item{...}{passed to the \code{dplyr} function}
+\item{...}{passed to the \code{dplyr} function.}
 }
 \description{
 dplyr verbs for event objects

--- a/man/ev_rep.Rd
+++ b/man/ev_rep.Rd
@@ -7,21 +7,21 @@
 ev_rep(x, ID = 1, n = NULL, wait = 0, as.ev = FALSE, id = NULL)
 }
 \arguments{
-\item{x}{event object}
+\item{x}{event object.}
 
-\item{ID}{numeric vector if IDs}
+\item{ID}{numeric vector if IDs.}
 
-\item{n}{passed to \code{\link{ev_repeat}}}
+\item{n}{passed to \code{\link[=ev_repeat]{ev_repeat()}}.}
 
-\item{wait}{passed to \code{\link{ev_repeat}}}
+\item{wait}{passed to \code{\link[=ev_repeat]{ev_repeat()}}.}
 
-\item{as.ev}{if \code{TRUE} an event object is returned}
+\item{as.ev}{if \code{TRUE} an event object is returned.}
 
-\item{id}{deprecated; use \code{ID} instead}
+\item{id}{deprecated; use \code{ID} instead.}
 }
 \value{
-A single data.frame or event object as 
-determined by the value of \code{as.ev}.
+A single data.frame or event object as
+determined by the value of \code{\link[=as.ev]{as.ev()}}.
 }
 \description{
 An event sequence can be replicated a certain number of
@@ -35,5 +35,5 @@ ev_rep(e1, 1:5)
 
 }
 \seealso{
-\code{\link{ev_repeat}}
+\code{\link[=ev_repeat]{ev_repeat()}}
 }

--- a/man/ev_repeat.Rd
+++ b/man/ev_repeat.Rd
@@ -22,3 +22,11 @@ See \code{as.ev} argument.
 \description{
 Repeat a block of dosing events
 }
+\examples{
+e1 <- ev(amt = 100, ii = 24, addl = 20)
+e4 <- ev_repeat(e1, n = 4, wait = 168)
+mod <- mrgsolve::house()
+out <- mrgsim(mod, events = e4, end = 3200)
+plot(out, "CP")
+
+}

--- a/man/ev_repeat.Rd
+++ b/man/ev_repeat.Rd
@@ -7,14 +7,14 @@
 ev_repeat(x, n, wait = 0, as.ev = FALSE)
 }
 \arguments{
-\item{x}{event object or dosing data frame}
+\item{x}{event object or dosing data frame.}
 
-\item{n}{number of times to repeat}
+\item{n}{number of times to repeat.}
 
-\item{wait}{time to wait between repeats}
+\item{wait}{time to wait between repeats.}
 
-\item{as.ev}{if \code{TRUE}, an event object is
-returned; otherwise a data.frame is returned}
+\item{as.ev}{if \code{TRUE}, an event object is returned; otherwise a data.frame
+is returned.}
 }
 \value{
 See \code{as.ev} argument.

--- a/man/ev_seq.Rd
+++ b/man/ev_seq.Rd
@@ -10,14 +10,14 @@ ev_seq(..., ID = NULL, .dots = NULL, id = NULL)
 \method{seq}{ev}(...)
 }
 \arguments{
-\item{...}{Event objects or numeric arguments named \code{wait} or \code{ii} to
-implement a period of no-dosing activity in the sequence (see details).}
+\item{...}{event objects or numeric arguments named \code{wait} or \code{ii} to
+implement a period of no-dosing activity in the sequence (see \strong{Details}).}
 
-\item{ID}{Numeric vector of subject IDs.}
+\item{ID}{numeric vector of subject IDs.}
 
-\item{.dots}{A list of event objects that replaces \code{...}.}
+\item{.dots}{a list of event objects that replaces \code{...}.}
 
-\item{id}{Deprecated; use \code{ID}.}
+\item{id}{deprecated; use \code{ID}.}
 }
 \value{
 A single event object sorted by \code{time}.
@@ -35,7 +35,7 @@ on the last row of the event object.
 
 The doses for the next event line start after all of the doses from the
 previous event line plus one dosing interval from the previous event line
-(see examples).
+(see \strong{Examples}).
 
 When numerics named \code{wait} or \code{ii} are mixed in with the event objects,
 a period with no dosing activity is incorporated into the sequence,
@@ -61,10 +61,9 @@ For now, both \code{ii} and \code{.ii} will be accepted but you will get a depre
 warning if you use \code{.ii}. Please use \code{ii} instead.
 
 Values for \code{time} in any event object act like a prefix time spacer wherever
-that event occurs in the event sequence (see examples).
+that event occurs in the event sequence (see \strong{Examples}).
 }
 \examples{
-
 e1 <- ev(amt = 100, ii = 12, addl = 1)
 
 e2 <- ev(amt = 200)

--- a/man/expand.idata.Rd
+++ b/man/expand.idata.Rd
@@ -19,20 +19,30 @@ ev_expand(...)
 evd_expand(...)
 }
 \arguments{
-\item{...}{passed to \code{\link[=expand.grid]{expand.grid()}}}
+\item{...}{passed to \code{\link[=expand.grid]{expand.grid()}}.}
+}
+\value{
+A data frame containing one row for each combination of the items
+passed in \code{...}. The result always has ID set to the row number.
 }
 \description{
 These functions expand all combinations of arguments using
-\code{\link[=expand.grid]{expand.grid()}}. The result always has only one row for one individual.
-Use \code{\link[=expand.evd]{expand.evd()}} or \code{\link[=evd_expand]{evd_expand()}} to convert nmtran names (e.g. AMT
-or CMT) to upper case (see \code{\link[=uctran]{uctran()}}).
+\code{\link[=expand.grid]{expand.grid()}}. \code{expand.idata()} generates an \code{idata} set; the others
+generate a full data set. The result always has only one row for one
+individual. Use \code{expand.evd()} or \code{evd_expand()} to render NMTRAN names
+(e.g. \code{AMT} or \code{CMT}) in upper case.
 }
 \details{
-An ID column is added as \code{seq(nrow(ans))} if not supplied by the user. For
-\code{expand.ev}, defaults also added include \code{cmt = 1}, \code{time = 0}, \code{evid = 1}.
-If \code{total} is included, then \code{addl} is derived as \code{total} - 1. If \code{tinf} is
-included, then an infusion rate is derived for row where \code{tinf} is greater
-than zero.
+An ID column is added as if not supplied by the user. In the output data
+frame, ID is always re-written as the row number.
+
+For \code{expand.ev()}, defaults also added include \code{cmt = 1}, \code{time = 0},
+\code{evid = 1}. If \code{total} is included, then \code{addl} is derived as \code{total-1}.
+If \code{tinf} is included, then an infusion rate is derived for row where
+\code{tinf} is greater than zero.
+
+\code{ev_expand()} is a synonym for \code{expand.ev()} and \code{evd_expand()} is a
+synonym for \code{expand.evd()}.
 }
 \examples{
 idata <- expand.idata(CL = c(1,2,3), VC = c(10,20,30))

--- a/man/expand_observations.Rd
+++ b/man/expand_observations.Rd
@@ -7,16 +7,16 @@
 expand_observations(data, times, unique = FALSE, obs_pos = -1L)
 }
 \arguments{
-\item{data}{a data set or event object}
+\item{data}{a data set or event object.}
 
-\item{times}{a vector of observation times}
+\item{times}{a vector of observation times.}
 
-\item{unique}{`logical`; if `TRUE` then values for `time` are 
-dropped if they are found anywhere in `data`}
+\item{unique}{\code{logical}; if \code{TRUE} then values for \code{time} are
+dropped if they are found anywhere in \code{data}.}
 
-\item{obs_pos}{determines sorting order for observations; use `-1` (default)
-to put observations first; otherwise, use large integer to ensure 
-observations are placed after doses}
+\item{obs_pos}{determines sorting order for observations; use \code{-1} (default)
+to put observations first; otherwise, use large integer to ensure
+observations are placed after doses.}
 }
 \value{
 A data frame with additional rows for added observation records.

--- a/man/idata_set.Rd
+++ b/man/idata_set.Rd
@@ -24,56 +24,55 @@ idata_set(x, data, ...)
 \S4method{idata_set}{mrgmod,missing}(x, object, ...)
 }
 \arguments{
-\item{x}{model object}
+\item{x}{model object.}
 
-\item{data}{a data set that can be coerced to data.frame}
+\item{data}{a data set that can be coerced to data.frame.}
 
-\item{...}{passed along}
+\item{...}{other arguments passed along when \code{object} is a function.}
 
-\item{.subset}{an unquoted expression passed to 
-\code{dplyr::filter}; retain only certain rows in the data set}
+\item{.subset}{an unquoted expression passed to \code{\link[dplyr:filter]{dplyr::filter()}}; retain
+only certain rows in the data set.}
 
-\item{.select}{passed to \code{dplyr::select}; retain only certain 
-columns in the data set; this should be the result of a call to 
-\code{dplyr::vars()}}
+\item{.select}{passed to \code{\link[dplyr:select]{dplyr::select()}}; retain only certain columns in
+the data set; this should be the result of a call to \code{\link[dplyr:vars]{dplyr::vars()}}.}
 
-\item{object}{character name of an object existing in \code{$ENV} 
-to use for the data set}
+\item{object}{character name of an object existing in \verb{$ENV}
+to use for the data set.}
 
-\item{need}{passed to \code{\link{inventory}}}
+\item{need}{passed to \code{\link[=inventory]{inventory()}}.}
 }
 \description{
-The individual data set (\code{idata_set}) is a data frame with one 
-row for each individual in a population, specifying parameters and 
+The individual data set (\code{idata_set}) is a data frame with one
+row for each individual in a population, specifying parameters and
 other individual-level data.
 }
 \details{
-The \code{idata_set} is a data.frame that specifies individual-level 
-data for the problem.  An  \code{ID} column is required and there 
-can be no more than one row in the data frame for each individual.  
+The \code{idata_set} is a data frame that specifies individual-level
+data for the problem. An \code{ID} column is required and there
+can be no more than one row in the data frame for each individual.
 
 In most cases, the columns in the \code{idata_set} have the same names
-as parameters in the \code{\link{param}} list.  When this is the case, 
-the parameter set is updated as the simulation proceeds once at the 
-start of each individual.  The `idata_set` can also be used to 
+as parameters in the \code{\link[=param]{param()}} list.  When this is the case,
+the parameter set is updated as the simulation proceeds once at the
+start of each individual.  The \code{idata_set} can also be used to
 set initial conditions for each individual: for a compartment called
-\code{CMT}, make a column in \code{idata_set} called \code{CMT_0} and 
-make the value the desired initial value for that compartment.  Note that 
-this initial condition will be over-ridden if you also set the \code{CMT_0} 
-in \code{$MAIN}.
+\code{CMT}, make a column in \code{idata_set} called \code{CMT_0} and
+make the value the desired initial value for that compartment.  Note that
+this initial condition will be overridden if you also set the \code{CMT_0}
+in \verb{$MAIN} (\verb{$PK}).
 
 The most common application of \code{idata_set} is to specify a population
-or batch of simulations to do.  We commonly use \code{idata_set} with an 
-event object (see \code{\link{ev}}).  In that case, the event gets applied
-to each individual in the \code{\link{idata_set}}.  
+or batch of simulations to do.  We commonly use \code{idata_set} with an
+event object (see \code{\link[=ev]{ev()}}).  In that case, the event gets applied
+to each individual in the \code{idata_set}.
 
-It is also possible to provide both a \code{data_set} and a \code{idata_set}.  
+It is also possible to provide both a \code{data_set} and a \code{idata_set}.
 In this case, the \code{idata_set} is used as a parameter lookup for \code{IDs}
 found in the \code{data_set}.  Remember in this case, it is the \code{data_set}
 (not the \code{idata_set}) that determines the number of individuals in the
 simulation.
 
-An error will be generated if any parameter columns in the 
+An error will be generated if any parameter columns in the
 input idata set contain \code{NA}.
 }
 \examples{
@@ -98,5 +97,5 @@ mod \%>\% ev(amt = 100) \%>\% mrgsim(idata=exidata)
 
 }
 \seealso{
-\code{\link{data_set}}, \code{\link{ev}}
+\code{\link[=data_set]{data_set()}}, \code{\link[=ev]{ev()}}
 }

--- a/man/init.Rd
+++ b/man/init.Rd
@@ -22,32 +22,31 @@ init(.x, ...)
 \S4method{init}{ANY}(.x, ...)
 }
 \arguments{
-\item{.x}{the model object}
+\item{.x}{the model object.}
 
-\item{...}{passed along}
+\item{...}{\code{name = value} assignments to update the initial conditions list.}
 
-\item{.y}{list to be merged into parameter list}
+\item{.y}{list to be merged into parameter list.}
 
-\item{.pat}{a regular expression (character) to be applied as 
-a filter when printing compartments to the screen}
+\item{.pat}{a regular expression (character) to be applied as
+a filter when printing compartments to the screen.}
 }
 \value{
-an object of class \code{cmt_list} (see 
-\code{\link{numericlist}})
+An object of class \code{cmt_list} (see \link{numericlist}).
 }
 \description{
-Calling \code{init} with the model object as the first argument 
-will return the model initial conditions as a \code{numericlist} 
-object. See \code{\link{numericlist}} for methods to  deal with 
+Calling \code{init()} with the model object as the first argument
+will return the model initial conditions as a \link{numericlist}
+object. See \link{numericlist} for methods to  deal with
 \code{cmt_list} objects.
 }
 \details{
-Can be used to either get a compartment list object from a 
-\code{mrgmod} model object or to update the compartment initial 
-conditions in a model object.  For both uses, the return value 
-is a \code{cmt_list} object. For the former use, \code{init} 
-is usually called to print the compartment initial conditions 
-to the screen, but the \code{cmt_list} object can also be coerced 
+Can be used to either get a compartment list object from a
+\code{mrgmod} model object or to update the compartment initial
+conditions in a model object.  For both uses, the return value
+is a \code{cmt_list} object. For the former use, \code{init()}
+is usually called to print the compartment initial conditions
+to the screen, but the \code{cmt_list} object can also be coerced
 to a list or numeric R object.
 }
 \examples{
@@ -55,6 +54,7 @@ to a list or numeric R object.
 mod <- mrgsolve::house()
 
 init(mod)
+
 init(mod, .pat="^C") ## may be useful for large models
 
 class(init(mod))
@@ -62,5 +62,8 @@ class(init(mod))
 init(mod)$CENT
 
 as.list(init(mod))
+
 as.data.frame(init(mod))
+
+
 }

--- a/man/inventory.Rd
+++ b/man/inventory.Rd
@@ -2,40 +2,44 @@
 % Please edit documentation in R/inven.R
 \name{inventory}
 \alias{inventory}
-\title{Check whether all required parameters needed in a model are present in an object}
+\title{Check whether all required parameters needed in a model are present in an
+object}
 \usage{
 inventory(x, obj, ..., .strict = FALSE)
 }
 \arguments{
-\item{x}{model object}
+\item{x}{model object.}
 
-\item{obj}{data.frame to pass to \code{\link{idata_set}} or \code{\link{data_set}}}
+\item{obj}{data.frame to pass to \code{\link[=idata_set]{idata_set()}} or \code{\link[=data_set]{data_set()}}.}
 
-\item{...}{capture dplyr-style parameter requirements}
+\item{...}{capture dplyr-style parameter requirements.}
 
 \item{.strict}{whether to stop execution if all requirements are present
- (\code{TRUE}) 
-or just warn (\code{FALSE}); see details}
+(\code{TRUE}) or just warn (\code{FALSE}); see \strong{Details}.}
 }
 \value{
-original mrgmod
+\code{x} is returned invisibly.
 }
 \description{
-Check whether all required parameters needed in a model are present in an object
+This function has largely been superseded by \code{\link[=check_data_names]{check_data_names()}}.
 }
 \details{
-If parameter requirements are not explicitly stated, the requirement defaults to 
+If parameter requirements are not explicitly stated, the requirement defaults to
 all parameter names in \code{x}.  Note that, by default,
 the inventory is not \code{.strict} unless the user explicitly
-states the parameter requirement. That is, if parameter requirements are explicitly 
+states the parameter requirement. That is, if parameter requirements are explicitly
 stated, \code{.strict} will be set to \code{TRUE} if a value \code{.strict} was not
 passed in the call.
 }
 \examples{
 \dontrun{
-inventory(mod, idata, CL:V) # parameters defined, inclusively, CL through Volume 
-inventory(mod, idata, everything()) # all parameters
-inventory(mod, idata, contains("OCC")) # all parameters containing OCC
-inventory(mod, idata, -F) # all parameters except F
+  inventory(mod, idata, CL:V) # parameters defined, inclusively, CL through Volume 
+  inventory(mod, idata, everything()) # all parameters
+  inventory(mod, idata, contains("OCC")) # all parameters containing OCC
+  inventory(mod, idata, -F) # all parameters except F
 }
+
+}
+\seealso{
+\code{\link[=check_data_names]{check_data_names()}}
 }

--- a/man/is.mrgmod.Rd
+++ b/man/is.mrgmod.Rd
@@ -17,6 +17,7 @@ The function checks to see if the object is either
 \code{mrgmod} or \code{packmod}.
 }
 \examples{
-is.mrgmod(house())
+mod <- mrgsolve::house()
+is.mrgmod(mod)
 
 }

--- a/man/is.mrgsims.Rd
+++ b/man/is.mrgsims.Rd
@@ -2,16 +2,16 @@
 % Please edit documentation in R/class_mrgsims.R
 \name{is.mrgsims}
 \alias{is.mrgsims}
-\title{Check if an object is mrgsim output}
+\title{Check if an object is mrgsims output}
 \usage{
 is.mrgsims(x)
 }
 \arguments{
-\item{x}{any object}
+\item{x}{any object.}
 }
 \value{
 \code{TRUE} if \code{x} inherits \code{mrgsims}.
 }
 \description{
-Check if an object is mrgsim output
+Check if an object is mrgsims output
 }

--- a/man/lctran.Rd
+++ b/man/lctran.Rd
@@ -22,7 +22,7 @@ uctran(data, ...)
 \method{uctran}{ev}(data, ...)
 }
 \arguments{
-\item{data}{a data set with nmtran-like format.}
+\item{data}{a data set with nmtran-like format or an event object.}
 
 \item{...}{for potential future use.}
 
@@ -30,9 +30,8 @@ uctran(data, ...)
 and lower case versions of any nmtran-like column in the data frame.}
 }
 \value{
-A data frame or event object with possibly renamed columns.
-
-The input data set, with select columns made lower case.
+A data frame or event object, with column names possibly converted to upper
+or lower case.
 }
 \description{
 Previous data set requirements included lower case names for data items

--- a/man/loadso.Rd
+++ b/man/loadso.Rd
@@ -10,27 +10,26 @@ loadso(x, ...)
 \method{loadso}{mrgmod}(x, ...)
 }
 \arguments{
-\item{x}{the model object}
+\item{x}{a model object.}
 
-\item{...}{not used}
+\item{...}{not used.}
 }
 \value{
 The model object (invisibly).
 }
 \description{
 Once the model is compiled, the model object can be used to re-load
-the model shared object (the compiled code underlying the mode) when 
+the model shared object (the compiled code underlying the mode) when
 the simulation is to be done in a different R process.
 }
 \details{
-The `loadso` function most frequently needs to be used when parallelizing
-simulations across worker nodes.  The model can be run after calling 
-`loadso`, without requiring that it is re-compiled on worker nodes. It is 
-likely required that the model is built (and the shared object stored) in 
+The \code{loadso} function most frequently needs to be used when parallelizing
+simulations across worker nodes.  The model can be run after calling
+\code{loadso}, without requiring that it is re-compiled on worker nodes. It is
+likely required that the model is built (and the shared object stored) in
 a local directory off of the working R directory (see the second example).
 }
 \examples{
-
 \dontrun{ 
   mod <- mread("pk1", modlib())
   loadso(mod)

--- a/man/matlist.Rd
+++ b/man/matlist.Rd
@@ -29,14 +29,14 @@
 \S4method{show}{matlist}(object)
 }
 \arguments{
-\item{x}{a matlist object}
+\item{x}{a matlist object.}
 
 \item{detailed}{if \code{TRUE}, then a simple list of matrices is returned;
 otherwise, then entire \code{matlist} object data is returned along with the
 name of the \code{class} (e.g. either \code{omegalist} or \code{sigmalist}) as well
-as the \code{names} of the matrices}
+as the \code{names} of the matrices.}
 
-\item{...}{passed through to other methods}
+\item{...}{passed through to other methods.}
 
 \item{object}{passed to showmatlist}
 }

--- a/man/matrix_converters.Rd
+++ b/man/matrix_converters.Rd
@@ -37,16 +37,16 @@ as_dmat(x, ...)
 as_cmat(x, ...)
 }
 \arguments{
-\item{x}{data frame or list}
+\item{x}{data frame or list.}
 
-\item{...}{arguments passed to \code{\link{dmat}} or \code{\link{bmat}}}
+\item{...}{arguments passed to \code{\link[=dmat]{dmat()}} or \code{\link[=cmat]{cmat()}}.}
 
-\item{pat}{regular expression, character}
+\item{pat}{regular expression, character.}
 
-\item{cols}{column names to use instead of \code{pat}}
+\item{cols}{column names to use instead of \code{pat}.}
 }
 \value{
-A numeric matrix for list and numeric methods.  For data.frames, 
+A numeric matrix for list and numeric methods.  For data.frames,
 a list of matrices are returned.
 }
 \description{
@@ -56,19 +56,18 @@ diagonal matrix (\code{d}), a block matrix (\code{b}), or a a correlation
 matrix (\code{c}).
 }
 \details{
-Use \code{as_dmat} to create a diagonal matrix, \code{as_bmat}
-to create a block matrix, and \code{as_cmat} to create a block 
+Use \code{as_dmat()} to create a diagonal matrix, \code{as_bmat()}
+to create a block matrix, and \code{as_cmat()} to create a block
 matrix where off-diagonal elements are understood to be correlations
-rather than covariances. \code{as_cmat} uses \code{as_bmat} to 
-form the matrix and then converts off-diagonal elements to 
+rather than covariances. \code{as_cmat()} uses \code{as_bmat()} to
+form the matrix and then converts off-diagonal elements to
 covariances before returning.
 
 The methods for \code{data.frame} will work down the rows
-of the data frame and make the appropriate matrix from 
+of the data frame and make the appropriate matrix from
 the data in each row.  The result is a list of matrices.
 }
 \examples{
-
 df <- data.frame(
   OMEGA1.1 = c(1,2),
   OMEGA2.1 = c(11,22),
@@ -83,5 +82,5 @@ as_dmat(df[1,],"OMEGA")
 
 }
 \seealso{
-\code{\link{bmat}}, \code{\link{dmat}}, \code{\link{cmat}}
+\code{\link[=bmat]{bmat()}}, \code{\link[=dmat]{dmat()}}, \code{\link[=cmat]{cmat()}}
 }

--- a/man/matrix_helpers.Rd
+++ b/man/matrix_helpers.Rd
@@ -14,20 +14,24 @@ cmat(..., digits = -1)
 dmat(...)
 }
 \arguments{
-\item{...}{matrix data}
+\item{...}{matrix data.}
 
-\item{correlation}{logical; if TRUE, off-diagonal elements are assumed 
-to be correlations and converted to covariances}
+\item{correlation}{logical; if \code{TRUE}, off-diagonal elements are assumed
+to be correlations and converted to covariances.}
 
-\item{digits}{if greater than zero, matrix is passed to signif (along 
-with digits) prior to returning}
+\item{digits}{if greater than zero, matrix is passed to \code{\link[=signif]{signif()}} (along
+with digits) prior to returning.}
+}
+\value{
+A matrix.
 }
 \description{
-Create matrices from vector input
+These functions are simple utilities for creating diagonal, block or
+correlation matrices.
 }
 \details{
-\code{bmat} makes a block matrix.  \code{cmat} makes a correlation matrix. 
-\code{dmat} makes a diagonal matrix.
+\code{bmat()} makes a block matrix. \code{cmat()} makes a correlation matrix.
+\code{dmat()} makes a diagonal matrix.
 }
 \examples{
 
@@ -39,7 +43,5 @@ cmat(0.5, 0.87,0.2)
 
 }
 \seealso{
-\code{\link{as_bmat}}
-
-\code{\link{as_dmat}}
+\code{\link[=as_bmat]{as_bmat()}}, \code{\link[=as_dmat]{as_dmat()}}
 }

--- a/man/mcode.Rd
+++ b/man/mcode.Rd
@@ -15,25 +15,25 @@ mcode_cache(
 )
 }
 \arguments{
-\item{model}{model name}
+\item{model}{model name.}
 
-\item{code}{character string specifying a \code{mrgsolve} model}
+\item{code}{character string specifying a \code{mrgsolve} model.}
 
-\item{project}{project name}
+\item{project}{project directory for the model.}
 
-\item{...}{passed to \code{\link{mread}}; see that help topic for other
-arguments that can be set}
+\item{...}{passed to \code{\link[=mread]{mread()}}; see that help topic for other arguments
+that can be set.}
 }
 \description{
-This is a convenience function that ultimately calls \code{\link{mread}}.
-Model code is written to a file and read back in using \code{\link{mread}}.
+This is a convenience function that ultimately calls \code{\link[=mread]{mread()}}.
+Model code is written to a file and read back in using \code{\link[=mread]{mread()}}.
 }
 \details{
-Note that the arguments are in slightly different order than 
-\code{\link{mread}}.  The default \code{project} is \code{tempdir()}.
+Note that the arguments are in slightly different order than
+\code{\link[=mread]{mread()}}.  The default \code{project} is \code{\link[=tempdir]{tempdir()}}.
 
-See the \code{\link{mread}} help topic for discussion about caching
-compilation results with \code{mcode_cache}.
+See the \code{\link[=mread]{mread()}} help topic for discussion about caching
+compilation results with \code{\link[=mcode_cache]{mcode_cache()}}.
 }
 \examples{
 
@@ -47,10 +47,10 @@ double V = 20;
 double KA = 1;
 '
 
-mod <- mcode("example",code)
+mod <- mcode("example", code)
 }
 
 }
 \seealso{
-\code{\link{mread}}, \code{\link{mread_cache}}
+\code{\link[=mread]{mread()}}, \code{\link[=mread_cache]{mread_cache()}}
 }

--- a/man/mcode.Rd
+++ b/man/mcode.Rd
@@ -36,7 +36,6 @@ See the \code{\link[=mread]{mread()}} help topic for discussion about caching
 compilation results with \code{\link[=mcode_cache]{mcode_cache()}}.
 }
 \examples{
-
 \dontrun{ 
 code <- '
 $CMT DEPOT CENT
@@ -47,7 +46,7 @@ double V = 20;
 double KA = 1;
 '
 
-mod <- mcode("example", code)
+mod <- mcode("example", code, compile = FALSE)
 }
 
 }

--- a/man/modlib.Rd
+++ b/man/modlib.Rd
@@ -14,7 +14,10 @@ modlib(model = NULL, ..., list = FALSE)
 \item{list}{logical; if \code{TRUE}, a list of available models is returned.}
 }
 \description{
-Internal model library
+Pre-coded models are included in the mrgsolve installation; these can be
+compiled and loaded with \code{modlib()}. These models are usually most useful
+for exploratory simulation or learning mrgsolve. Production simulation work
+is typically accomplished by a custom-coded model.
 }
 \details{
 See \link{modlib_details}, \link{modlib_pk}, \link{modlib_pkpd}, \link{modlib_tmdd},

--- a/man/modlib.Rd
+++ b/man/modlib.Rd
@@ -7,25 +7,24 @@
 modlib(model = NULL, ..., list = FALSE)
 }
 \arguments{
-\item{model}{\code{character} name of a model in the library}
+\item{model}{\code{character} name of a model in the library.}
 
-\item{...}{passed to \code{\link{mread_cache}}}
+\item{...}{passed to \code{\link[=mread_cache]{mread_cache()}}.}
 
-\item{list}{list available models}
+\item{list}{logical; if \code{TRUE}, a list of available models is returned.}
 }
 \description{
 Internal model library
 }
 \details{
-See \code{\link{modlib_details}}, \code{\link{modlib_pk}}, 
-\code{\link{modlib_pkpd}}, 
-\code{\link{modlib_tmdd}}, \code{\link{modlib_viral}} for details.
+See \link{modlib_details}, \link{modlib_pk}, \link{modlib_pkpd}, \link{modlib_tmdd},
+\link{modlib_viral} for details.
 
-Call \code{modlib("<modelname>")} to compile and load a mode from the 
+Call \code{modlib("<modelname>")} to compile and load a mode from the
 library.
 
-Call \code{modlib(list=TRUE)} to list available models.  Once the model 
-is loaded (see examples below), call \code{as.list(mod)$code} to see
+Call \code{modlib(list=TRUE)} to list available models.  Once the model
+is loaded (see examples below), call \code{as.list(mod)$code} to extract
 model code and equations.
 }
 \examples{
@@ -51,7 +50,6 @@ mod <- mread("1005",   modlib())  # embedded NONMEM result
 mod <- mread("nm-like", modlib()) # model with nonmem-like syntax
 mod <- mread("evtools", modlib())
 
-mrgsolve:::code(mod)
+as.list(mod)$code
 }
-
 }

--- a/man/mread.Rd
+++ b/man/mread.Rd
@@ -120,7 +120,7 @@ the model.  This is the location where the model shared object will be
 stored on disk.  The default is a temporary directory, so compilation
 artifacts are lost when R restarts when the default is used.  Changing
 \code{soloc} to a persistent directory location will preserve those
-artifacts across R restarts.  Also, if simulation from a single model is
+artifacts across R restarts. Also, if simulation from a single model is
 being done in separate processes on separate compute nodes, it might be
 necessary to store these compilation artifacts in a local directory
 to make them accessible to the different nodes. If the \code{soloc}
@@ -133,7 +133,7 @@ restarted.
 \section{Model Library}{
 
 
-mrgsolve comes bundled with several precoded PK, PK/PD, and
+mrgsolve comes bundled with several pre-coded PK, PK/PD, and
 other systems models that are accessible via the \code{mread()} interface.
 
 Models available in the library include:
@@ -163,15 +163,11 @@ $ODE dxdt_CENT = -(CL/VC)*CENT;
 '
 
 mod <- mcode("ex_mread", code)
-
 mod
 
-mod \%>\% init(CENT=1000) \%>\% mrgsim \%>\% plot
-
+mod \%>\% init(CENT=1000) \%>\% mrgsim() \%>\% plot()
 
 mod <- mread("irm3", modlib())
-
-mod
 
 # if the model is in the file mymodel.cpp
 mod <- mread("mymodel")
@@ -182,8 +178,6 @@ mod <- mread(file = "mymodel.txt")
 or
 
 mod <- mread_file("mymodel.txt")
-
-
 }
 
 }

--- a/man/mread.Rd
+++ b/man/mread.Rd
@@ -41,114 +41,115 @@ mread_cache(
 mread_file(file, ...)
 }
 \arguments{
-\item{model}{model name}
+\item{model}{model name.}
 
-\item{project}{location of the model specification file an any 
+\item{project}{location of the model specification file an any
 headers to be included; see also the discussion about model; this argument
-can be set via \code{options()}
-library under details as well as the \code{\link{modlib}} help topic}
+can be set via \code{\link[=options]{options()}}.
+library under details as well as the \code{\link[=modlib]{modlib()}} help topic.}
 
-\item{code}{a character string with model specification code to be 
-used instead of a model file}
+\item{code}{a character string with model specification code to be
+used instead of a model file.}
 
 \item{file}{the full file name (with extension, but without path)
-where the model is specified}
+where the model is specified.}
 
-\item{udll}{use unique name for shared object}
+\item{udll}{use unique name for shared object.}
 
-\item{ignore.stdout}{passed to system call for compiling model}
+\item{ignore.stdout}{passed to system call when compiling the model; set this
+to \code{FALSE} to print output to the R console.}
 
-\item{raw}{if TRUE, return a list of raw output}
+\item{raw}{if \code{TRUE}, return model content as a list, bypassing the compile
+step; this argument is typically used for debugging problems with the
+model build.}
 
-\item{compile}{logical; if \code{TRUE}, the model will be built}
+\item{compile}{logical; if \code{TRUE}, the model will be built.}
 
-\item{audit}{check the model specification file for errors}
+\item{audit}{check the model specification file for errors.}
 
-\item{quiet}{don't print messages when compiling}
+\item{quiet}{don't print messages when compiling.}
 
-\item{check.bounds}{check boundaries of parameter list}
+\item{check.bounds}{check boundaries of parameter list.}
 
-\item{warn}{logical; if \code{TRUE}, print warning messages that may arise}
+\item{warn}{logical; if \code{TRUE}, print warning messages that may arise while
+building the model.}
 
 \item{soloc}{the directory location where the model shared object is built
-and stored; see details; this argument can be set via \code{options()}; 
-if the directory does not exist, `mread` will attempt to create it.}
+and stored; see details; this argument can be set via \code{\link[=options]{options()}};
+if the directory does not exist, \code{mread()} will attempt to create it.}
 
-\item{capture}{a character vector or comma-separated string of additional 
-model variables to capture; these variables will be added to the capture 
-list for the current call to \code{\link{mread}} only}
+\item{capture}{a character vector or comma-separated string of additional
+model variables to capture; these variables will be added to the capture
+list for the current call to \code{mread()} only.}
 
-\item{preclean}{logical; if \code{TRUE}, compilation artifacts are 
-cleaned up first}
+\item{preclean}{logical; if \code{TRUE}, compilation artifacts are
+cleaned up first.}
 
 \item{recover}{if \code{TRUE}, a list of build will be returned in case
-the model shared object fails to compile; use this option to and 
-the returned object to collect information assist in debugging}
+the model shared object fails to compile; use this option to and
+the returned object to collect information assist in debugging.}
 
-\item{...}{passed to \code{\link[mrgsolve]{update}}; also arguments passed
-to mread from \code{\link{mread_cache}}.}
+\item{...}{passed to \code{\link[=update]{update()}}; also arguments passed
+to \code{mread()} from \code{mread_cache()}.}
 }
 \description{
-\code{mread} reads and parses the \code{mrgsolve} model specification file,
-builds the model, and returns a model object for simulation. 
-\code{mread_cache} does the same, but caches the compilation result for 
-later use.
+\code{mread()} reads and parses the mrgsolve model specification file,
+builds the model, and returns a model object for simulation.
+\code{mread_cache()} does the same, but caches the compilation result for
+later use. \code{mread_file()} can be used for convenience, taking the model
+file name as the first argument.
 }
 \details{
-The \code{model} argument is required.  For typical use, 
-the \code{file} argument is omitted and the value 
+The \code{model} argument is required.  For typical use,
+the \code{file} argument is omitted and the value
 for \code{file} is generated from the value for \code{model}.
-To determine the source file name, \code{mrgsolve} will look for 
-a file extension in \code{model}.  A file extension is 
-assumed when it finds a period followed by one to three alpha-numeric 
-characters at the end of the string (e.g. \code{mymodel.txt} but not 
-\code{my.model}).  If no file extension is found, the extension \code{.cpp} 
-is assumed (e.g. \code{file} is \code{<model-name>.cpp}).  If a file 
-extension is found, \code{file} is \code{<model-name>}.    
+To determine the source file name, mrgsolve will look for
+a file extension in \code{model}.  A file extension is
+assumed when it finds a period followed by one to three alpha-numeric
+characters at the end of the string (e.g. \code{mymodel.txt} but not
+\code{my.model}).  If no file extension is found, the extension \code{.cpp}
+is assumed (e.g. \code{file} is \verb{<model-name>.cpp}).  If a file
+extension is found, \code{file} is \verb{<model-name>}.
 
 Best practice is to avoid using \code{.} in \code{model} unless
-you are using \code{model} to point to the model specification 
-file name. Otherwise, use \code{\link{mread_file}}. 
+you are using \code{model} to point to the model specification
+file name. Otherwise, use \code{mread_file()}.
 
 Use the \code{soloc} argument to specify a directory location for building
-the model.  This is the location where the model shared object will be 
-stored on disk.  The default is a temporary directory, so compilation 
+the model.  This is the location where the model shared object will be
+stored on disk.  The default is a temporary directory, so compilation
 artifacts are lost when R restarts when the default is used.  Changing
-\code{soloc} to a persistent directory location will preserve those 
-artifacts across R restarts.  Also, if simulation from a single model is 
-being done in separate processes on separate compute nodes, it might be 
-necessary to store these compilation artifacts in a local directory 
-to make them accessible to the different nodes. If the \code{soloc} 
-directory does not exist, `mread` will attempt to create it.
+\code{soloc} to a persistent directory location will preserve those
+artifacts across R restarts.  Also, if simulation from a single model is
+being done in separate processes on separate compute nodes, it might be
+necessary to store these compilation artifacts in a local directory
+to make them accessible to the different nodes. If the \code{soloc}
+directory does not exist, \code{mread()} will attempt to create it.
 
-Similarly, using \code{mread_cache} will cache results in the temporary 
-directory and the cache cannot be accessed after the R process is 
+Similarly, using \code{mread_cache()} will cache results in the temporary
+directory and the cache cannot be accessed after the R process is
 restarted.
 }
 \section{Model Library}{
 
 
-\code{mrgsolve} comes bundled with several precoded PK, PK/PD, and 
-other systems models that are accessible via the \code{mread} interface.  
+mrgsolve comes bundled with several precoded PK, PK/PD, and
+other systems models that are accessible via the \code{mread()} interface.
 
 Models available in the library include:
-
 \itemize{
-  \item PK models: \code{pk1cmt}, \code{pk2cmt}, \code{pk3cmt},
-                   \code{pk1}, \code{pk2}, \code{popex}, \code{tmdd}
-  \item PKPD models: \code{irm1}, \code{irm2}, \code{irm3}, \code{irm4},
-                      \code{emax}, \code{effect}
-  \item Other models: \code{viral1}, \code{viral2}
+\item PK models: \code{pk1cmt}, \code{pk2cmt}, \code{pk3cmt}, \code{pk1}, \code{pk2}, \code{popex}, \code{tmdd}
+\item PKPD models: \code{irm1}, \code{irm2}, \code{irm3}, \code{irm4}, \code{emax}, \code{effect}
+\item Other models: \code{viral1}, \code{viral2}
 }
 
-When the library model is accessed, \code{mrgsolve} will compile and load
-the model as you would for any other model.  It is only necessary to 
+When the library model is accessed, mrgsolve will compile and load
+the model as you would for any other model.  It is only necessary to
 reference the correct model name and point the \code{project} argument
-to the \code{mrgsolve} model library location via \code{\link{modlib}}.
+to the mrgsolve model library location via \code{\link[=modlib]{modlib()}}.
 
-For more details, see \code{\link{modlib_pk}}, \code{\link{modlib_pkpd}}, 
-\code{\link{modlib_tmdd}}, \code{\link{modlib_viral}}, and 
-\code{\link{modlib_details}} for more information about the state 
+For more details, see \link{modlib_pk}, \link{modlib_pkpd}, \link{modlib_tmdd},
+\link{modlib_viral}, and \link{modlib_details} for more information about the state
 variables and parameters in each model.
 }
 
@@ -187,5 +188,5 @@ mod <- mread_file("mymodel.txt")
 
 }
 \seealso{
-\code{\link{mcode}}, \code{\link{mcode_cache}}
+\code{\link[=mcode]{mcode()}}, \code{\link[=mcode_cache]{mcode_cache()}}
 }

--- a/man/mread.Rd
+++ b/man/mread.Rd
@@ -67,7 +67,7 @@ model build.}
 
 \item{audit}{check the model specification file for errors.}
 
-\item{quiet}{don't print messages when compiling.}
+\item{quiet}{don't print messages from mrgsolve when compiling.}
 
 \item{check.bounds}{check boundaries of parameter list.}
 

--- a/man/mrgsim.Rd
+++ b/man/mrgsim.Rd
@@ -39,20 +39,20 @@ do_mrgsim(
 )
 }
 \arguments{
-\item{x}{the model object}
+\item{x}{the model object.}
 
-\item{data}{NMTRAN-like data set (see \code{\link[=data_set]{data_set()}})}
+\item{data}{NMTRAN-like data set (see \code{\link[=data_set]{data_set()}}).}
 
 \item{idata}{a matrix or data frame of model parameters,
-one parameter per row (see \code{\link[=idata_set]{idata_set()}})}
+one parameter per row (see \code{\link[=idata_set]{idata_set()}}).}
 
-\item{events}{an event object}
+\item{events}{an event object.}
 
 \item{nid}{integer number of individuals to simulate; only used if
-idata and data are missing}
+idata and data are missing.}
 
 \item{...}{passed to \code{\link[=update]{update()}} and
-\code{\link[=do_mrgsim]{do_mrgsim()}}}
+\code{\link[=do_mrgsim]{do_mrgsim()}}.}
 
 \item{output}{if \code{NULL} (the default) a mrgsims object is returned;
 otherwise, pass \code{df} to return a data.frame or \code{matrix} to
@@ -143,7 +143,7 @@ every \code{interrupt} simulation records; pass a negative number to never check
 for the user interrupt interval.}
 }
 \value{
-An object of class \link{mrgsims}
+An object of class \link{mrgsims}.
 }
 \description{
 This function sets up the simulation run from data stored in the model
@@ -156,22 +156,22 @@ inputs. \code{mrgsim_df} coerces output to data.frame prior to returning.
 \details{
 \itemize{
 \item Use \code{\link[=mrgsim_df]{mrgsim_df()}} to return a data frame rather than
-\code{mrgsims} object
+\code{mrgsims} object.
 \item Both \code{data} and \code{idata} will be coerced to numeric matrix
 \item \code{carry_out} can be used to insert data columns into the output
 data set. This is partially dependent on the nature of the data brought
-into the problem
+into the problem.
 \item When using \code{data} and \code{idata} together, an error is
 generated if an  ID occurs in \code{data} but not \code{idata}.
 Also, when looking up data in \code{idata}, ID in \code{idata} is
 assumed to be uniquely keyed to ID in \code{data}.  No error is
 generated if ID is duplicated in \code{data}; parameters will be used
-from the first occurrence found in \code{idata}
+from the first occurrence found in \code{idata}.
 \item \code{carry_out}: \code{idata} is assumed to be individual-level and variables that
 are carried from \code{idata} are repeated throughout the individual's simulated
 data.  Variables carried from \code{data} are carried via last-observation carry
 forward.  \code{NA} is returned from observations that are inserted into
-simulated output that occur prior to the first record in \code{data}
+simulated output that occur prior to the first record in \code{data}.
 \item \code{recover}: this is similar to \code{carry_out} with respect to
 end result, but it uses a different process.  Columns to be recovered are
 cached prior to running the simulation, and then joined back on to the

--- a/man/mrgsim_q.Rd
+++ b/man/mrgsim_q.Rd
@@ -26,66 +26,70 @@ mrgsim_q(
 times will only be added to the output if there are no observation
 records in \code{data}.}
 
-\item{output}{output data type; if \code{mrgsims}, then the default output
-object is returned; if \code{"df"} then a data frame is returned.}
+\item{output}{output data type; if \verb{"mrgsims", then the default output object is returned; if }"df"` then a data frame is returned.}
 
-\item{skip_init_calc}{don't use \code{$MAIN} to calculate initial conditions.}
+\item{skip_init_calc}{don't use \verb{$MAIN} to calculate initial conditions.}
 
 \item{simcall}{not used; only the default value of 0 is allowed.}
 
-\item{etasrc}{source for ETA() values in the model; values can include: 
-"omega", `"data"`, `"data.all"`, `"idata"`, or `"idata.all"`; see 
-'Details' in [mrgsim()].}
+\item{etasrc}{source for ETA() values in the model; values can include:
+"omega", \code{"data"}, \code{"data.all"}, \code{"idata"}, or \code{"idata.all"}; see
+'Details' in \code{\link[=mrgsim]{mrgsim()}}.}
 }
 \value{
-By default, an object of class `mrgsims`. Use `output = "df"` to return 
+By default, an object of class \code{mrgsims}. Use \code{output = "df"} to return
 a data frame.
 }
 \description{
-Use the function when you would usually use \code{\link{mrgsim_d}}, 
-but you need a quicker turnaround time.  The timing differences 
+Use the function when you would usually use \code{\link[=mrgsim_d]{mrgsim_d()}},
+but you need a quicker turnaround time.  The timing differences
 might be difficult to detect for a single simulation run
 but could become appreciable with repeated simulation.  See
-\code{details} for important differences in how \code{\link{mrgsim_q}}
-is invoked compared to \code{\link{mrgsim}} and \code{\link{mrgsim_d}}.  
+\strong{Details} for important differences in how \code{mrgsim_q()}
+is invoked compared to \code{\link[=mrgsim]{mrgsim()}} and \code{\link[=mrgsim_d]{mrgsim_d()}}.
 This function should always be used for benchmarking simulation time with
 mrgsolve.
 }
 \details{
+\code{mrgsim_q()} mainly cuts some of the overhead from the simulation. So, the
+primary efficiency gain from using \code{mrgsim_q()} comes when the simulation
+executes very quickly. It is unlikely you will see a big performance
+difference between \code{mrgsim_q()} and \code{\link[=mrgsim]{mrgsim()}} when the model is difficult to
+solve or if there is a large input data set.
+
 This function does not support the piped simulation workflow.  All
-arguments must be passed into the function except for \code{x}.  
+arguments must be passed into the function except for \code{x}.
 
-A data set is required for this simulation workflow.  The 
+A data set is required for this simulation workflow.  The
 data set can have only dosing records or doses with observations.
-When the data set only includes doses, a single numeric vector of 
-observation times should be passed in.  
+When the data set only includes doses, a single numeric vector of
+observation times should be passed in.
 
-This simulation workflow does not support \code{Req} (request) 
-functionality.  All compartments and captured variables will 
+This simulation workflow does not support \code{Req} (request)
+functionality.  All compartments and captured variables will
 always be returned in the simulation output.
 
 This simulation workflow does not support carry-out functionality.
 
 This simulation workflow does not accept arguments to be passed
-to \code{\link[mrgsolve]{update}}. This must be done by a separate
-call to \code{\link[mrgsolve]{update}}.
+to \code{\link[=update]{update()}}. This must be done by a separate
+call to \code{\link[=update]{update()}}.
 
-This simulation workflow does not support use of event objects.  If 
-an event object is needed, it should be converted to a data set 
-prior to the simulation run (see \code{as_data_set} or 
-\code{\link{as.data.frame.ev}}.
+This simulation workflow does not support use of event objects.  If
+an event object is needed, it should be converted to a data set
+prior to the simulation run (see \code{\link[=as_data_set]{as_data_set()}} or
+\code{\link[=as.data.frame]{as.data.frame()}}).
 
-This simulation workflow does not support idata sets or any 
-feature enabled by idata set use.  Individual level parameters
+This simulation workflow does not support idata sets or any
+feature enabled by \code{idata} set use.  Individual level parameters
 should be joined onto the data set prior to simulation.  Otherwise
-\code{\link{mrgsim_i}} or \code{\link{mrgsim_ei}} should be used.
+\code{\link[=mrgsim_i]{mrgsim_i()}} or \code{\link[=mrgsim_ei]{mrgsim_ei()}} should be used.
 
-By default, a mrgsims object is returned (as with \code{\link{mrgsim}}). 
-Use the \code{output="df"} argument to request a plain 
+By default, a mrgsims object is returned (as with \code{\link[=mrgsim]{mrgsim()}}).
+Use the \code{output = "df"} argument to request a plain
 data.frame of simulated data on return.
 }
 \examples{
-
 mod <- mrgsolve::house()
 
 data <- expand.ev(amt = c(100, 300, 1000))
@@ -96,5 +100,5 @@ out
 
 }
 \seealso{
-\code{\link{mrgsim}}, \code{\link{mrgsim_variants}}, \code{\link{qsim}}
+\code{\link[=mrgsim]{mrgsim()}}, \link{mrgsim_variants}, \code{\link[=qsim]{qsim()}}
 }

--- a/man/mrgsim_variants.Rd
+++ b/man/mrgsim_variants.Rd
@@ -23,17 +23,17 @@ mrgsim_i(x, idata, data = NULL, events = NULL, ...)
 mrgsim_0(x, idata = NULL, data = NULL, events = NULL, ...)
 }
 \arguments{
-\item{x}{the model object}
+\item{x}{the model object.}
 
-\item{events}{an event object}
+\item{events}{an event object.}
 
 \item{idata}{a matrix or data frame of model parameters,
-one parameter per row (see \code{\link[=idata_set]{idata_set()}})}
+one parameter per row (see \code{\link[=idata_set]{idata_set()}}).}
 
-\item{data}{NMTRAN-like data set (see \code{\link[=data_set]{data_set()}})}
+\item{data}{NMTRAN-like data set (see \code{\link[=data_set]{data_set()}}).}
 
 \item{...}{passed to \code{\link[=update]{update()}} and
-\code{\link[=do_mrgsim]{do_mrgsim()}}}
+\code{\link[=do_mrgsim]{do_mrgsim()}}.}
 }
 \description{
 These functions are called by \code{\link[=mrgsim]{mrgsim()}} and have

--- a/man/mrgsims.Rd
+++ b/man/mrgsims.Rd
@@ -32,44 +32,40 @@
 \S4method{show}{mrgsims}(object)
 }
 \arguments{
-\item{x}{mrgsims object}
+\item{x}{mrgsims object.}
 
 \item{name}{name of column of simulated output to retain}
 
-\item{...}{passed to other functions}
+\item{...}{passed to other functions.}
 
-\item{row.names}{passed to \code{\link{as.data.frame}}}
+\item{row.names}{passed to \code{\link[=as.data.frame]{as.data.frame()}}.}
 
-\item{optional}{passed to \code{\link{as.data.frame}}}
+\item{optional}{passed to \code{\link[=as.data.frame]{as.data.frame()}}.}
 
-\item{object}{passed to show}
+\item{object}{passed to show.}
 }
 \description{
-These methods help the user view simulation output and extract 
-simulated data to work with further.  The methods listed here 
-for the most part have generics defined by R or other R packages.  
-See the \code{seealso} section for other methods defined 
-by \code{mrgsolve} that have their own documentation pages.
+These methods help the user view simulation output and extract
+simulated data to work with further.  The methods listed here
+for the most part have generics defined by R or other R packages.
+See the \strong{See Also} section for other methods defined
+by mrgsolve that have their own documentation pages.
 }
 \details{
-Most methods should behave as expected according to other method 
+Most methods should behave as expected according to other method
 commonly used in R (e.g. head, tail, as.data.frame, etc ...)
-
 \itemize{
-  \item{\code{$}} selects a column in the simulated data and 
-  returns numeric
-  \item{\code{head}} see \code{\link{head.matrix}}; returns 
-  simulated data
-  \item{\code{tail}} see \code{\link{tail.matrix}}; returns 
-  simulated data
-  \item{\code{dim}, \code{nrow}, \code{ncol}} returns dimensions, 
-  number of rows, and number of columns in simulated data
-  \item{\code{as.data.frame}} coerces simulated data to data.frame 
-  and returns the data.frame
-  \item{\code{as.matrix}} returns matrix of simulated data
-  \item{\code{summary}} coerces simulated data to data.frame 
-  and passes to \code{\link{summary.data.frame}}
-  \item{\code{plot}} plots simulated data; see \code{\link{plot_mrgsims}}
+\item \code{$} selects a column in the simulated data and
+returns numeric
+\item \code{head()} see \code{\link[=head.matrix]{head.matrix()}}; returns simulated data
+\item \code{tail()} see \code{\link[=tail.matrix]{tail.matrix()}}; returns simulated data
+\item \code{dim()}, \code{nrow()}, \code{ncol()} returns dimensions,
+number of rows, and number of columns in simulated data
+\item \code{as.data.frame()} coerces simulated data to data.frame
+\item \code{as.matrix()} returns matrix of simulated data
+\item \code{summary()} coerces simulated data to data.frame and passes to
+\code{\link[=summary.data.frame]{summary.data.frame()}}
+\item \code{\link[=plot]{plot()}} plots simulated data; see \link{plot_mrgsims}
 }
 }
 \examples{
@@ -100,12 +96,13 @@ out$CP
 }
 
 plot(out)
+
 \dontrun{
 plot(out, CP~.)
 plot(out, CP+RESP~time, scales="same", xlab="Time", main="Model sims")
 }
 }
 \seealso{
-\code{\link{stime}}
+\code{\link[=stime]{stime()}}
 }
 \keyword{internal}

--- a/man/mrgsims_modify.Rd
+++ b/man/mrgsims_modify.Rd
@@ -14,9 +14,9 @@ select_sims(.data, ...)
 filter_sims(.data, ...)
 }
 \arguments{
-\item{.data}{a mrgsims object}
+\item{.data}{a mrgsims object.}
 
-\item{...}{other arguments passed to the \code{dplyr} functions}
+\item{...}{other arguments passed to the \code{dplyr} functions.}
 }
 \description{
 These functions modify the simulated data in an mrgsims object and return

--- a/man/mrgsolve_package.Rd
+++ b/man/mrgsolve_package.Rd
@@ -121,6 +121,7 @@ x <- mod \%>\% ev(amt=300, ii=12, addl=3) \%>\% mrgsim
 \seealso{
 Useful links:
 \itemize{
+  \item \url{https://mrgsolve.org/docs}
   \item \url{https://github.com/metrumresearchgroup/mrgsolve}
   \item Report bugs at \url{https://github.com/metrumresearchgroup/mrgsolve/issues}
 }

--- a/man/nmext.Rd
+++ b/man/nmext.Rd
@@ -26,45 +26,45 @@ nmext(
 )
 }
 \arguments{
-\item{run}{run number}
+\item{run}{run number.}
 
-\item{project}{project directory}
+\item{project}{project directory.}
 
-\item{file}{deprecated; use \code{path} instead}
+\item{file}{deprecated; use \code{path} instead.}
 
-\item{path}{full path to NONMEM \code{ext} file}
+\item{path}{full path to NONMEM \code{ext} file.}
 
-\item{root}{the directory that `path` and `project` are relative to; this is
-currently limited to the `working` directory or `cppdir`, the directory 
-where the model file is located}
+\item{root}{the directory that \code{path} and \code{project} are relative to; this is
+currently limited to the \code{working} directory or \code{cppdir}, the directory
+where the model file is located.}
 
-\item{index}{the estimation number to return;  "last" will return the 
-last estimation results; otherwise, pass an integer indicating which 
-estimation results to return}
+\item{index}{the estimation number to return;  "last" will return the
+last estimation results; otherwise, pass an integer indicating which
+estimation results to return.}
 
-\item{theta}{logical; if TRUE, the \code{$THETA} vector is returned}
+\item{theta}{logical; if TRUE, the \verb{$THETA} vector is returned.}
 
-\item{omega}{logical; if TRUE, the \code{$OMEGA} matrix is returned}
+\item{omega}{logical; if TRUE, the \verb{$OMEGA} matrix is returned.}
 
-\item{sigma}{logical; if TRUE, the \code{$SIGMA} matrix is returned}
+\item{sigma}{logical; if TRUE, the \verb{$SIGMA} matrix is returned.}
 
-\item{olabels}{labels for \code{$OMEGA}}
+\item{olabels}{labels for \verb{$OMEGA}.}
 
-\item{slabels}{labels for \code{$SIGMA}}
+\item{slabels}{labels for \verb{$SIGMA}.}
 
-\item{oprefix}{prefix for \code{$OMEGA} labels}
+\item{oprefix}{prefix for \verb{$OMEGA} labels.}
 
-\item{sprefix}{prefix for \code{$SIGMA} labels}
+\item{sprefix}{prefix for \verb{$SIGMA} labels.}
 
-\item{tname}{name for \code{$THETA}}
+\item{tname}{name for \verb{$THETA}.}
 
-\item{oname}{name for \code{$OMEGA}}
+\item{oname}{name for \verb{$OMEGA}.}
 
-\item{sname}{name for \code{$SIGMA}}
+\item{sname}{name for \verb{$SIGMA}.}
 
-\item{read_fun}{function to use when reading the \code{ext} file}
+\item{read_fun}{function to use when reading the \code{ext} file.}
 
-\item{env}{internal}
+\item{env}{internal use only.}
 }
 \description{
 Import model estimates from a NONMEM ext file

--- a/man/nmxml.Rd
+++ b/man/nmxml.Rd
@@ -27,69 +27,69 @@ nmxml(
 )
 }
 \arguments{
-\item{run}{run number}
+\item{run}{run number.}
 
-\item{project}{project directory}
+\item{project}{project directory.}
 
-\item{file}{deprecated; use \code{path} instead}
+\item{file}{deprecated; use \code{path} instead.}
 
-\item{path}{the complete path to the \code{run.xml} file}
+\item{path}{the complete path to the \code{run.xml} file.}
 
-\item{root}{the directory that `path` and `project` are relative to; this is
-currently limited to the `working` directory or `cppdir`, the directory 
-where the model file is located}
+\item{root}{the directory that \code{path} and \code{project} are relative to; this is
+currently limited to the \code{working} directory or \code{cppdir}, the directory
+where the model file is located.}
 
-\item{theta}{logical; if TRUE, the \code{$THETA} vector is returned}
+\item{theta}{logical; if TRUE, the \verb{$THETA} vector is returned.}
 
-\item{omega}{logical; if TRUE, the \code{$OMEGA} matrix is returned}
+\item{omega}{logical; if TRUE, the \verb{$OMEGA} matrix is returned.}
 
-\item{sigma}{logical; if TRUE, the \code{$SIGMA} matrix is returned}
+\item{sigma}{logical; if TRUE, the \verb{$SIGMA} matrix is returned.}
 
-\item{olabels}{labels for \code{$OMEGA}}
+\item{olabels}{labels for \verb{$OMEGA}.}
 
-\item{slabels}{labels for \code{$SIGMA}}
+\item{slabels}{labels for \verb{$SIGMA}.}
 
-\item{oprefix}{prefix for \code{$OMEGA} labels}
+\item{oprefix}{prefix for \verb{$OMEGA} labels.}
 
-\item{sprefix}{prefix for \code{$SIGMA} labels}
+\item{sprefix}{prefix for \verb{$SIGMA} labels.}
 
-\item{tname}{name for \code{$THETA}}
+\item{tname}{name for \verb{$THETA}.}
 
-\item{oname}{name for \code{$OMEGA}}
+\item{oname}{name for \verb{$OMEGA}.}
 
-\item{sname}{name for \code{$SIGMA}}
+\item{sname}{name for \verb{$SIGMA}.}
 
-\item{index}{the estimation number to return;  "last" will return the 
-last estimation results; otherwise, pass an integer indicating which 
-estimation results to return}
+\item{index}{the estimation number to return;  "last" will return the
+last estimation results; otherwise, pass an integer indicating which
+estimation results to return.}
 
-\item{xpath}{xml path containing run results; if the default doesn't work, 
-consider using \code{.//estimation} as an alternative; see details}
+\item{xpath}{xml path containing run results; if the default doesn't work,
+consider using \verb{.//estimation} as an alternative; see details.}
 
-\item{env}{internal}
+\item{env}{internal use only.}
 }
 \value{
-A list with theta, omega and sigma elements, 
-depending on what was requested
+A list with theta, omega and sigma elements, depending on what was
+requested.
 }
 \description{
 Import model estimates from a NONMEM xml file
 }
 \details{
-If \code{run} and \code{project} are supplied, the .xml file is 
-assumed to be located in \code{run.xml}, in directory \code{run} 
-off the \code{project} directory.  If \code{file} is supplied, 
+If \code{run} and \code{project} are supplied, the \code{.xml} file is
+assumed to be located in \code{run.xml}, in directory \code{run}
+off the \code{project} directory.  If \code{file} is supplied,
 \code{run} and \code{project} arguments are ignored.
 
-This function requires that the \code{xml2} package 
+This function requires that the xml2 package
 be installed and loadable.  If \code{requireNamespace("xml2")}
-fails, an error will be generated. 
+fails, an error will be generated.
 
 \code{nmxml} usually expects to find run results in the xpath called
-\code{.//nm:estimation}.  Occasionally, the run results are not stored in 
-this namespace but no namespaces are found in the xml file.  In this case, 
-the user can specify the xpath containing run results.  Consider trying 
-\code{.//estimation} as an alternative if the default fails.
+\verb{.//nm:estimation}.  Occasionally, the run results are not stored in
+this namespace but no namespaces are found in the xml file.  In this case,
+the user can specify the xpath containing run results.  Consider trying
+\verb{.//estimation} as an alternative if the default fails.
 }
 \examples{
 
@@ -97,7 +97,6 @@ if(requireNamespace("xml2")) {
   proj <- system.file("nonmem", package = "mrgsolve")
   mrgsolve:::nmxml(run = 1005, project = proj)
 }
-
 }
 \seealso{
 nmext

--- a/man/numerics_only.Rd
+++ b/man/numerics_only.Rd
@@ -2,19 +2,19 @@
 % Please edit documentation in R/mrgindata.R
 \name{numerics_only}
 \alias{numerics_only}
-\title{Prepare data.frame for input to mrgsim}
+\title{Prepare data.frame for input to mrgsim()}
 \usage{
 numerics_only(x, quiet = FALSE, convert_lgl = FALSE)
 }
 \arguments{
-\item{x}{a input data set}
+\item{x}{a input data set.}
 
-\item{quiet}{logical indicating whether or not warnings 
-should be printed}
+\item{quiet}{logical indicating whether or not warnings
+should be printed.}
 
-\item{convert_lgl}{if \code{TRUE}, convert logical 
-columns with \code{\link{as.integer}}}
+\item{convert_lgl}{if \code{TRUE}, convert logical
+columns with \code{\link[=as.integer]{as.integer()}}.}
 }
 \description{
-Prepare data.frame for input to mrgsim
+Prepare data.frame for input to mrgsim()
 }

--- a/man/obsonly.Rd
+++ b/man/obsonly.Rd
@@ -17,7 +17,7 @@ obsonly(x, value = TRUE, ...)
 Collect only observation records in the simulated output
 }
 \details{
-There is also a `obsonly` argument to [mrgsim()] that can 
+There is also an `obsonly` argument to [mrgsim()] that can 
 be set to accomplish the same thing as a call to `obsonly()` in 
 the pipeline.
 }

--- a/man/obsonly.Rd
+++ b/man/obsonly.Rd
@@ -9,7 +9,7 @@ obsonly(x, value = TRUE, ...)
 \arguments{
 \item{x}{model object.}
 
-\item{value}{the value for `obsonly`.}
+\item{value}{use `TRUE` to collect and return observation records only.}
 
 \item{...}{not used.}
 }

--- a/man/obsonly.Rd
+++ b/man/obsonly.Rd
@@ -2,22 +2,22 @@
 % Please edit documentation in R/chain.R
 \name{obsonly}
 \alias{obsonly}
-\title{Collect only observations in the simulated output}
+\title{Collect only observation records in the simulated output}
 \usage{
 obsonly(x, value = TRUE, ...)
 }
 \arguments{
-\item{x}{model object}
+\item{x}{model object.}
 
-\item{value}{the value for \code{obsonly}}
+\item{value}{the value for `obsonly`.}
 
-\item{...}{passed along}
+\item{...}{not used.}
 }
 \description{
-Collect only observations in the simulated output
+Collect only observation records in the simulated output
 }
 \details{
-There is also a \code{obsonly} argument to \code{\link{mrgsim}} that can 
-be set to accomplish the same thing as a call to \code{obsonly} in 
+There is also a `obsonly` argument to [mrgsim()] that can 
+be set to accomplish the same thing as a call to `obsonly()` in 
 the pipeline.
 }

--- a/man/omega.Rd
+++ b/man/omega.Rd
@@ -49,7 +49,7 @@ The primary function is \code{omat()} that can be used to both get the
 matrices in a model object.
 }
 \examples{
-## example("omega")
+# example("omega")
 mat1 <- matrix(1)
 mat2 <- diag(c(1,2,3))
 mat3 <- matrix(c(0.1, 0.002, 0.002, 0.5), 2,2)
@@ -57,30 +57,14 @@ mat4 <- dmat(0.1, 0.2, 0.3, 0.4)
 
 omat(mat1)
 omat(mat1, mat2, mat3)
-omat(A=mat1, B=mat2, C=mat3)
+omat(A = mat1, B = mat2, C = mat3)
 
 mod <- mrgsolve::house() \%>\% omat(mat4)
 
 omat(mod)
-omat(mod, make=TRUE)
+omat(mod, make = TRUE)
+as.matrix(omat(mod))
 
-
-\dontrun{
-
-$OMEGA
-1 2 3
-
-$OMEGA \@block
-1 0.1 2
-
-$OMEGA \@cor
-\@ prefix ETA_
-\@ labels CL VC KA
-0.1
-0.67 0.2
-0 0 0.3
-
-}
 }
 \seealso{
 \code{\link[=smat]{smat()}}, \code{\link[=dmat]{dmat()}}, \code{\link[=bmat]{bmat()}}, \code{\link[=cmat]{cmat()}}

--- a/man/omega.Rd
+++ b/man/omega.Rd
@@ -30,22 +30,22 @@ omat(.x, ...)
 \S4method{omat}{mrgsims}(.x, make = FALSE, ...)
 }
 \arguments{
-\item{.x}{a matrix, list of matrices or \code{matlist} object}
+\item{.x}{a matrix, list of matrices or \code{matlist} object.}
 
-\item{...}{passed to other functions, including \code{\link{modMATRIX}}}
+\item{...}{passed to other functions, including \code{\link[=modMATRIX]{modMATRIX()}}.}
 
-\item{labels}{character vector of names for \code{$OMEGA} elements; must 
-be equal to number of rows/columns in the matrix}
+\item{labels}{character vector of names for \verb{$OMEGA} elements; must
+be equal to number of rows/columns in the matrix.}
 
-\item{make}{logical; if TRUE, matrix list is rendered into a single matrix}
+\item{make}{logical; if \code{TRUE}, matrix list is rendered into a single matrix.}
 
-\item{open}{passed to \code{\link{merge.list}}}
+\item{open}{passed to \code{\link[=merge.list]{merge.list()}}.}
 
-\item{x}{\code{matlist} object}
+\item{x}{\code{matlist} object.}
 }
 \description{
-The primary function is \code{omat} that can be used to both get the 
-\code{$OMEGA} matrices out of a model object and to update \code{$OMEGA} 
+The primary function is \code{omat()} that can be used to both get the
+\verb{$OMEGA} matrices out of a model object and to update \verb{$OMEGA}
 matrices in a model object.
 }
 \examples{
@@ -81,4 +81,7 @@ $OMEGA \@cor
 0 0 0.3
 
 }
+}
+\seealso{
+\code{\link[=smat]{smat()}}, \code{\link[=dmat]{dmat()}}, \code{\link[=bmat]{bmat()}}, \code{\link[=cmat]{cmat()}}
 }

--- a/man/outvars.Rd
+++ b/man/outvars.Rd
@@ -7,10 +7,10 @@
 outvars(x, unlist = FALSE)
 }
 \arguments{
-\item{x}{mrgmod object}
+\item{x}{model object.}
 
 \item{unlist}{if \code{TRUE} then a character vector (rather than list) is
-returned}
+returned.}
 }
 \value{
 When \code{unlist} is \code{FALSE} (default) : a named list, with \code{cmt} showing names
@@ -23,7 +23,7 @@ Outputs can include model compartments or variables defined in the model
 that have been marked to \code{capture} in simulated output.
 }
 \examples{
-
-outvars(mrgsolve::house())
+mod <- house()
+outvars(mod)
 
 }

--- a/man/outvars.Rd
+++ b/man/outvars.Rd
@@ -23,7 +23,7 @@ Outputs can include model compartments or variables defined in the model
 that have been marked to \code{capture} in simulated output.
 }
 \examples{
-mod <- house()
+mod <- mrgsolve::house()
 outvars(mod)
 
 }

--- a/man/param_tags.Rd
+++ b/man/param_tags.Rd
@@ -28,7 +28,7 @@ or \code{covariates} as these will automatically be expected on input data when
 you call \code{\link[=check_data_names]{check_data_names()}}. User-defined tags are also possible, but you
 will need to alert \code{\link[=check_data_names]{check_data_names()}} to look for them.
 
-\strong{Examples}
+\strong{Model Specification Examples}
 
 You can use the \verb{$INPUT} block to add the \code{input} tag on these parameters
 
@@ -50,7 +50,7 @@ FFLAG = 1, DFLAG = 0
 }
 
 \examples{
-mod <- house()
+mod <- mrgsolve::house()
 
 param_tags(mod)
 

--- a/man/qsim.Rd
+++ b/man/qsim.Rd
@@ -64,10 +64,16 @@ default output object; other options include \code{df} (for data.frame) or
 \code{matrix}.}
 }
 \description{
-This is just a lighter version of \code{\link[=mrgsim]{mrgsim()}}, with fewer options.
-See \strong{Details}.
+This is just a lighter version of \code{\link[=mrgsim]{mrgsim()}}, with fewer options but with
+better efficiency in certain cases.  See \strong{Details}.
 }
 \details{
+\code{qsim()} mainly cuts some of the overhead from the simulation. So, the
+primary efficiency gain from using \code{qsim()} comes when the simulation
+executes very quickly. It is unlikely you will see a big performance
+difference between \code{qsim()} and \code{\link[=mrgsim]{mrgsim()}} when the model is difficult to
+solve or if there is a large input data set.
+
 There is no pipeline interface for this function; all configuration options
 (see \strong{Arguments}) must be passed as formal arguments to the function.
 You can't \code{carry_out}, \code{Request} specific columns, or pass items in for update.

--- a/man/qsim.Rd
+++ b/man/qsim.Rd
@@ -21,7 +21,7 @@ qsim(
 \arguments{
 \item{x}{the model object.}
 
-\item{data}{can be either event object or data set}
+\item{data}{can be either event object or data set.}
 
 \item{idata}{a matrix or data frame of model parameters,
 one parameter per row (see \code{\link[=idata_set]{idata_set()}}).}
@@ -52,26 +52,26 @@ always be true if the lag time doesn't change over time.  But it might
 \code{addl} sequence.  This known limitation shouldn't affect \code{tad} calculation
 in most common dosing lag time implementations.}
 
-\item{Req}{synonym for outvars}
+\item{Req}{synonym for \code{outvars}.}
 
 \item{outvars}{output items to request; if missing, then only captured items
-will be returned in the output}
+will be returned in the output.}
 
 \item{skip_init_calc}{don't use \verb{$MAIN} to calculate initial conditions.}
 
 \item{output}{output data type; the default is \code{mrgsims}, which returns the
 default output object; other options include \code{df} (for data.frame) or
-\code{matrix}}
+\code{matrix}.}
 }
 \description{
 This is just a lighter version of \code{\link[=mrgsim]{mrgsim()}}, with fewer options.
-See \code{Details}.
+See \strong{Details}.
 }
 \details{
 There is no pipeline interface for this function; all configuration options
-(see \code{Arguments}) must be passed as formal arguments to the function.
+(see \strong{Arguments}) must be passed as formal arguments to the function.
 You can't \code{carry_out}, \code{Request} specific columns, or pass items in for update.
-Some other limitations, but only convenience-related.  See \code{Arguments} for
+Some other limitations, but only convenience-related.  See \strong{Arguments} for
 available options.  Specifically, there is no \code{...} argument for this function.
 Use the \code{\link[=update]{update()}} method to update the model object.
 }

--- a/man/qsim.Rd
+++ b/man/qsim.Rd
@@ -19,12 +19,12 @@ qsim(
 )
 }
 \arguments{
-\item{x}{the model object}
+\item{x}{the model object.}
 
 \item{data}{can be either event object or data set}
 
 \item{idata}{a matrix or data frame of model parameters,
-one parameter per row (see \code{\link[=idata_set]{idata_set()}})}
+one parameter per row (see \code{\link[=idata_set]{idata_set()}}).}
 
 \item{obsonly}{if \code{TRUE}, dosing records are not included
 in the output.}

--- a/man/read_nmext.Rd
+++ b/man/read_nmext.Rd
@@ -14,13 +14,13 @@ read_nmext(
 )
 }
 \arguments{
-\item{run}{a run number or run identifier}
+\item{run}{a run number or run identifier.}
 
-\item{project}{the NONMEM project directory}
+\item{project}{the NONMEM project directory.}
 
-\item{file}{the \code{ext} file name}
+\item{file}{the \code{ext} file name.}
 
-\item{path}{full path and file name for \code{ext} file}
+\item{path}{full path and file name for \code{ext} file.}
 
 \item{read_fun}{function to read the \code{ext} file; \code{\link[data.table:fread]{data.table::fread()}} will
 be used if available; otherwise \code{\link[utils:read.table]{utils::read.table()}} is used.}
@@ -31,7 +31,7 @@ integer specifying the table number; in case there is exactly
 one table in the \code{.ext} file, pass the value "single" to bypass parsing
 the file to look for sub tables (this might be useful when BAYES analysis
 was performed as the only estimation method and there are 10000s of
-posterior samples in the file)}
+posterior samples in the file).}
 }
 \value{
 A list with param, omega, and sigma in a format ready to be used to

--- a/man/realize_addl.Rd
+++ b/man/realize_addl.Rd
@@ -19,7 +19,7 @@ realize_addl(x, ...)
 \method{realize_addl}{ev}(x, ...)
 }
 \arguments{
-\item{x}{a \code{data_set} data frame or an event object (see details).}
+\item{x}{a \code{data_set} data frame or an event object (see \strong{Details}).}
 
 \item{...}{not used.}
 

--- a/man/realize_addl.Rd
+++ b/man/realize_addl.Rd
@@ -33,7 +33,7 @@ in new data set records; this option is critical when handling
 data sets with time-varying, non-dose-related data items; see \strong{Details}.}
 }
 \value{
-A \code{data_set} data.frame or event object, consistent with the type of \code{x}.
+A data.frame or event object, consistent with the type of \code{x}.
 The \code{ii} and \code{addl} columns will all be set to zero. The result is always
 ungrouped.
 }

--- a/man/realize_addl.Rd
+++ b/man/realize_addl.Rd
@@ -19,18 +19,18 @@ realize_addl(x, ...)
 \method{realize_addl}{ev}(x, ...)
 }
 \arguments{
-\item{x}{a \code{data_set} data frame or an event object (see details)}
+\item{x}{a \code{data_set} data frame or an event object (see details).}
 
-\item{...}{not used}
+\item{...}{not used.}
 
 \item{warn}{if \code{TRUE} a warning is issued if no \code{ADDL} or
-\code{addl} column is found}
+\code{addl} column is found.}
 
-\item{mark_new}{if \code{TRUE}, a flag is added to indicate new columns}
+\item{mark_new}{if \code{TRUE}, a flag is added to indicate new columns.}
 
 \item{fill}{specifies how to handle non-dose related data columns
 in new data set records; this option is critical when handling
-data sets with time-varying, non-dose-related data items; see details}
+data sets with time-varying, non-dose-related data items; see \strong{Details}.}
 }
 \value{
 A \code{data_set} data.frame or event object, consistent with the type of \code{x}.
@@ -52,7 +52,7 @@ ungrouped.
 
 Use caution when passing in data that has non-dose-related data
 columns that vary within a subject and pay special attention
-to the \code{fill} argument. By definition, \code{realize_addl}
+to the \code{fill} argument. By definition, \code{realize_addl()}
 will add new rows to your data frame and it is not obvious
 how the non-dose-related data should be handled in these new
 rows.  When \code{inherit} is chosen, the new records have

--- a/man/revar.Rd
+++ b/man/revar.Rd
@@ -10,10 +10,19 @@ revar(x, ...)
 \S4method{revar}{mrgmod}(x, ...)
 }
 \arguments{
-\item{x}{model object}
+\item{x}{model object.}
 
-\item{...}{passed along}
+\item{...}{passed along.}
+}
+\value{
+A named list containing \code{omega} and \code{sigma} matrices.
 }
 \description{
-Get model random effect variances and covariances
+Use this function to extract both OMEGA and SIGMA matrices from a
+model object. Typical use is for display on the R console.
+}
+\examples{
+mod <- mrgsolve::house()
+revar(mod)
+
 }

--- a/man/see.Rd
+++ b/man/see.Rd
@@ -17,11 +17,11 @@ see(x, ...)
 \item{raw}{return the raw code.}
 }
 \value{
-`NULL` is returned invisibly when `raw` is `FALSE`; when `raw` is 
-set to `TRUE`, the model code is returned as a character vector.
+\code{NULL} is returned invisibly when \code{raw} is \code{FALSE}; when \code{raw} is
+set to \code{TRUE}, the model code is returned as a character vector.
 }
 \description{
-This is a simple way to display the model code on the R console using 
-the model object. The `raw` argument will return the model code as a 
+This is a simple way to display the model code on the R console using
+the model object. The \code{raw} argument will return the model code as a
 character vector.
 }

--- a/man/see.Rd
+++ b/man/see.Rd
@@ -10,15 +10,18 @@ see(x, ...)
 \S4method{see}{mrgmod}(x, raw = FALSE, ...)
 }
 \arguments{
-\item{x}{model object}
+\item{x}{model object.}
 
-\item{...}{passed along}
+\item{...}{not used.}
 
-\item{raw}{return the raw code}
+\item{raw}{return the raw code.}
 }
 \value{
-invisible NULL
+`NULL` is returned invisibly when `raw` is `FALSE`; when `raw` is 
+set to `TRUE`, the model code is returned as a character vector.
 }
 \description{
-Print model code to the console
+This is a simple way to display the model code on the R console using 
+the model object. The `raw` argument will return the model code as a 
+character vector.
 }

--- a/man/sigma.Rd
+++ b/man/sigma.Rd
@@ -30,23 +30,22 @@ smat(.x, ...)
 \S4method{smat}{mrgsims}(.x, make = FALSE, ...)
 }
 \arguments{
-\item{.x}{a matrix, list of matrices or \code{matlist} object}
+\item{.x}{a matrix, list of matrices or \code{matlist} object.}
 
-\item{...}{passed to other functions, including \code{\link{modMATRIX}}}
+\item{...}{passed to other functions, including \code{\link[=modMATRIX]{modMATRIX()}}.}
 
-\item{labels}{character vector of names for \code{$SIGMA} elements; must be
-equal 
-to number of rows/columns in the matrix}
+\item{labels}{character vector of names for \verb{$SIGMA} elements; must be
+equal to number of rows/columns in the matrix.}
 
-\item{make}{logical; if TRUE, matrix list is rendered into a single matrix}
+\item{make}{logical; if \code{TRUE}, matrix list is rendered into a single matrix.}
 
-\item{open}{passed to \code{\link{merge.list}}}
+\item{open}{passed to \code{\link[=merge.list]{merge.list()}}.}
 
-\item{x}{\code{matlist} object}
+\item{x}{\code{matlist} object.}
 }
 \description{
-The primary function is \code{smat} that can be used to both get the 
-\code{$SIGMA} matrices out of a model object and to update \code{$SIGMA} 
+The primary function is \code{smat()} which can be used to both get the
+\verb{$SIGMA} matrices out of a model object and to update \verb{$SIGMA}
 matrices in a model object.
 }
 \examples{
@@ -64,4 +63,8 @@ mod <- mrgsolve::house() \%>\% smat(mat1)
 
 smat(mod)
 smat(mod, make=TRUE)
+
+}
+\seealso{
+\code{\link[=dmat]{dmat()}}, \code{\link[=bmat]{bmat()}}, \code{\link[=cmat]{cmat()}}
 }

--- a/man/simargs.Rd
+++ b/man/simargs.Rd
@@ -2,19 +2,19 @@
 % Please edit documentation in R/utils.R
 \name{simargs}
 \alias{simargs}
-\title{Access or clear arguments for calls to mrgsim}
+\title{Access or clear arguments for calls to mrgsim()}
 \usage{
 simargs(x, which = NULL, clear = FALSE, ...)
 }
 \arguments{
-\item{x}{model object}
+\item{x}{model object.}
 
-\item{which}{character with length 1 naming a single arg to get}
+\item{which}{character with length 1 naming a single arg to get.}
 
 \item{clear}{logical indicating whether or not to clear \code{args} from
-the model object}
+the model object.}
 
-\item{...}{passed along}
+\item{...}{not used.}
 }
 \value{
 If \code{clear} is \code{TRUE}, the argument list is
@@ -23,7 +23,7 @@ list is returned.
 }
 \description{
 As a model object navigates a pipeline prior to simulation, arguments are
-collected to eventually be passed to \code{\link[=mrgsim]{mrgsim()}}. \code{simargs} lets you
+collected to eventually be passed to \code{\link[=mrgsim]{mrgsim()}}. \code{simargs()} lets you
 intercept and possibly clear those arguments.
 }
 \examples{

--- a/man/soloc.Rd
+++ b/man/soloc.Rd
@@ -7,10 +7,10 @@
 soloc(x, short = FALSE)
 }
 \arguments{
-\item{x}{model object}
+\item{x}{model object.}
 
-\item{short}{logical; if \code{TRUE}, \code{soloc}s will
-be rendered  with a short path name}
+\item{short}{logical; if \code{TRUE}, \code{soloc}s will be rendered  with a short
+path name.}
 }
 \value{
 A string containing the full path to the model shared object.

--- a/man/stime.Rd
+++ b/man/stime.Rd
@@ -10,31 +10,32 @@
 stime(x, ...)
 }
 \arguments{
-\item{x}{object of class mrgmod}
+\item{x}{a model object or a mrgsims object.}
 
-\item{...}{passed on}
+\item{...}{not used.}
 }
 \value{
-a sorted vector of unique times
+A sorted vector of unique simulation times from the time grid in
+the model object.
 }
 \description{
 Get the times at which the model will be evaluated
 }
 \details{
-Simulation times include the sequence of times created from 
-\code{start}, \code{end}, and \code{delta} and the vector of times
-found in \code{add}.  Making \code{end} negative will omit any 
-\code{start} / \code{end} / \code{delta} sequence.  Negative values 
-are discarded from the result.
+Simulation times include the sequence of times created from
+\code{start}, \code{end}, and \code{delta} and the vector of times found in \code{add}.
+
+Making \code{end} negative (e.g. -1) will omit the \code{start-end-delta}
+sequence.  Negative values are discarded from the result.
 }
 \examples{
-
 ## example("stime", package="mrgsolve")
 
-mod <- mrgsolve::house(end=12, delta=2, add=c(11,13,15))
+mod <- mrgsolve::house(end = 12, delta = 2, add = c(11,13,15))
 
 stime(mod)
 
+update(mod, end = -1) \%>\% stime()
 
 }
 \keyword{internal}

--- a/man/tgrid.Rd
+++ b/man/tgrid.Rd
@@ -33,34 +33,33 @@ tgrid(
 \S4method{stime}{mrgmod}(x, ...)
 }
 \arguments{
-\item{start}{simulation start time}
+\item{start}{simulation start time.}
 
-\item{end}{simulation end time}
+\item{end}{simulation end time.}
 
-\item{delta}{simulation time step}
+\item{delta}{simulation time step.}
 
-\item{add}{addition simulation times}
+\item{add}{addition simulation times.}
 
-\item{.offset}{the resulting set of times will be adjusted by this amount}
+\item{.offset}{the resulting set of times will be adjusted by this amount.}
 
-\item{.scale}{the resulting set of times will be scaled by this factor}
+\item{.scale}{the resulting set of times will be scaled by this factor.}
 
-\item{...}{passed on to other methods}
+\item{...}{not used.}
 
-\item{x}{tgrid object}
+\item{x}{tgrid object.}
 
 \item{object}{passed to show}
 }
 \description{
-simtime objects allow the user to specify simulation start and end times, 
+simtime objects allow the user to specify simulation start and end times,
 along with the simulation time step.
 }
 \examples{
+peak <- tgrid(0, 6, 0.2)
+sparse <- tgrid(0, 24, 4)
 
-peak <- tgrid(0,6,0.2)
-sparse <- tgrid(0,24,4)
-
-day1 <- c(peak,sparse)
+day1 <- c(peak, sparse)
 
 design <- c(day1, day1+72, day1+240)
 
@@ -69,7 +68,7 @@ mod <- mrgsolve::house()
 
 out <- mod \%>\% ev(amt=1000, ii=24, addl=10) \%>\% mrgsim(tgrid=design)
 
-plot(out,CP~., type='b')
+plot(out, CP ~ time, type = 'b')
 }
 }
 \keyword{internal}

--- a/man/tgrid_ops.Rd
+++ b/man/tgrid_ops.Rd
@@ -27,11 +27,11 @@
 \S4method{*}{tgrids,numeric}(e1, e2)
 }
 \arguments{
-\item{x}{mrgmod object}
+\item{x}{a tgrid object.}
 
-\item{...}{passed along to other methods}
+\item{...}{additional tgrid objects.}
 
-\item{recursive}{not used}
+\item{recursive}{not used.}
 
 \item{e1}{tgrid or tgrids object}
 

--- a/man/tscale.Rd
+++ b/man/tscale.Rd
@@ -7,18 +7,18 @@
 tscale(x, value = 1, ...)
 }
 \arguments{
-\item{x}{model object}
+\item{x}{model object.}
 
-\item{value}{value by which time will be scaled}
+\item{value}{value by which time will be scaled.}
 
-\item{...}{passed along}
+\item{...}{not used.}
 }
 \description{
 Re-scale time in the simulated output
 }
 \details{
-There is also a \code{tscale} argument to \code{\link{mrgsim}} that can 
-be set to accomplish the same thing as a call to \code{tscale} in 
+There is also a \code{tscale} argument to \code{\link[=mrgsim]{mrgsim()}} that can
+be set to accomplish the same thing as a call to \code{tscale} in
 the pipeline.
 }
 \examples{
@@ -26,6 +26,6 @@ the pipeline.
 mod <- mrgsolve::house()
 
 # The output is in days:
-mod \%>\% tscale(1/24) \%>\% mrgsim
+mod \%>\% tscale(1/24) \%>\% mrgsim()
 
 }

--- a/man/zero_re.Rd
+++ b/man/zero_re.Rd
@@ -10,19 +10,18 @@ zero_re(.x, ...)
 \S4method{zero_re}{mrgmod}(.x, ...)
 }
 \arguments{
-\item{.x}{a model object}
+\item{.x}{a model object.}
 
 \item{...}{which matrix to zero out; pass \code{omega} to just zero out \code{omega},
-\code{sigma} to just zero out \code{sigma}; passing nothing will zero out both}
+\code{sigma} to just zero out \code{sigma}; passing nothing will zero out both.}
 }
 \value{
-An updated object with elements of OMEGA and / or SIGMA set to zero..
+An updated object with elements of OMEGA and/or SIGMA set to zero.
 }
 \description{
-Sets all elements of the OMEGA or SIGMA matrix to zero
+Sets all elements of the OMEGA or SIGMA matrix to zero.
 }
 \examples{
-
 mod <- house()
 revar(mod)
 mod <- zero_re(mod)


### PR DESCRIPTION
Reformatting all documentation.

- argument descriptions start with lower case and end with period.
- switch to `@md` where we make changes to the other parts of the help topic
- change `##'` to `#'`
- Add examples and return values where we can
- Definitely some files I left alone


Latest pkgdown site:[DOCS.zip](https://github.com/user-attachments/files/17337395/DOCS.zip) Might aid review. 
