### PR TITLE
Exact matching when aliasing block names

### DIFF
--- a/R/mread.R
+++ b/R/mread.R
@@ -186,10 +186,11 @@ mread <- function(model, project = getOption("mrgsolve.project", getwd()),
   ## Block name aliases
   incoming_block_names <- names(spec)
   names(spec) <- toupper(names(spec))
-  names(spec) <- gsub("DES",   "ODE",   names(spec), fixed = TRUE)
-  names(spec) <- gsub("POST",  "TABLE", names(spec), fixed = TRUE)
-  names(spec) <- gsub("ERROR", "TABLE", names(spec), fixed = TRUE)
-  names(spec) <- gsub("^PK$",  "MAIN",  names(spec), fixed = FALSE)
+  
+  names(spec) <- sub("^DES$",   "ODE",   names(spec))
+  names(spec) <- sub("^POST$",  "TABLE", names(spec))
+  names(spec) <- sub("^ERROR$", "TABLE", names(spec))
+  names(spec) <- sub("^PK$",    "MAIN",  names(spec))
   
   ## Expand partial matches
   index <- pmatch(names(spec), block_list, duplicates.ok = TRUE)

--- a/tests/testthat/test-mread.R
+++ b/tests/testthat/test-mread.R
@@ -60,3 +60,13 @@ test_that("ERROR is alias for TABLE", {
   expect_is(mcode("error-is-table", code), "mrgmod")
 })
 
+test_that("mread does not expand partial alias matches", {
+  expect_warning(
+    mcode(
+      "test-mread-no-partial-alias",
+      "$CMT A B\n$DESFOO\ndxdt_A  = 0;\ndxdt_B=0;",
+    ),
+    regexp = "invalid blocks found: DESFOO",
+    fixed = TRUE
+  )
+})


### PR DESCRIPTION
I think there was an issue when mistyping a block name like this:

```
$ODEFOO
```

Which gets turned into 

```
$DESFOO
```

The block name aliasing should be / was always intended to be exact matching on the whole name. I'm not sure of a another one-liner in base R to do this or not. 

