### PR TITLE
ERR is an alias for EPS when using nm-vars

### DIFF
--- a/R/Aaaa.R
+++ b/R/Aaaa.R
@@ -122,7 +122,7 @@ Reserved <- c("ID", "amt", "cmt", "ii", "ss", "evid",
               "double", "int", "bool", "capture", 
               "until", "now")
 
-Reserved_nm <- c("A", "DADT", "A_0", "T")
+Reserved_nm <- c("A", "DADT", "A_0", "T", "ERR")
 
 globalVariables(c("test_package","time", "ID","block", "descr",
                   "everything", "TIME", "address","x", 

--- a/inst/base/modelheader.h
+++ b/inst/base/modelheader.h
@@ -137,6 +137,7 @@ typedef double capture;
 #define A_0(a) _A_0_[a-1]
 #define DADT(a) _DADT_[a-1]
 #define T _ODETIME_[0]
+#define ERR(a) EPS(a) 
 #define EXP(a) exp(a)
 #define DEXP(a) exp(a)
 #define LOG(a) log(a)

--- a/inst/maintenance/unit/test-nm-vars.R
+++ b/inst/maintenance/unit/test-nm-vars.R
@@ -358,4 +358,12 @@ test_that("preprocess_nm_vars returns the full spec unchanged except code blocks
   expect_equal(out$PARAM, "CL = 0.1")
 })
 
+test_that("ERR is reserved when using nm-vars", {
+  code <- c("$PLUGIN nm-vars", "$PARAM ERR = 1")
+  expect_error(
+    mcode("err-is-reserved", code, compile = FALSE), 
+    "Reserved names in parameter list"
+  )
+})
+
 rm(testenv)

--- a/inst/models/nm-like.cpp
+++ b/inst/models/nm-like.cpp
@@ -25,5 +25,10 @@ DADT(1) = -KA*A(1)
 DADT(2) =  KA*A(1) - (CL/V)*A(2)
 DADT(3) =  KIN * (1-INH) - KOUT * A(3)
 
+$SIGMA 0.0025
+
 $ERROR
 CP = A(2)/V
+DV = CP*EXP(ERR(1))
+
+$CAPTURE CP


### PR DESCRIPTION
`ERR` also becomes reserve when using `nm-vars`.  Motivation: people might have this in the NONMEM code and we want to enable that when using `nm-vars`. 


```
 +--------------------------------------------------------------------+
 |                                                                    |
 |                               $ERROR                               |
 |                                                                    |
 +--------------------------------------------------------------------+

 MEANING: Marks the beginning of abbreviated code for the ERROR routine
 CONTEXT: NM-TRAN Control Record

 USAGE:
 $ERROR
 abbreviated code


 Right-hand quantities in assignment statement and in conditions:

   F (Required. The value of the scaled drug amount in the  observation
   compartment.)

   Data item labels specified on the $INPUT statement.

   THETA(n)

   ETA(n)   (Required  if the data are single-subject, and can be coded
   ERR(n).  Optional if the data are population.)

   EPS(n)  (Required if the data  are  population,  and  can  be  coded
   ERR(n).)

   ERROR-defined  items  that appeared earlier as left-hand quantities.
   This includes Y.
```