### PR TITLE
Fix floating point issue with time in some output records 

### DIFF
--- a/inst/maintenance/unit/test-alag.R
+++ b/inst/maintenance/unit/test-alag.R
@@ -115,3 +115,32 @@ test_that("EVID 1 or 4 at SS with lag time are identical", {
   
   expect_identical(out1a, out4a)
 })
+
+
+code_alag_float <- '
+$PKMODEL cmt = "A,B", depot = TRUE
+
+$PARAM CL = 1, V = 22, KA = 1.2, lag = 1.2322
+
+$OMEGA 1.2
+
+$MAIN
+ALAG_A = exp(log(lag) + ETA(1));
+'
+mod <- mcode("test-alag-float", code_alag_float, end = 24*87, delta = 24)
+
+test_that("Prevent floating point issues with TIME and random ALAG + ADDL", {
+  
+  expect_length(unique(stime(mod)), 88)
+  
+  data <- expand.ev(amt = 100, ii = 12, addl = 100, ID = 1:1000)
+  
+  out <- mrgsim(
+    mod,
+    data = data,
+    carry_out = "evid", 
+    obsonly = TRUE
+  )     
+  
+  expect_length(unique(out$time), 88) # Before fix, fails with length in the 90s
+})

--- a/src/datarecord.cpp
+++ b/src/datarecord.cpp
@@ -555,14 +555,17 @@ void datarecord::schedule(reclist& thisi, double maxtime,
     this_evid = Rate > 0 ? 5 : 1;
   }
   
-  //thisi.reserve(thisi.size() + n_dose); // TODO: remove 
-  
   double ontime = 0;
+  
+  // Doing this math once fixes issues with very small differences in output 
+  // TIME values: 
+  // https://github.com/metrumresearchgroup/mrgsolve/issues/1286
+  double parent_time = Time - lagt;
   
   int mp = 1000000000;
   
   int nextpos = addl_ev_first ?  -1000000000 : mp;
-  
+
   for(unsigned int k = 1; k <= Addl; ++k) {
     
     ontime = Time + Ii*double(k);
@@ -570,7 +573,8 @@ void datarecord::schedule(reclist& thisi, double maxtime,
     if(ontime > maxtime) break;
     
     if(add_parent_doses) {
-      rec_ptr ev_parent = NEWREC(Cmt, this_evid, Amt, ontime-lagt, Rate, nextpos, Id);
+      rec_ptr ev_parent = NEWREC(Cmt, this_evid, Amt, 
+                                 parent_time + Ii*double(k), Rate, nextpos, Id);
       ev_parent -> unarm(); 
       ev_parent -> phantom_rec();
       thisi.push_back(ev_parent);      

--- a/src/datarecord.cpp
+++ b/src/datarecord.cpp
@@ -574,7 +574,8 @@ void datarecord::schedule(reclist& thisi, double maxtime,
     
     if(add_parent_doses) {
       rec_ptr ev_parent = NEWREC(Cmt, this_evid, Amt, 
-                                 parent_time + Ii*double(k), Rate, nextpos, Id);
+                                 parent_time + Ii*double(k), 
+                                 Rate, nextpos, Id);
       ev_parent -> unarm(); 
       ev_parent -> phantom_rec();
       thisi.push_back(ev_parent);      

--- a/src/datarecord.cpp
+++ b/src/datarecord.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2013 - 2024  Metrum Research Group
+// Copyright (C) 2013 - 2025  Metrum Research Group
 //
 // This file is part of mrgsolve.
 //
@@ -576,8 +576,8 @@ void datarecord::schedule(reclist& thisi, double maxtime,
       rec_ptr ev_parent = NEWREC(Cmt, this_evid, Amt, 
                                  parent_time + Ii*double(k), 
                                  Rate, nextpos, Id);
-      ev_parent -> unarm(); 
-      ev_parent -> phantom_rec();
+      ev_parent->unarm(); 
+      ev_parent->phantom_rec();
       thisi.push_back(ev_parent);      
     }
     


### PR DESCRIPTION
We've see several reports in the past year where `TIME` in simulated output had some very small inaccuracies, clearly related to floating point arithmetic. 

This only happened when 
1. There was a random lag time
2. There were additional doses
3. The lag time made the scheduled "parent" dose the time of another record
4. Only observation records were requested in the output

I tracked this down to the code involved in this PR; basically, in upstream code we're adding a lag time to the time of the parent dose; then in the `schedule()` function, we're repeatedly subtracting that lag time off in order to put "parent" doses into the record stack. 

This is clearly where the issue is happening, but I still don't know _why_ it's happening. All the affected records should be doses. 

In this PR, we calculate the time of the parent dose once, rather than repeatedly. This seems to fix the issue. 
