### PR TITLE
regimen object starts at time when created; adjust next dose time

### DIFF
--- a/inst/base/mrgsolve-evtools-regimen.h
+++ b/inst/base/mrgsolve-evtools-regimen.h
@@ -17,6 +17,8 @@ public:
   double ii() {return Ii;}
   void   rate(double rate_);
   double rate() {return Rate;}
+  double time_next() {return dose_time;}
+  void   time_next(double time_);
   void   until(double until_);
   double until() {return Until;}
   void   flagnext();
@@ -41,12 +43,13 @@ void regimen::reset() {
   Rate = 0.0;
   Ii = 1.0e9;
   Until = 1.0e9;
-  dose_time = 0.0;
+  dose_time = Self ? Self->time : 0.0;
   prev_dose_time = -1.0e9;
   Flagnext = false;
 }
 
 regimen::regimen() {
+  initialized = false;
   reset();
 }
 
@@ -73,6 +76,11 @@ void regimen::cmt(int cmt_) {
 
 void regimen::ii(double ii_) {
   Ii = ii_;
+  return;
+}
+
+void regimen::time_next(double time_) {
+  dose_time = time_;
   return;
 }
 

--- a/inst/base/mrgsolve-evtools-regimen.h
+++ b/inst/base/mrgsolve-evtools-regimen.h
@@ -33,7 +33,6 @@ private:
   double Amt; 
   double Rate;
   double Until;
-  bool initialized;
   databox* Self;
 };
 
@@ -49,13 +48,11 @@ void regimen::reset() {
 }
 
 regimen::regimen() {
-  initialized = false;
   reset();
 }
 
 void regimen::init(databox& self_) {
   Self = &self_;
-  initialized = true;
   reset();
 }
 
@@ -90,7 +87,7 @@ void regimen::until(double until_) {
 }
 
 void regimen::execute() {
-  if(!initialized) return;
+  if(!Self) return;
   if(!evt::near(Self->time, dose_time)) return;
   if(Self->time >= Until) return;
   evt::infuse(*Self, Amt, Cmt, Rate);

--- a/mrgsolve.Rproj
+++ b/mrgsolve.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: d47f7e1a-4457-48ae-a7e3-05ec7dd8c9c4
 
 RestoreWorkspace: Default
 SaveWorkspace: Default


### PR DESCRIPTION
When I created these `regimen` objects to implement a self-running dosing regimen, it was inadvertently set up to always start at `TIME==0`. While this makes sense in a lot of cases, there is no reason to expect this is so. 

The PR updates the regimen object in the following ways

1. The time of the first dose defaults to the `TIME` at which the object is created
2. Two methods are added, called `time_next()`; one sets and one gets the time of the next dose
3. As a part of implementing this change, I realized that `Self` is a null pointer until we call the `init()` method which accepts  `self` as an argument and stores it. Because of this, we can tell if the object has been initialized by testing `Self`, allowing us to drop the `initialized` member which doesn't give us any additional information. To be specific, I had to rely on this check of `Self` in order to implement the new default time so it made sense to go ahead and rely on that throughout to test for initialization. Also note that you wouldn't ordinarily work with the object this way (test for initialization; but we have to in this case b/c we are working within the confines of R and (specifically) the collection of functions that make up the model code. 


From 1 and 2 above: this PR lets you either initialize the `regimen` object at the start of an individual and then re-time for later  _or_ initialize the object right at the time you want to start dosing. 