### PR TITLE
Don't let mtime or mevent send back an object in the past

### DIFF
--- a/inst/base/databox_cpp.h
+++ b/inst/base/databox_cpp.h
@@ -19,13 +19,15 @@
 #ifndef DATABOX_CPP_H
 #define DATABOX_CPP_H
 
-void databox::mevent(double time, int evid) {
-  mrgsolve::evdata ev(time,evid);
+void databox::mevent(double time_, int evid) {
+  if(time_ < time) return;
+  mrgsolve::evdata ev(time_,evid);
   ev.check_unique = true;
   mevector.push_back(ev);
 }
 
-double databox::mtime(double time) {
+double databox::mtime(double time_) {
+  if(time_ < time) return time;
   mrgsolve::evdata ev(time,2);
   ev.check_unique = true;
   mevector.push_back(ev);

--- a/inst/base/mrgsolv.h
+++ b/inst/base/mrgsolv.h
@@ -115,9 +115,9 @@ public:
   void stop_id() {SYSTEMOFF=2;}///< stops solving for the current id, filling with NA
   void stop_id_cf(){SYSTEMOFF=1;}///< stops solving for the current id, filling last value
   std::vector<mrgsolve::evdata> mevector;///< a collection of model events to pass back
-  void mevent(double time, int evid);///< constructor for evdata objects
+  void mevent(double time_, int evid);///< constructor for evdata objects
   void push(mrgsolve::evdata x);
-  double mtime(double time);///< creates evdata object for simple model event time
+  double mtime(double time_);///< creates evdata object for simple model event time
   double tad();///< calculates time after dose
 }; 
 


### PR DESCRIPTION
This change to `self.mevent()` and `self.mtime()` update those method to have behavior consistent with change in #1295 where we issue an error for modeled events that happen in the past. These used to be ignored; now, we do that check when the object is created and decline to send anything back to mrgsolve for event in the past. 