### PR TITLE
Pass D, ALAG, and simeps to $TABLE

### DIFF
--- a/inst/base/mrgsolv.h
+++ b/inst/base/mrgsolv.h
@@ -129,7 +129,7 @@ typedef std::vector<double> dvec;
 #define MRGSOLVE_INIT_SIGNATURE_N 10
 
 //! signature for <code>$TABLE</code>
-#define MRGSOLVE_TABLE_SIGNATURE const dvec& _A_0_, const dvec& _A_, dvec& _THETA_, const dvec& _F_, const dvec& _R_, const dvec& _D_, databox& self, const dvec& _pred_, dvec& _capture_, mrgsolve::resim& simeta, mrgsolve::resim& simeps
+#define MRGSOLVE_TABLE_SIGNATURE const dvec& _A_0_, const dvec& _A_, dvec& _THETA_, const dvec& _F_, const dvec& _ALAG_, const dvec& _R_, const dvec& _D_, databox& self, const dvec& _pred_, dvec& _capture_, mrgsolve::resim& simeta, mrgsolve::resim& simeps
 #define MRGSOLVE_TABLE_SIGNATURE_N 11
 
 //! signature for <code>$EVENT</code> same as what we use for <code>$TABLE</code>

--- a/inst/base/mrgsolv.h
+++ b/inst/base/mrgsolv.h
@@ -125,12 +125,12 @@ public:
 typedef std::vector<double> dvec;
 
 //! signature for <code>$MAIN</code>
-#define MRGSOLVE_INIT_SIGNATURE  dvec& _A_0_,const dvec& _A_, const dvec& _THETA_,  dvec& _F_, dvec& _ALAG_, dvec& _R_, dvec& _D_,  databox& self, dvec& _pred_, mrgsolve::resim& simeta
+#define MRGSOLVE_INIT_SIGNATURE  dvec& _A_0_,const dvec& _A_, const dvec& _THETA_,  dvec& _F_, dvec& _ALAG_, dvec& _R_, dvec& _D_, databox& self, dvec& _pred_, mrgsolve::resim& simeta
 #define MRGSOLVE_INIT_SIGNATURE_N 10
 
 //! signature for <code>$TABLE</code>
-#define MRGSOLVE_TABLE_SIGNATURE const dvec& _A_, const dvec& _A_0_,  dvec& _THETA_,  const dvec& _F_, const dvec& _R_,  databox& self, const dvec& _pred_, dvec& _capture_, mrgsolve::resim& simeps
-#define MRGSOLVE_TABLE_SIGNATURE_N 9
+#define MRGSOLVE_TABLE_SIGNATURE const dvec& _A_0_, const dvec& _A_, dvec& _THETA_,  const dvec& _F_, const dvec& _R_, const dvec& _D_, databox& self, const dvec& _pred_, dvec& _capture_, mrgsolve::resim& simeta, mrgsolve::resim& simeps
+#define MRGSOLVE_TABLE_SIGNATURE_N 11
 
 //! signature for <code>$EVENT</code> same as what we use for <code>$TABLE</code>
 #define MRGSOLVE_EVENT_SIGNATURE MRGSOLVE_TABLE_SIGNATURE

--- a/inst/base/mrgsolv.h
+++ b/inst/base/mrgsolv.h
@@ -125,11 +125,11 @@ public:
 typedef std::vector<double> dvec;
 
 //! signature for <code>$MAIN</code>
-#define MRGSOLVE_INIT_SIGNATURE  dvec& _A_0_,const dvec& _A_, const dvec& _THETA_,  dvec& _F_, dvec& _ALAG_, dvec& _R_, dvec& _D_, databox& self, dvec& _pred_, mrgsolve::resim& simeta
+#define MRGSOLVE_INIT_SIGNATURE dvec& _A_0_, const dvec& _A_, const dvec& _THETA_, dvec& _F_, dvec& _ALAG_, dvec& _R_, dvec& _D_, databox& self, dvec& _pred_, mrgsolve::resim& simeta
 #define MRGSOLVE_INIT_SIGNATURE_N 10
 
 //! signature for <code>$TABLE</code>
-#define MRGSOLVE_TABLE_SIGNATURE const dvec& _A_0_, const dvec& _A_, dvec& _THETA_,  const dvec& _F_, const dvec& _R_, const dvec& _D_, databox& self, const dvec& _pred_, dvec& _capture_, mrgsolve::resim& simeta, mrgsolve::resim& simeps
+#define MRGSOLVE_TABLE_SIGNATURE const dvec& _A_0_, const dvec& _A_, dvec& _THETA_, const dvec& _F_, const dvec& _R_, const dvec& _D_, databox& self, const dvec& _pred_, dvec& _capture_, mrgsolve::resim& simeta, mrgsolve::resim& simeps
 #define MRGSOLVE_TABLE_SIGNATURE_N 11
 
 //! signature for <code>$EVENT</code> same as what we use for <code>$TABLE</code>

--- a/inst/base/mrgsolv.h
+++ b/inst/base/mrgsolv.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2013 - 2024  Metrum Research Group
+// Copyright (C) 2013 - 2025  Metrum Research Group
 //
 // This file is part of mrgsolve.
 //

--- a/inst/maintenance/unit/test-D-R-F.R
+++ b/inst/maintenance/unit/test-D-R-F.R
@@ -35,12 +35,19 @@ if(mode==2) D_CENT = D1;
 
 $CMT CENT GUT
 $ODE dxdt_CENT = GUT-0.1*CENT; dxdt_GUT = -1*GUT;
