### PR TITLE
Validate names supplied to $SET

### DIFF
--- a/R/Aaaa.R
+++ b/R/Aaaa.R
@@ -79,7 +79,7 @@ GLOBALS$SET_ARGS <- c("Req", "obsonly", "recsort", "carry.out", "Trequest",
 )
 GLOBALS$UPDATE_SINGLE <- c(
   "atol", "rtol", "ss_rtol", "ss_atol", "verbose", "debug", "preclean", "mindt",
-  "digits", "ixpr", "mxhnil", "start", "end", "add", "delta", "maxsteps"
+  "digits", "ixpr", "mxhnil", "start", "end", "add", "delta", "maxsteps",
   "hmin", "hmax", "tscale", "request"
  )
 GLOBALS$UPDATE_OTHER <- c("param", "init", "omega", "sigma", "outvars")

--- a/R/Aaaa.R
+++ b/R/Aaaa.R
@@ -77,6 +77,11 @@ GLOBALS$TRAN_FILL_NA <- c(
 GLOBALS$SET_ARGS <- c("Req", "obsonly", "recsort", "carry.out", "Trequest", 
  "trequest", "carry_out", "Request"
 )
+GLOBALS$UPDATE_SINGLE <- c("atol","rtol","ss_rtol", "ss_atol", "verbose",
+"debug","preclean","mindt", "digits", "ixpr", "mxhnil","start", "end", "add",
+ "delta", "maxsteps", "hmin", "hmax","tscale", "request")
+GLOBALS$UPDATE_OTHER <- c("param", "init", "omega", "sigma", "outvars")
+GLOBALS$ALL_UPDATABLE <- c(GLOBALS$UPDATE_SINGLE, GLOBALS$UPDATE_OTHER)
 GLOBALS[["version"]] <- utils::packageVersion("mrgsolve")
 
 block_list <- c("ENV", "PROB", "PARAM", "INIT",

--- a/R/Aaaa.R
+++ b/R/Aaaa.R
@@ -72,11 +72,6 @@ GLOBALS$TRAN_FILL_NA <- c(
   "AMT", "CMT", "EVID", "II", "ADDL", "RATE", "SS", 
   "amt", "cmt", "evid", "ii", "addl", "rate", "ss"
 )
-# Arguments to mrgsim that can be stated in $SET and then 
-# passed to mrgsim
-GLOBALS$SET_ARGS <- c("Req", "obsonly", "recsort", "carry.out", "Trequest", 
- "trequest", "carry_out", "Request"
-)
 GLOBALS$UPDATE_SINGLE <- c(
   "atol", "rtol", "ss_rtol", "ss_atol", "verbose", "debug", "preclean", "mindt",
   "digits", "ixpr", "mxhnil", "start", "end", "add", "delta", "maxsteps",
@@ -86,6 +81,11 @@ GLOBALS$UPDATE_OTHER <- c("param", "init", "omega", "sigma", "outvars")
 GLOBALS$UPDATE_ALL <- c(GLOBALS$UPDATE_SINGLE, GLOBALS$UPDATE_OTHER)
 GLOBALS$SET_EXTRA <- c(
   "collapse_omega", "collapse_sigma", "ss_cmt", "clink", "fixed_type"
+)
+# Arguments to mrgsim that can be stated in $SET and then 
+# passed to mrgsim
+GLOBALS$SET_ARGS <- c("Req", "obsonly", "recsort", "carry.out", "Trequest", 
+ "trequest", "carry_out", "Request"
 )
 GLOBALS[["version"]] <- utils::packageVersion("mrgsolve")
 

--- a/R/Aaaa.R
+++ b/R/Aaaa.R
@@ -72,6 +72,11 @@ GLOBALS$TRAN_FILL_NA <- c(
   "AMT", "CMT", "EVID", "II", "ADDL", "RATE", "SS", 
   "amt", "cmt", "evid", "ii", "addl", "rate", "ss"
 )
+# Arguments to mrgsim that can be stated in $SET and then 
+# passed to mrgsim
+GLOBALS$SET_ARGS <- c("Req", "obsonly", "recsort", "carry.out", "Trequest", 
+ "trequest", "carry_out", "Request"
+)
 GLOBALS[["version"]] <- utils::packageVersion("mrgsolve")
 
 block_list <- c("ENV", "PROB", "PARAM", "INIT",

--- a/R/Aaaa.R
+++ b/R/Aaaa.R
@@ -77,11 +77,16 @@ GLOBALS$TRAN_FILL_NA <- c(
 GLOBALS$SET_ARGS <- c("Req", "obsonly", "recsort", "carry.out", "Trequest", 
  "trequest", "carry_out", "Request"
 )
-GLOBALS$UPDATE_SINGLE <- c("atol","rtol","ss_rtol", "ss_atol", "verbose",
-"debug","preclean","mindt", "digits", "ixpr", "mxhnil","start", "end", "add",
- "delta", "maxsteps", "hmin", "hmax","tscale", "request")
+GLOBALS$UPDATE_SINGLE <- c(
+  "atol", "rtol", "ss_rtol", "ss_atol", "verbose", "debug", "preclean", "mindt",
+  "digits", "ixpr", "mxhnil", "start", "end", "add", "delta", "maxsteps"
+  "hmin", "hmax", "tscale", "request"
+ )
 GLOBALS$UPDATE_OTHER <- c("param", "init", "omega", "sigma", "outvars")
-GLOBALS$ALL_UPDATABLE <- c(GLOBALS$UPDATE_SINGLE, GLOBALS$UPDATE_OTHER)
+GLOBALS$UPDATE_ALL <- c(GLOBALS$UPDATE_SINGLE, GLOBALS$UPDATE_OTHER)
+GLOBALS$SET_EXTRA <- c(
+  "collapse_omega", "collapse_sigma", "ss_cmt", "clink", "fixed_type"
+)
 GLOBALS[["version"]] <- utils::packageVersion("mrgsolve")
 
 block_list <- c("ENV", "PROB", "PARAM", "INIT",

--- a/R/compile.R
+++ b/R/compile.R
@@ -25,7 +25,6 @@ generate_rdefs <- function(pars,
                            model = "",
                            omats,
                            smats,
-                           set = list(), 
                            plugin = NULL,
                            dbsyms = FALSE, ...) {
 
@@ -73,7 +72,7 @@ generate_rdefs <- function(pars,
 
     Fdef <- Adef <- Ddef <- Rdef <- cmtndef <- NULL
 
-    cmtn <- unique(intersect(cvec_cs(set$CMTN),cmt))
+    cmtn <- unique(intersect(cvec_cs(cmtn,cmt))
     
     # Handle plugins; note plugin[["nm-defs"]] are punched in below     
     if(!is.null(plugin[["N_CMT"]])) cmtn <- cmt  

--- a/R/compile.R
+++ b/R/compile.R
@@ -25,6 +25,7 @@ generate_rdefs <- function(pars,
                            model = "",
                            omats,
                            smats,
+                           cmtn = NULL, 
                            plugin = NULL,
                            dbsyms = FALSE, ...) {
 
@@ -72,7 +73,7 @@ generate_rdefs <- function(pars,
 
     Fdef <- Adef <- Ddef <- Rdef <- cmtndef <- NULL
 
-    cmtn <- unique(intersect(cvec_cs(cmtn,cmt))
+    cmtn <- unique(intersect(cvec_cs(cmtn),cmt))
     
     # Handle plugins; note plugin[["nm-defs"]] are punched in below     
     if(!is.null(plugin[["N_CMT"]])) cmtn <- cmt  

--- a/R/handle_spec_block.R
+++ b/R/handle_spec_block.R
@@ -994,7 +994,7 @@ handle_SET <- function(spec) {
   ans <- tolist(dump_opts(spec[["SET"]]))
   valid <- c(GLOBALS$UPDATE_ALL, GLOBALS$SET_EXTRA, GLOBALS$SET_ARGS)
   incoming <- charmatch(names(ans), valid)
-  bad <- which(is.na(incoming))
+  bad <- which(is.na(incoming) | incoming == 0)
   if(!length(bad)) {
     return(ans)  
   }

--- a/R/handle_spec_block.R
+++ b/R/handle_spec_block.R
@@ -993,15 +993,17 @@ BLOCK <- function(x, env, type, code = NULL, get = NULL, ...) {
 handle_SET <- function(spec) {
   ans <- tolist(dump_opts(spec[["SET"]]))
   valid <- c(GLOBALS$UPDATE_ALL, GLOBALS$SET_EXTRA, GLOBALS$SET_ARGS)
-  bad <- setdiff(names(ans), valid)
-  if(length(bad)) {
-    if(length(bad) > 1) { 
-      msg <- "The $SET block cannot handle these items:"
-    } else {
-      msg <- "The $SET block cannot handle this item"
-    }
-    names(bad) <- rep("x", length(bad))
-    abort(msg, body = bad, call = caller_env())
+  incoming <- charmatch(names(ans), valid)
+  bad <- which(is.na(incoming))
+  if(!length(bad)) {
+    return(ans)  
   }
-  ans
+  if(length(bad) > 1) { 
+    msg <- "The $SET block cannot handle these items:"
+  } else {
+    msg <- "The $SET block cannot handle this item"
+  }
+  bad <- names(ans)[bad]
+  names(bad) <- rep("x", length(bad))
+  abort(msg, body = bad, call = caller_env())
 }

--- a/R/handle_spec_block.R
+++ b/R/handle_spec_block.R
@@ -1001,7 +1001,7 @@ handle_SET <- function(spec) {
   if(length(bad) > 1) { 
     msg <- "The $SET block cannot handle these items:"
   } else {
-    msg <- "The $SET block cannot handle this item"
+    msg <- "The $SET block cannot handle this item:"
   }
   bad <- names(ans)[bad]
   names(bad) <- rep("x", length(bad))

--- a/R/handle_spec_block.R
+++ b/R/handle_spec_block.R
@@ -989,3 +989,19 @@ BLOCK <- function(x, env, type, code = NULL, get = NULL, ...) {
   x <- structure(.Data=code, class=paste0("spec",type),pos=1)
   handle_spec_block(x,env)
 }
+
+handle_SET <- function(spec) {
+  ans <- tolist(dump_opts(spec[["SET"]]))
+  valid <- c(GLOBALS$UPDATE_ALL, GLOBALS$SET_EXTRA, GLOBALS$SET_ARGS)
+  bad <- setdiff(names(ans), valid)
+  if(length(bad)) {
+    if(length(bad) > 1) { 
+      msg <- "The $SET block cannot handle these items:"
+    } else {
+      msg <- "The $SET block cannot handle this item"
+    }
+    names(bad) <- rep("x", length(bad))
+    abort(msg, body = bad, call = caller_env())
+  }
+  ans
+}

--- a/R/modspec.R
+++ b/R/modspec.R
@@ -99,16 +99,8 @@ capture_etas <- function(x, env) {
   x
 }
 
-## These are arguments to mrgsim that
-## can be stated in $SET and then passed to mrgsim
-set_args <- c(
-  "Req", "obsonly", "recsort",
-  "carry.out","Trequest","trequest", 
-  "carry_out", "Request"
-)
-
 set_simargs <- function(x, SET) {
-  simargs <- SET[is.element(names(SET), set_args)]
+  simargs <- SET[is.element(names(SET), GLOBALS$SET_ARGS)]
   if(length(simargs) > 0) {
     x@args <- combine_list(x@args, simargs)
   }   

--- a/R/mread.R
+++ b/R/mread.R
@@ -200,7 +200,7 @@ mread <- function(model, project = getOption("mrgsolve.project", getwd()),
   
   ## Pull out the settings and ENV now
   ## We might be passing parse settings in here ...
-  SET <- tolist(dump_opts(spec[["SET"]]))
+  SET <- handle_SET(spec)
   ENV <- eval_ENV_block(spec[["ENV"]],build[["project"]])
   if("SET" %in% names(spec)) spec[["SET"]] <- ""
   if("ENV" %in% names(spec)) spec[["ENV"]] <- ""

--- a/R/mread.R
+++ b/R/mread.R
@@ -289,11 +289,6 @@ mread <- function(model, project = getOption("mrgsolve.project", getwd()),
   mread.env[["audit_dadt"]] <- 
     isTRUE(audit) && isTRUE(mread.env[["audit_dadt"]])
   
-  # Look for compartments we're dosing into: F/ALAG/D/R
-  # and add them to CMTN
-  dosing <- dosing_cmts(spec[["MAIN"]], names(init))
-  SET[["CMTN"]] <- c(spec[["CMTN"]], dosing)
-  
   # new model object ----
   x <- new(
     "mrgmod",
@@ -329,6 +324,10 @@ mread <- function(model, project = getOption("mrgsolve.project", getwd()),
   
   # Modify SS compartments
   x <- set_ss_cmt(x, SET[["ss_cmt"]])
+
+  # Look for compartments we're dosing into: F/ALAG/D/R and add them to CMTN
+  dosing <- dosing_cmts(spec[["MAIN"]], names(init))
+  CMTN <- c(spec[["CMTN"]], dosing)
   
   # model r defs ----
   # These are the various #define statements
@@ -344,7 +343,7 @@ mread <- function(model, project = getOption("mrgsolve.project", getwd()),
     model = model(x),
     omats = omat(x),
     smats = smat(x),
-    set = SET,
+    cmtn = CMTN,
     check.bounds = check.bounds, 
     plugin = plugin,
     dbsyms = args[["dbsyms"]]

--- a/R/update.R
+++ b/R/update.R
@@ -98,7 +98,7 @@ setMethod("update", "mrgmod", function(object, ..., merge=TRUE, open=FALSE,
   
   a <- names(args)
   
-  m <- charmatch(a, all_updatable)
+  m <- charmatch(a, GLOBALS$UPDATE_ALL)
   
   if(anyNA(m) && isTRUE(strict)) {
     if(!is.null(getOption("mrgsolve.update.strict"))) {
@@ -123,9 +123,9 @@ setMethod("update", "mrgmod", function(object, ..., merge=TRUE, open=FALSE,
   }
   
   valid <- !is.na(m)
-  a[valid] <- all_updatable[m[valid]]
+  a[valid] <- GLOBALS$UPDATE_ALL[m[valid]]
   names(args) <- a
-  valid.in <- which(a %in% GLOBALS$SINGLE_UPDATE)
+  valid.in <- which(a %in% GLOBALS$UPDATE_SINGLE)
   if(length(valid.in) > 0) {
     for(i in seq_along(valid.in)) {
       slot(object, a[valid.in[i]]) <- args[[a[valid.in[i]]]]

--- a/R/update.R
+++ b/R/update.R
@@ -85,7 +85,7 @@ setMethod("update", "mrgmod", function(object, ..., merge=TRUE, open=FALSE,
   # TODO: get rid of the merge argument to `update()`
   # TODO: get rid of the open argument to `update()`
   # TODO: longer term ... error when bad arguments are passed
-  browser()
+
   args <- list(...)
   
   if(!is.null(data)) {

--- a/R/update.R
+++ b/R/update.R
@@ -17,15 +17,6 @@
 
 setAs("NULL", "character", function(from) character(0))
 
-sval <- unique(c("atol","rtol","ss_rtol", "ss_atol",
-                 "verbose","debug","preclean","mindt",
-                 "digits", "ixpr", "mxhnil","start", "end", "add", "delta",
-                 "maxsteps", "hmin", "hmax","tscale", "request"))
-
-other_val <- c("param", "init", "omega", "sigma", "outvars")
-
-all_updatable <- c(sval,other_val)
-
 #' Update the model object
 #'
 #' After the model object is created, update various attributes.
@@ -94,7 +85,7 @@ setMethod("update", "mrgmod", function(object, ..., merge=TRUE, open=FALSE,
   # TODO: get rid of the merge argument to `update()`
   # TODO: get rid of the open argument to `update()`
   # TODO: longer term ... error when bad arguments are passed
-
+  browser()
   args <- list(...)
   
   if(!is.null(data)) {
@@ -134,7 +125,7 @@ setMethod("update", "mrgmod", function(object, ..., merge=TRUE, open=FALSE,
   valid <- !is.na(m)
   a[valid] <- all_updatable[m[valid]]
   names(args) <- a
-  valid.in <- which(a %in% sval)
+  valid.in <- which(a %in% GLOBALS$SINGLE_UPDATE)
   if(length(valid.in) > 0) {
     for(i in seq_along(valid.in)) {
       slot(object, a[valid.in[i]]) <- args[[a[valid.in[i]]]]

--- a/R/update.R
+++ b/R/update.R
@@ -85,7 +85,7 @@ setMethod("update", "mrgmod", function(object, ..., merge=TRUE, open=FALSE,
   # TODO: get rid of the merge argument to `update()`
   # TODO: get rid of the open argument to `update()`
   # TODO: longer term ... error when bad arguments are passed
-
+  
   args <- list(...)
   
   if(!is.null(data)) {

--- a/R/update.R
+++ b/R/update.R
@@ -122,7 +122,7 @@ setMethod("update", "mrgmod", function(object, ..., merge=TRUE, open=FALSE,
     warn(msg, call = NULL)
   }
   
-  valid <- !is.na(m)
+  valid <- !is.na(m) & m != 0
   a[valid] <- GLOBALS$UPDATE_ALL[m[valid]]
   names(args) <- a
   valid.in <- which(a %in% GLOBALS$UPDATE_SINGLE)

--- a/mrgsolve.Rproj
+++ b/mrgsolve.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: e9d097b0-d89c-4ef9-8bef-4afbd1908e9e
 
 RestoreWorkspace: Default
 SaveWorkspace: Default

--- a/tests/testthat/test-modspec.R
+++ b/tests/testthat/test-modspec.R
@@ -773,4 +773,10 @@ test_that("Invalid item in $SET generates error", {
     "The $SET block cannot handle these items", 
     fixed = TRUE
   )
+  code <- "$SET a = 2"  # ambiguous partial match
+  expect_error(
+    mcode("dollar-set-item-check-3", code),
+    "The $SET block cannot handle this item",
+    fixed = TRUE
+  )
 })

--- a/tests/testthat/test-modspec.R
+++ b/tests/testthat/test-modspec.R
@@ -767,4 +767,10 @@ test_that("Invalid item in $SET generates error", {
     "The $SET block cannot handle this item", 
     fixed = TRUE
   )
+  code <- "$SET end = 25, kyle = 2, zip = 55455"
+  expect_error(
+    mcode("dollar-set-item-check-2", code),
+    "The $SET block cannot handle these items", 
+    fixed = TRUE
+  )
 })

--- a/tests/testthat/test-modspec.R
+++ b/tests/testthat/test-modspec.R
@@ -759,3 +759,11 @@ test_that("Skip cpp dot check gh-1159", {
   
   expect_s4_class(mcode("cpp-dot-skip-4", code, compile = FALSE), "mrgmod")
 })
+
+test_that("Invalid item in $SET generates error", {
+  code <- "$SET end = 25, kyle = 2"
+  expect_error(
+    mcode("dollar-set-item-check-1", code),
+    "The $SET block does now allow this item", fixed = TRUE
+  )
+})

--- a/tests/testthat/test-modspec.R
+++ b/tests/testthat/test-modspec.R
@@ -764,6 +764,7 @@ test_that("Invalid item in $SET generates error", {
   code <- "$SET end = 25, kyle = 2"
   expect_error(
     mcode("dollar-set-item-check-1", code),
-    "The $SET block does now allow this item", fixed = TRUE
+    "The $SET block cannot handle this item", 
+    fixed = TRUE
   )
 })

--- a/tests/testthat/test-opts.R
+++ b/tests/testthat/test-opts.R
@@ -36,7 +36,6 @@ test_that("Options where they don't belong", {
   $CMT CENT
   $TABLE >> zip=55455
   double a = 2;
-  $SET y = TRUE
   $CMTN CENT
   '
   mod <- mcode("test-opts-1", code, compile=FALSE)


### PR DESCRIPTION
See #1237 

Basically, the `$SET` block can take some items that get passed directly to `update()` and other items that get used for various things under the hood. The problem reported in #1237 shows what can happen when an invalid name gets passed in (beyond just not getting picked up and notification sent to user). 

This PR centralizes the names of all items that can be in play  via `$SET` and `update()` and implements a `handle_()` function to validate inputs, generating an error if an input is bad. 