### PR TITLE
add code for determining when an infusion ends

### DIFF
--- a/R/Aaaa.R
+++ b/R/Aaaa.R
@@ -91,7 +91,7 @@ Reserved_cvar <- c("SOLVERTIME","table","ETA","EPS", "AMT", "CMT",
                    "NEWIND", "DONE", "CFONSTOP", "DXDTZERO",
                    "CFONSTOP","INITSOLV","_F", "_R","_ALAG",
                    "SETINIT", "report", "_VARS_", "VARS", 
-                   "SS_ADVANCE")
+                   "SS_ADVANCE", "END_OF_INFUSION")
 
 Reserved <- c("ID", "amt", "cmt", "ii", "ss", "evid",
               "addl", "rate","time", Reserved_cvar,

--- a/inst/base/modelheader.h
+++ b/inst/base/modelheader.h
@@ -86,6 +86,8 @@ typedef double capture;
 #define CMT self.cmt
 // Bool flag indicating that the system is advancing to steady-state
 #define SS_ADVANCE _ss_flag_
+// Bool flag indicating that an infusion is ending
+#define END_OF_INFUSION (self.evid==9)
 // Always accept THETA(n) as THETAn
 #define THETA(a) THETA##a
 

--- a/mrgsolve.Rproj
+++ b/mrgsolve.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: ff67c058-07dc-4312-8daf-f0e94518cd9f
 
 RestoreWorkspace: Default
 SaveWorkspace: Default


### PR DESCRIPTION
This PR adds a variable that the user can check (read) to see when an infusion is ending. This is currently just an alias for EVID==9. 
