### PR TITLE
Clobber both upper and lower case names when writing model

### DIFF
--- a/R/mwrite.R
+++ b/R/mwrite.R
@@ -120,6 +120,9 @@ mwrite_model_to_list <- function(x) {
   code <- modelparse(code, comment_re = character(0))
   code <- lapply(code, trimws, which = "right")
   
+  names(code) <- toupper(names(code))
+  code_names <- names(code)
+  
   l$set <- tolist(code$SET)
   
   if(nrow(x@annot$data)) {
@@ -130,14 +133,14 @@ mwrite_model_to_list <- function(x) {
     } 
     annot <- knitr::kable(annot, format = "simple")
     annot <- c("# Model Annotations: ", "", annot)
-    if("PROB" %in% names(code)) {
+    if("PROB" %in% code_names) {
       code$PROB <- c(code$PROB, "", annot)  
     } else {
       code <- c(list(PROB = annot), code)
     }
   }
   
-  if("PROB" %in% names(code)) {
+  if("PROB" %in% code_names) {
     l$prob <- code$PROB
     code$PROB <- NULL
   }
@@ -145,7 +148,7 @@ mwrite_model_to_list <- function(x) {
   clob <- c("PARAM", "INPUT", "THETA", "CMT", "INIT", "OMEGA", "SIGMA", 
             "NMEXT", "NMXML", "VCMT", "SET", "CAPTURE")
   
-  w <- which(toupper(names(code)) %in% clob)
+  w <- which(code_names %in% clob)
   
   if(length(w)) {
     code <- code[-w]
@@ -153,7 +156,7 @@ mwrite_model_to_list <- function(x) {
   
   # Need special handling here in case compartments are declared 
   # as a part of PKMODEL
-  if("PKMODEL" %in% names(code)) {
+  if("PKMODEL" %in% code_names) {
     pk <- tolist(code$PKMODEL)
     parsed <- do.call(PKMODEL, pk)
     pk$ncmt <- parsed$n
@@ -161,7 +164,7 @@ mwrite_model_to_list <- function(x) {
     code$PKMODEL <- tocode(pk)
   }
   # Put block names back into code
-  code <- Map(code, names(code), f = function(text, name) {
+  code <- Map(code, code_names, f = function(text, name) {
     c(glue("${name}"), text, " ")
   })
   l$code <- unlist(code, use.names = FALSE)

--- a/R/mwrite.R
+++ b/R/mwrite.R
@@ -121,7 +121,6 @@ mwrite_model_to_list <- function(x) {
   code <- lapply(code, trimws, which = "right")
   
   names(code) <- toupper(names(code))
-  code_names <- names(code)
   
   l$set <- tolist(code$SET)
   
@@ -133,14 +132,14 @@ mwrite_model_to_list <- function(x) {
     } 
     annot <- knitr::kable(annot, format = "simple")
     annot <- c("# Model Annotations: ", "", annot)
-    if("PROB" %in% code_names) {
+    if("PROB" %in% names(code)) {
       code$PROB <- c(code$PROB, "", annot)  
     } else {
       code <- c(list(PROB = annot), code)
     }
   }
   
-  if("PROB" %in% code_names) {
+  if("PROB" %in% names(code)) {
     l$prob <- code$PROB
     code$PROB <- NULL
   }
@@ -148,7 +147,7 @@ mwrite_model_to_list <- function(x) {
   clob <- c("PARAM", "INPUT", "THETA", "CMT", "INIT", "OMEGA", "SIGMA", 
             "NMEXT", "NMXML", "VCMT", "SET", "CAPTURE")
   
-  w <- which(code_names %in% clob)
+  w <- which(names(code) %in% clob)
   
   if(length(w)) {
     code <- code[-w]
@@ -156,7 +155,7 @@ mwrite_model_to_list <- function(x) {
   
   # Need special handling here in case compartments are declared 
   # as a part of PKMODEL
-  if("PKMODEL" %in% code_names) {
+  if("PKMODEL" %in% names(code)) {
     pk <- tolist(code$PKMODEL)
     parsed <- do.call(PKMODEL, pk)
     pk$ncmt <- parsed$n
@@ -164,7 +163,7 @@ mwrite_model_to_list <- function(x) {
     code$PKMODEL <- tocode(pk)
   }
   # Put block names back into code
-  code <- Map(code, code_names, f = function(text, name) {
+  code <- Map(code, names(code), f = function(text, name) {
     c(glue("${name}"), text, " ")
   })
   l$code <- unlist(code, use.names = FALSE)

--- a/R/mwrite.R
+++ b/R/mwrite.R
@@ -145,7 +145,7 @@ mwrite_model_to_list <- function(x) {
   clob <- c("PARAM", "INPUT", "THETA", "CMT", "INIT", "OMEGA", "SIGMA", 
             "NMEXT", "NMXML", "VCMT", "SET", "CAPTURE")
   
-  w <- which(names(code) %in% clob)
+  w <- which(toupper(names(code)) %in% clob)
   
   if(length(w)) {
     code <- code[-w]

--- a/mrgsolve.Rproj
+++ b/mrgsolve.Rproj
@@ -1,5 +1,4 @@
 Version: 1.0
-
 ProjectId: 0063b92e-a050-4fd7-986e-be62f57eb1b1
 
 RestoreWorkspace: Default

--- a/tests/testthat/test-mwrite.R
+++ b/tests/testthat/test-mwrite.R
@@ -232,6 +232,7 @@ test_that("code gets appropriately quoted", {
 })
 
 test_that("model with lower case names", {
+  skip_if_not_installed("yaml")
   code <- "$param cl = 1\n$cmt a b c\n$SET rtol = 1e-2"
   mod <- mcode("test-mwrite-lower", code, compile = FALSE)
   temp <- tempfile()

--- a/tests/testthat/test-mwrite.R
+++ b/tests/testthat/test-mwrite.R
@@ -1,4 +1,4 @@
-# Copyright (C) 2013 - 2024  Metrum Research Group
+# Copyright (C) 2013 - 2025  Metrum Research Group
 #
 # This file is part of mrgsolve.
 #
@@ -229,4 +229,12 @@ test_that("code gets appropriately quoted", {
   cpp <- yaml_to_cpp(file = temp, model = "test-quote", project = tempdir())
   lines <- readLines(cpp)
   expect_match(lines, 'outvars = "A"', all=FALSE)
+})
+
+test_that("model with lower case names", {
+  code <- "$param cl = 1\n$cmt a b c\n$SET rtol = 1e-2"
+  mod <- mcode("test-mwrite-lower", code, compile = FALSE)
+  temp <- tempfile()
+  mwrite_yaml(mod, temp)
+  mod2 <- mread_yaml(temp)
 })

--- a/tests/testthat/test-mwrite.R
+++ b/tests/testthat/test-mwrite.R
@@ -236,5 +236,37 @@ test_that("model with lower case names", {
   mod <- mcode("test-mwrite-lower", code, compile = FALSE)
   temp <- tempfile()
   mwrite_yaml(mod, temp)
-  mod2 <- mread_yaml(temp)
+  mod2 <- mread_yaml(temp, compile = FALSE)
+  expect_is(mod2, "mrgmod")
+  l1 <- as.list(mod)
+  l2 <- as.list(mod2)
+  expect_identical(l1$param, l2$param)
+  expect_identical(l1$cmt, l2$cmt)
+  expect_identical(l1$rtol, l2$rtol)
+})
+
+test_that("mwrite normalizes block names to upper case", {
+  skip_if_not_installed("yaml")
+  
+  ucode <- '$CMT DEPOT CENT
+$PKMODEL ncmt=1, depot=TRUE
+$MAIN
+double CL = 1
+double V = 20
+double KA = 1'
+  umod <- mcode("test-case", ucode, compile = FALSE)
+  utemp <- tempfile()
+  mwrite_yaml(umod, file = utemp)
+  
+  lcode <- '$cmt DEPOT CENT
+$pkmodel ncmt=1, depot=TRUE
+$main
+double CL = 1
+double V = 20
+double KA = 1'
+  lmod <- mcode("test-case", lcode, compile = FALSE)
+  ltemp <- tempfile()
+  mwrite_yaml(lmod, file = ltemp)
+  
+  expect_identical(readLines(utemp), readLines(ltemp))
 })

--- a/tests/testthat/test-mwrite.R
+++ b/tests/testthat/test-mwrite.R
@@ -230,4 +230,3 @@ test_that("code gets appropriately quoted", {
   lines <- readLines(cpp)
   expect_match(lines, 'outvars = "A"', all=FALSE)
 })
-

--- a/tests/testthat/test-mwrite.R
+++ b/tests/testthat/test-mwrite.R
@@ -230,3 +230,4 @@ test_that("code gets appropriately quoted", {
   lines <- readLines(cpp)
   expect_match(lines, 'outvars = "A"', all=FALSE)
 })
+


### PR DESCRIPTION
Force block names to be upper case when processing and on write. So, when writing a model back to file, it will _always_ use `$BLOCK` style.  This will be a change, but it's reasonable. 