### PR TITLE
Correctly handle EVID4 doses at steady state with lag time

### DIFF
--- a/inst/maintenance/unit/test-alag.R
+++ b/inst/maintenance/unit/test-alag.R
@@ -1,4 +1,4 @@
-# Copyright (C) 2013 - 2019  Metrum Research Group
+# Copyright (C) 2013 - 2025  Metrum Research Group
 #
 # This file is part of mrgsolve.
 #
@@ -96,4 +96,22 @@ test_that("ss dose with lag time issue-484", {
   out1 <- mrgsim_d(mod,data1) %>% slice(-c(1,2))
   out2 <- mrgsim_d(mod,data2) %>% slice(-c(1,2))
   expect_identical(out1,out2)
+})
+
+test_that("EVID 1 or 4 at SS with lag time are identical", {
+  ev1 <- ev(amt = 100, ii = 24, ss = 1, LAG = 10)
+  ev4 <- mutate(ev1, evid = 4)
+  
+  out1 <- mrgsim_e(mod, ev1, recsort = 3, output = "df")
+  out4 <- mrgsim_e(mod, ev4, recsort = 3, output = "df")
+  
+  expect_identical(out1, out4)
+  
+  ev1a <- mutate(ev1, addl = 3, LAG = 5)
+  ev4a <- mutate(ev4, addl = 3, LAG = 5)
+  
+  out1a <- mrgsim_e(mod, ev1a, recsort = 3, output = "df")
+  out4a <- mrgsim_e(mod, ev4a, recsort = 3, output = "df")
+  
+  expect_identical(out1a, out4a)
 })

--- a/mrgsolve.Rproj
+++ b/mrgsolve.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 0063b92e-a050-4fd7-986e-be62f57eb1b1
 
 RestoreWorkspace: Default
 SaveWorkspace: Default

--- a/src/datarecord.cpp
+++ b/src/datarecord.cpp
@@ -191,7 +191,8 @@ void datarecord::implement(odeproblem* prob) {
   case 8: // replace
     prob->y(eq_n, Amt);
     break;
-  case 4:
+  case 4: // dose and reset; reset only if non-ss
+    if(!Armed) break;
     if(this->ss()==0) {
       for(int i=0; i < prob->neq(); ++i) {
         prob->y(i,0.0);
@@ -200,7 +201,6 @@ void datarecord::implement(odeproblem* prob) {
       }
       prob->init_call(Time);
     }
-    if(!Armed) break;
     if(Rate > 0) {
       this->evid(5);
     } else {

--- a/src/devtran.cpp
+++ b/src/devtran.cpp
@@ -548,19 +548,21 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
         // Checking 
         if(!this_rec->is_lagged()) {
           
-          if(prob.alag(this_cmtn) > mindt && this_rec->is_dose()) { // there is a valid lagtime
-            
+          // there is a valid lag time
+          if(prob.alag(this_cmtn) > mindt && this_rec->is_dose()) {
             if(this_rec->ss() > 0) {
               this_rec->steady(&prob, a[i], solver);
               tfrom = tto;
-              this_rec->ss(0);
             }
+            this_rec->ss(0);
             rec_ptr newev = NEWREC(*this_rec);
+            if(newev->evid()==4) {
+              newev->evid(1);
+            }
             newev->pos(__ALAG_POS);
             newev->phantom_rec();
             newev->lagged();
             newev->time(this_rec->time() + prob.alag(this_cmtn));
-            newev->ss(0);
             insert_record(a[i], j, newev, put_ev_first);
             newev->schedule(a[i], maxtime, put_ev_first, NN, prob.alag(this_cmtn));
             this_rec->unarm();

--- a/src/devtran.cpp
+++ b/src/devtran.cpp
@@ -554,6 +554,8 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
               this_rec->steady(&prob, a[i], solver);
               tfrom = tto;
             }
+            // We already advanced to ss
+            // Lagged dose and all subsequent should be vanilla EVID=1 doses
             this_rec->ss(0);
             rec_ptr newev = NEWREC(*this_rec);
             if(newev->evid()==4) {


### PR DESCRIPTION
`EVID===4` resets the system and then doses. `SS==1` advances the system to steady-state and then doses.  The current behavior is that `EVID 4` records at steady state act just like `EVID 1` records at steady state; this was confirmed by testing against NONMEMs behavior. 

It was noted in #1261 that, when there is also a lag time for the dose, mrgsolve was dosing as immediately after reset rather than immediately after advancing to steady state.  This PR fixes that behavior. 

Some terminology / background

- A dose that is not `Armed` means there appears to be a dose at that time, but nothing is actually dosed; this is in place at the time of the apparent dose
- When there is a lagged dose, we disarm the apparent dosing record, then schedule a dose or series of doses at the lag time; these are "phantom" records that actually implement a dose some time after the apparent dose


1. In the dose `implement` method, if the record is not `Armed`, we just break out; there is nothing to reset and we don't want to go on and dose after that reset
2. In the main simulation code, lagged doses all lose the ss flag and they are all converted in to evid 1, to act like vanilla dosing records

Confirming that we now match up with NONMEM here:
https://github.com/mrgsolve/nmtests/blob/master/dosing/dosing-vignette.md#23-reset-and-dose-evid-4-with-ss1-and-lag

And the mis-match prior to fixing here:
https://github.com/mrgsolve/nmtests/commit/fc464d8b8af023faff23a9359e773ee29ae3ec51#diff-f9292bfdbc09d870158ed0c0760957e19c4161d00f623e1c4b143ba83503a400


Also, there is a unit test showing that steady state doses with a lag time are identical whether EVID is 1 or 4. 

We should consider if that `implement` method should exit immediately for _any_ unarmed event; maybe after we set `itask`.  See #1267 