+
+$TABLE
+capture foo = D_CENT;
 '
 
 mod <-
   mcode("testinfusion",code) %>%
   update(end=72) %>% obsonly
 
+test_that("Interact with D_CMT in $TABLE #1290", {
+  out <- mrgsim(mod, param = list(mode = 2))
+  expect_true(all(out$foo==2))
+})
 
 data <- expand.ev(ID=1:2, rate=c(1,5,10,50), amt=100)
 set.seed(1212)

--- a/inst/maintenance/unit/test-D-R-F.R
+++ b/inst/maintenance/unit/test-D-R-F.R
@@ -1,4 +1,4 @@
-# Copyright (C) 2013 - 2019  Metrum Research Group, LLC
+# Copyright (C) 2013 - 2025  Metrum Research Group
 #
 # This file is part of mrgsolve.
 #

--- a/inst/maintenance/unit/test-alag.R
+++ b/inst/maintenance/unit/test-alag.R
@@ -36,7 +36,7 @@ context("test-alag")
 
 test_that("Access ALAG in $TABLE #1290", {
   out <- mrgsim(mod)
-  diff <- out$foo - mod$LAG
+  diff <- abs(out$foo - mod$LAG)
   expect_true(all(diff < 1e-5))
 })
 

--- a/inst/maintenance/unit/test-alag.R
+++ b/inst/maintenance/unit/test-alag.R
@@ -27,10 +27,18 @@ $PARAM LAG = 2.8, CL = 1, V = 20
 $PKMODEL cmt = "CENT"
 $MAIN
 ALAG_CENT = LAG;
+$TABLE
+capture foo = ALAG_CENT;
 '
 mod <- mcode("alag1", code)
 
 context("test-alag")
+
+test_that("Access ALAG in $TABLE #1290", {
+  out <- mrgsim(mod)
+  diff <- out$foo - mod$LAG
+  expect_true(all(diff < 1e-5))
+})
 
 test_that("Lagged bolus", {
     out <- mod %>% ev(amt=100) %>% mrgsim(delta=0.01,add=c(2.7999999,2.8000001), end=10)

--- a/inst/maintenance/unit/test-simeta.R
+++ b/inst/maintenance/unit/test-simeta.R
@@ -71,6 +71,10 @@ if(mode==5) {
   b = EPS(2);
   c = 9;
 }
+if(mode==6) { 
+  simeta();
+  d = ETA(1);  
+}
 '
 
 mod <- mcode("simeta-n", code, end = 6, delta = 2)
@@ -91,6 +95,11 @@ test_that("resimulate all eta", {
   all2$d <- NULL
   expect_identical(all, all2)
   
+  # Interact with simeta in $TABLE #1289
+  set.seed(1234)
+  all3 <- mrgsim_df(mod, param = list(n = 0, mode = 6))
+  diff <- all3$d - all2$a
+  expect_true(all(diff < 1e-6))
 })
 
 test_that("resimulate all or specific eps", {

--- a/inst/maintenance/unit/test-simeta.R
+++ b/inst/maintenance/unit/test-simeta.R
@@ -98,7 +98,7 @@ test_that("resimulate all eta", {
   # Interact with simeta in $TABLE #1289
   set.seed(1234)
   all3 <- mrgsim_df(mod, param = list(n = 0, mode = 6))
-  diff <- all3$d - all2$a
+  diff <- abs(all3$d - all2$a)
   expect_true(all(diff < 1e-6))
 })
 

--- a/src/odeproblem.cpp
+++ b/src/odeproblem.cpp
@@ -242,12 +242,12 @@ void odeproblem::init_call_record(const double& time) {
 
 //! Call <code>$TABLE</code> function.
 void odeproblem::table_call() {
-  Table(Init_value,Y,Param,F,R,d,pred,Capture,simeta,simeps);  
+  Table(Init_value,Y,Param,F,Alag,R,D,d,pred,Capture,simeta,simeps);  
 }
 
 //! Call <code>$EVENT</code> function.
 void odeproblem::event_call() {
-  Event(Init_value,Y,Param,F,R,d,pred,Capture,simeps);  
+  Event(Init_value,Y,Param,F,Alag,R,D,d,pred,Capture,simeta,simeps);  
 }
 
 //! Call <code>$PREAMBLE</code> function.

--- a/src/odeproblem.cpp
+++ b/src/odeproblem.cpp
@@ -242,12 +242,12 @@ void odeproblem::init_call_record(const double& time) {
 
 //! Call <code>$TABLE</code> function.
 void odeproblem::table_call() {
-  Table(Y,Init_value,Param,F,R,d,pred,Capture,simeps);  
+  Table(Init_value,Y,Param,F,R,d,pred,Capture,simeta,simeps);  
 }
 
 //! Call <code>$EVENT</code> function.
 void odeproblem::event_call() {
-  Event(Y,Init_value,Param,F,R,d,pred,Capture,simeps);  
+  Event(Init_value,Y,Param,F,R,d,pred,Capture,simeps);  
 }
 
 //! Call <code>$PREAMBLE</code> function.

--- a/src/odeproblem.cpp
+++ b/src/odeproblem.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2013 - 2024  Metrum Research Group
+// Copyright (C) 2013 - 2025  Metrum Research Group
 //
 // This file is part of mrgsolve.
 //


### PR DESCRIPTION
This PR lets users interact with several mrgsolve variables in the `$TABLE` block: 

1. `D_CMT`
2. `ALAG_CMT`
3. `simeps()`


The PR also standardizes the pass order for `$MAIN` and `$TABLE` and does some light linting. 