### PR TITLE
Fix url in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,7 @@ Description: Fast simulation from ordinary differential equation
     (ODE) based models typically employed in quantitative pharmacology and
     systems biology.
 License: GPL (>=2)
-URL: https://mrgsolve.org/docs/, https://github.com/metrumresearchgroup/mrgsolve/
+URL: https://mrgsolve.org/docs/, https://github.com/metrumresearchgroup/mrgsolve
 BugReports: 
     https://github.com/metrumresearchgroup/mrgsolve/issues
 Depends:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,7 @@ Description: Fast simulation from ordinary differential equation
     (ODE) based models typically employed in quantitative pharmacology and
     systems biology.
 License: GPL (>=2)
-URL: https://mrgsolve.org/docs, https://github.com/metrumresearchgroup/mrgsolve
+URL: https://mrgsolve.org/docs/, https://github.com/metrumresearchgroup/mrgsolve/
 BugReports: 
     https://github.com/metrumresearchgroup/mrgsolve/issues
 Depends:

--- a/man/mrgsolve_package.Rd
+++ b/man/mrgsolve_package.Rd
@@ -122,7 +122,7 @@ x <- mod \%>\% ev(amt=300, ii=12, addl=3) \%>\% mrgsim
 Useful links:
 \itemize{
   \item \url{https://mrgsolve.org/docs/}
-  \item \url{https://github.com/metrumresearchgroup/mrgsolve/}
+  \item \url{https://github.com/metrumresearchgroup/mrgsolve}
   \item Report bugs at \url{https://github.com/metrumresearchgroup/mrgsolve/issues}
 }
 

--- a/man/mrgsolve_package.Rd
+++ b/man/mrgsolve_package.Rd
@@ -121,8 +121,8 @@ x <- mod \%>\% ev(amt=300, ii=12, addl=3) \%>\% mrgsim
 \seealso{
 Useful links:
 \itemize{
-  \item \url{https://mrgsolve.org/docs}
-  \item \url{https://github.com/metrumresearchgroup/mrgsolve}
+  \item \url{https://mrgsolve.org/docs/}
+  \item \url{https://github.com/metrumresearchgroup/mrgsolve/}
   \item Report bugs at \url{https://github.com/metrumresearchgroup/mrgsolve/issues}
 }
 


### PR DESCRIPTION
Found this with `R CMD check --as-cran`

```
Found the following (possibly) invalid URLs:
  URL: https://mrgsolve.org/docs (moved to https://mrgsolve.org/docs/)
    From: DESCRIPTION
          man/mrgsolve_package.Rd
    Status: 301
    Message: Moved Permanently
For content that is 'Moved Permanently', please change http to https,
add trailing slashes, or replace the old by the new URL.
```