### PR TITLE
refactor c method for matlist to return all non-skipped matrices

### DIFF
--- a/R/matlist.R
+++ b/R/matlist.R
@@ -1,4 +1,4 @@
-# Copyright (C) 2013 - 2024  Metrum Research Group
+# Copyright (C) 2013 - 2025  Metrum Research Group
 #
 # This file is part of mrgsolve.
 #
@@ -338,24 +338,27 @@ cumoffset <- function(x) {
   ans
 }
 
-##' Operations with matlist objects
-##' 
-##' @param x a matlist object
-##' @param ... other matlist objects
-##' @param recursive not used
-##' @rdname matlist_ops
-##' @export
-setMethod("c", "matlist", function(x,...,recursive=FALSE) {
+#' Operations with matlist objects
+#' 
+#' @param x a matlist object.
+#' @param ... other matlist objects.
+#' @param recursive not used.
+#' @rdname matlist_ops
+#' @export
+setMethod("c", "matlist", function(x, ..., recursive = FALSE) {
   what <- c(list(x), list(...))
   stopifnot(all(sapply(what, is.matlist)))
-  what <- what[sapply(what, slot, name = "n") > 0]
-  if(length(what)==1) return(x)
+  nonzero <- sapply(what, slot, name = "n") > 0
+  if(!any(nonzero)) {
+    return(omat()) 
+  }
+  if(length(nonzero)==1) return(what[which(nonzero)])
+  what <- what[nonzero]
   d <- lapply(what, as.matrix)
   d <- setNames(d, sapply(what, names))
   l <- sapply(unname(what), labels)
   create_matlist(d, labels = l, class = class(x)[1])
 })
-
 
 #' Collapse OMEGA or SIGMA matrix lists
 #' 

--- a/mrgsolve.Rproj
+++ b/mrgsolve.Rproj
@@ -1,5 +1,4 @@
 Version: 1.0
-
 ProjectId: 0063b92e-a050-4fd7-986e-be62f57eb1b1
 
 RestoreWorkspace: Default

--- a/tests/testthat/nm/1005-omega-skip.mod
+++ b/tests/testthat/nm/1005-omega-skip.mod
@@ -1,0 +1,11 @@
+[ nmxml ] 
+run = 1005
+project = 'nonmem'
+root = "cppfile"
+omega = FALSE
+
+[ nmxml ] 
+run = 1005
+project = 'nonmem'
+root = "cppfile"
+tname = "theta"

--- a/tests/testthat/test-nmxml.R
+++ b/tests/testthat/test-nmxml.R
@@ -383,3 +383,11 @@ test_that("provide path rather than run and project [SLV-TEST-023]", {
   nmxml_file <- basename(as.list(mod)[["nm_import"]])
   expect_equal(nmxml_file, "1005.xml")
 })
+
+test_that("return all non-skipped matrices gh-1274", {
+  skip_if_not(file.exists("nm/1005-omega-skip.mod"))
+  mod <- mread("1005-omega-skip.mod", project = "nm", compile = FALSE) 
+  expect_is(mod, "mrgmod")
+  expect_equal(length(omat(mod)), 1)
+  expect_equal(nrow(omat(mod)), 3)
+})


### PR DESCRIPTION
This pull request fixes a bug when a model imports nonmem estimates from multiple runs, but doesn't request all the omega matrices (#1274). The issue was faulty bookkeeping in the `c()` function. 

I opened another issue #1275 to refactor some functionality around determining the dimensions of these objects; right now, I just do it brute force and it works fine; but some of that functionality (1) could be used here and (2) could break depending on whether or not the matlist has "empty" slots. 

