### PR TITLE
root now defaults to cppfile for NMXML and NMEXT

### DIFF
--- a/R/nmxml.R
+++ b/R/nmxml.R
@@ -1,4 +1,4 @@
-# Copyright (C) 2013 - 2024  Metrum Research Group
+# Copyright (C) 2013 - 2026  Metrum Research Group
 #
 # This file is part of mrgsolve.
 #
@@ -72,7 +72,7 @@
 #' @md
 nmxml <- function(run = numeric(0), project = character(0),
                   file = character(0), path = character(0),
-                  root = c("working", "cppfile"), 
+                  root = c("cppfile", "working"), 
                   theta = TRUE, omega = TRUE, sigma = TRUE,
                   olabels = NULL, slabels = NULL,
                   oprefix = "", sprefix="",
@@ -227,7 +227,7 @@ nmxml <- function(run = numeric(0), project = character(0),
 #' @md
 nmext <- function(run = NA_real_, project = getwd(), 
                   file = paste0(run,".ext"), path = NULL,
-                  root = c("working", "cppfile"),
+                  root = c("cppfile", "working"),
                   index = "last",
                   theta = TRUE, omega = TRUE, sigma = TRUE,
                   olabels = NULL, slabels = NULL,

--- a/man/nmext.Rd
+++ b/man/nmext.Rd
@@ -9,7 +9,7 @@ nmext(
   project = getwd(),
   file = paste0(run, ".ext"),
   path = NULL,
-  root = c("working", "cppfile"),
+  root = c("cppfile", "working"),
   index = "last",
   theta = TRUE,
   omega = TRUE,

--- a/man/nmxml.Rd
+++ b/man/nmxml.Rd
@@ -10,7 +10,7 @@ nmxml(
   project = character(0),
   file = character(0),
   path = character(0),
-  root = c("working", "cppfile"),
+  root = c("cppfile", "working"),
   theta = TRUE,
   omega = TRUE,
   sigma = TRUE,

--- a/tests/testthat/nm/1005-both.cpp
+++ b/tests/testthat/nm/1005-both.cpp
@@ -1,7 +1,6 @@
 [ nmext ] 
 run = 1005
 project = 'nonmem'
-root = "cppfile"
 
 [ nmxml ] 
 run = 1005

--- a/tests/testthat/nm/1005-ext.cpp
+++ b/tests/testthat/nm/1005-ext.cpp
@@ -1,4 +1,3 @@
 [ nmext ] 
 run = 1005
 project = 'nonmem'
-root = "cppfile"

--- a/tests/testthat/nm/1005-omega-skip.mod
+++ b/tests/testthat/nm/1005-omega-skip.mod
@@ -1,7 +1,6 @@
 [ nmxml ] 
 run = 1005
 project = 'nonmem'
-root = "cppfile"
 omega = FALSE
 
 [ nmxml ] 

--- a/tests/testthat/nm/1005-path-ext.mod
+++ b/tests/testthat/nm/1005-path-ext.mod
@@ -1,4 +1,2 @@
 [ nmext ] 
 path = "nonmem/1005/1005.ext"
-root = "cppfile"
-

--- a/tests/testthat/nm/1005-path-xml.mod
+++ b/tests/testthat/nm/1005-path-xml.mod
@@ -1,4 +1,2 @@
 [ nmxml ] 
 path = "nonmem/1005/1005.xml"
-root = "cppfile"
-

--- a/tests/testthat/nm/1005-xml.cpp
+++ b/tests/testthat/nm/1005-xml.cpp
@@ -1,4 +1,3 @@
 [ nmxml ] 
 run = 1005
 project = 'nonmem'
-root = "cppfile"

--- a/tests/testthat/nm/cppstem-nmext/1005.cpp
+++ b/tests/testthat/nm/cppstem-nmext/1005.cpp
@@ -1,4 +1,3 @@
 [ nmext ] 
 run = "@cppstem"
 project = "../nonmem"
-root = "cppfile"

--- a/tests/testthat/nm/cppstem-nmxml/1005.cpp
+++ b/tests/testthat/nm/cppstem-nmxml/1005.cpp
@@ -1,4 +1,3 @@
 [ nmxml ] 
 run = "@cppstem"
 project = "../nonmem"
-root = "cppfile"


### PR DESCRIPTION
Preserving `working`, but pretty much everyone should now be taking the default "cppfile" .

Breaking change along with the host of other big changes going into 2.0. It used to be "working" was the only option; but it was such bad behavior. We introduced "cppfile" with the intent to eventually make that the only option. Will go for just making that default for now. 