### PR TITLE
group_by.mrgsims: drop now unneeded dplyr version check

### DIFF
--- a/R/Aaaa.R
+++ b/R/Aaaa.R
@@ -132,8 +132,6 @@ globalVariables(c("test_package","time", "ID","block", "descr",
 
 VERSION <- utils::packageVersion("mrgsolve")
 
-DPLYR_1_0_0 <- packageVersion("dplyr") >= '0.8.99.9000'
-
 # Keep to support mt_fun function in inst/mrgx/mrgx.h
 mrgx_mt_fun <- function() {}
 

--- a/R/mrgsims.R
+++ b/R/mrgsims.R
@@ -142,8 +142,7 @@ NULL
 #' @param .dots passed to various `dplyr` functions.
 #' @param .data an mrgsims object; passed to various `dplyr` functions.
 #' @param x passed to [dplyr::as.tbl()].
-#' @param add passed to [dplyr::group_by()] (for dplyr < `1.0.0`).
-#' @param .add passed to [dplyr::group_by()] (for dplyr >= `1.0.0`).
+#' @param .add passed to [dplyr::group_by()].
 #' @param .keep_all passed to [dplyr::distinct()].
 #' @param ... passed to other methods.
 #' 
@@ -181,12 +180,8 @@ filter.mrgsims <- function(.data,...) {
 
 ##' @rdname mrgsims_dplyr
 ##' @export
-group_by.mrgsims <- function(.data,...,add=FALSE,.add=FALSE) {
-  if(DPLYR_1_0_0) {
-    return(dplyr::group_by(as_tibble.mrgsims(.data), ..., .add = .add))
-  } else {
-    return(dplyr::group_by(as_tibble.mrgsims(.data), ..., add = add))
-  }
+group_by.mrgsims <- function(.data,...,.add=FALSE) {
+  return(dplyr::group_by(as_tibble.mrgsims(.data), ..., .add = .add))
 }
 
 ##' @rdname mrgsims_dplyr

--- a/man/mrgsims_dplyr.Rd
+++ b/man/mrgsims_dplyr.Rd
@@ -21,7 +21,7 @@
 
 \method{filter}{mrgsims}(.data, ...)
 
-\method{group_by}{mrgsims}(.data, ..., add = FALSE, .add = FALSE)
+\method{group_by}{mrgsims}(.data, ..., .add = FALSE)
 
 \method{distinct}{mrgsims}(.data, ..., .keep_all = FALSE)
 
@@ -48,9 +48,7 @@ as.tbl.mrgsims(x, ...)
 
 \item{...}{passed to other methods.}
 
-\item{add}{passed to \code{\link[dplyr:group_by]{dplyr::group_by()}} (for dplyr < \verb{1.0.0}).}
-
-\item{.add}{passed to \code{\link[dplyr:group_by]{dplyr::group_by()}} (for dplyr >= \verb{1.0.0}).}
+\item{.add}{passed to \code{\link[dplyr:group_by]{dplyr::group_by()}}.}
 
 \item{.keep_all}{passed to \code{\link[dplyr:distinct]{dplyr::distinct()}}.}
 


### PR DESCRIPTION
The minimum version for dplyr was bumped from 0.8.1 to 1.0.8 in mrgsolve 1.0.1 (affad9e7, 2022-03-12).