### PR TITLE
Release 1.6.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: mrgsolve
 Title: Simulate from ODE-Based Models
-Version: 1.6.0.9000
+Version: 1.6.1
 Authors@R: 
     c(person(given = "Kyle T", family = "Baron",
              role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# mrgsolve (development version)
+# mrgsolve 1.6.1
 
 - Internal refactor of `self.mevent()` and `self.mtime()` to _not_ send event
   objects back to mrgsolve when the requested object time is in the past; this


### PR DESCRIPTION
# mrgsolve 1.6.1

- Internal refactor of `self.mevent()` and `self.mtime()` to _not_ send event
  objects back to mrgsolve when the requested object time is in the past; this
  preserves previous functionality while respecting change in `1.6.0` that 
  generates an error for events (or event sequences) that happen or begin in 
  the past (#1297).
