### PR TITLE
Remove n argument to simeta  and simeps

### DIFF
--- a/R/modspec.R
+++ b/R/modspec.R
@@ -124,33 +124,6 @@ check_pkmodel <- function(x, subr, spec) {
   return(invisible(NULL))
 }
 
-check_sim_eta_eps_n <- function(x, spec) {
-  if(isFALSE(env_get_env(x)$MRGSOLVE_RESIM_N_WARN)) {
-    return(invisible(NULL))  
-  }
-  main <- spec[["MAIN"]]
-  tab <- spec[["TABLE"]]
-  simeta_n <- grep("\\bsimeta\\(\\s*[0-9]+\\s*\\)", main, perl = TRUE)
-  simeps_n <- grep("\\bsimeps\\(\\s*[0-9]+\\s*\\)", tab,  perl = TRUE)
-  if(length(simeta_n) > 0) {
-    warning(
-      "simeta(n) was requested; ", 
-      "resimulating single ETA values is now discouraged and will soon be deprecated; ", 
-      "use simeta() to resimulate all ETA; ",
-      "silence this warning by setting MRGSOLVE_RESIM_N_WARN to FALSE in $ENV."
-    )
-  }
-  if(length(simeps_n) > 0) {
-    warning(
-      "simeps(n) was requested; ", 
-      "resimulating single EPS values is now discouraged and will soon be deprecated; ", 
-      "use simeps() to resimulate all EPS; ",
-      "silence this warning by setting MRGSOLVE_RESIM_N_WARN to FALSE in $ENV."
-    )
-  }
-  return(invisible(NULL))
-}
-
 check_spec_contents <-  function(x, crump = TRUE, warn = TRUE, ...) {
   # Check for valid and invalid blocks
   invalid <- base::setdiff(x, block_list)

--- a/R/mread.R
+++ b/R/mread.R
@@ -416,7 +416,6 @@ mread <- function(model, project = getOption("mrgsolve.project", getwd()),
   # Find cpp objects with dot syntax; saved to mread.env$cpp_dot ----
   find_cpp_dot(spec, mread.env)
   check_cpp_dot(mread.env, x)
-  check_sim_eta_eps_n(x, spec)
   
   # This must come after nm-vars is processed; nmv is NULL if 
   # not using nm-vars

--- a/inst/base/mrgsolv.h
+++ b/inst/base/mrgsolv.h
@@ -39,8 +39,8 @@ struct resim {
   //! resim constructor
   resim(refun x, void* y) : fun(x), prob(y){}
   resim(){}
-  void operator()(int n = 0) {
-    return fun(prob, n);
+  void operator()() {
+    return fun(prob);
   }
   
 protected: 

--- a/inst/base/mrgsolv.h
+++ b/inst/base/mrgsolv.h
@@ -25,7 +25,7 @@
 #include <vector>
 #include <iostream>
 
-typedef void (*refun)(void*, int n);
+typedef void (*refun)(void*);
 
 namespace mrgsolve {
 /**

--- a/inst/maintenance/unit/test-simeta.R
+++ b/inst/maintenance/unit/test-simeta.R
@@ -1,4 +1,4 @@
-# Copyright (C) 2013 - 2022  Metrum Research Group
+# Copyright (C) 2013 - 2026  Metrum Research Group
 #
 # This file is part of mrgsolve.
 #
@@ -43,21 +43,6 @@ if(mode==1) {
   c = ETA(3);
 }
 
-if(mode==2) {
-  simeta(n); 
-  a = ETA(1); 
-  b = ETA(2); 
-  c = ETA(3);
-}
-
-if(mode==3) {
-  simeta(n); 
-  simeta(m);
-  a = ETA(1); 
-  b = ETA(2); 
-  c = ETA(3);
-}
-
 $ERROR
 if(mode==4) {
   simeps(); 
@@ -65,12 +50,6 @@ if(mode==4) {
   b = EPS(2);
 }
 
-if(mode==5) {
-  simeps(n);
-  a = EPS(1);
-  b = EPS(2);
-  c = 9;
-}
 if(mode==6) { 
   simeta();
   d = ETA(1);  
@@ -88,13 +67,6 @@ test_that("resimulate all eta", {
   all$d <- NULL
   expect_false(any(duplicated(unlist(all))))
   
-  # Setting n = 0 is the same as no argument
-  set.seed(1234)
-  all2 <- mrgsim_df(mod, param = list(n = 0, mode = 2))
-  all2$ID <- NULL
-  all2$d <- NULL
-  expect_identical(all, all2)
-  
   # Interact with simeta in $TABLE #1289
   set.seed(1234)
   all3 <- mrgsim_df(mod, param = list(n = 0, mode = 6))
@@ -111,64 +83,6 @@ test_that("resimulate all or specific eps", {
   all$d <- NULL
   all$time <- NULL
   expect_false(any(duplicated(unlist(all))))
-})
-
-test_that("warn when simeta(n) is called with off diagonals", {
-  code <- '
-  $OMEGA @block 
-  1 0.1 2
-  $MAIN 
-  simeta(2);
-  ' 
-  expect_warning(
-    mcode("simeta-n-warn", code, compile = FALSE), 
-    regexp = "values is now discouraged and will soon be deprecated", 
-    fixed  = TRUE
-  )
-  code <- '
-  $OMEGA @block 
-  1 0.1 2
-  $MAIN 
-  simeta();
-  ' 
-  expect_silent(mcode("simeta-n-nowarn-1", code, compile = FALSE))
-  code <- '
-  $ENV MRGSOLVE_RESIM_N_WARN = FALSE
-  $OMEGA @block 
-  1 0.1 2
-  $MAIN 
-  simeta(2);
-  ' 
-  expect_silent(mcode("simeta-n-nowarn-2", code, compile = FALSE))
-})
-
-test_that("warn when simeps(n) is called with off diagonals", {
-  code <- '
-  $SIGMA @block 
-  1 0.1 2
-  $TABLE
-  simeps(2);
-  ' 
-  expect_warning(
-    mcode("simeps-n-warn", code, compile = FALSE), 
-    regexp = "values is now discouraged and will soon be deprecated", 
-    fixed  = TRUE
-  )
-  code <- '
-  $SIGMA @block 
-  1 0.1 2
-  $TABLE
-  simeps();
-  ' 
-  expect_silent(mcode("simeps-n-nowarn", code, compile = FALSE))
-  code <- '
-  $ENV MRGSOLVE_RESIM_N_WARN = FALSE
-  $SIGMA @block 
-  1 0.1 2
-  $TABLE
-  simeps(1);
-  ' 
-  expect_silent(mcode("simeps-n-nowarn-2", code, compile = FALSE))
 })
 
 # Fixes issue discovered in #1092

--- a/inst/maintenance/unit/test-simeta.R
+++ b/inst/maintenance/unit/test-simeta.R
@@ -44,13 +44,13 @@ if(mode==1) {
 }
 
 $ERROR
-if(mode==4) {
+if(mode==2) {
   simeps(); 
   a = EPS(1); 
   b = EPS(2);
 }
 
-if(mode==6) { 
+if(mode==3) { 
   simeta();
   d = ETA(1);  
 }
@@ -69,15 +69,15 @@ test_that("resimulate all eta", {
   
   # Interact with simeta in $TABLE #1289
   set.seed(1234)
-  all3 <- mrgsim_df(mod, param = list(n = 0, mode = 6))
-  diff <- abs(all3$d - all2$a)
+  all3 <- mrgsim_df(mod, param = list(n = 0, mode = 3))
+  diff <- abs(all3$d - all$a)
   expect_true(all(diff < 1e-6))
 })
 
 test_that("resimulate all or specific eps", {
   data <- data.frame(amt = 0, evid = 0, time = c(0,0,0), cmt = 0, ID = 1)
   set.seed(87654)
-  all <- mrgsim_df(mod, data = data, param = list(mode = 4))
+  all <- mrgsim_df(mod, data = data, param = list(mode = 2))
   all$ID <- NULL
   all$c <- NULL
   all$d <- NULL

--- a/src/odeproblem.cpp
+++ b/src/odeproblem.cpp
@@ -30,33 +30,19 @@
 static Rcpp::NumericMatrix OMEGADEF(1,1);
 static arma::mat OMGADEF(1,1,arma::fill::zeros);
 
-void dosimeta(void* prob_, int n) {
+void dosimeta(void* prob_) {
   odeproblem* prob = reinterpret_cast<odeproblem*>(prob_);
   arma::mat eta = prob->mv_omega(1);
-  if(n > int(eta.n_cols)) {
-    throw Rcpp::exception("simeta index out of bounds", false);
-  }
-  if(n > 0) {
-    prob->eta(n-1,eta(0,n-1));
-    return;
-  }
-  for(unsigned int i=0; i < eta.n_cols; ++i) {
-    prob->eta(i,eta(0,i)); 
+  for(unsigned int i = 0; i < eta.n_cols; ++i) {
+    prob->eta(i, eta(0,i)); 
   }
 }
 
-void dosimeps(void* prob_, int n) {
+void dosimeps(void* prob_) {
   odeproblem* prob = reinterpret_cast<odeproblem*>(prob_);
   arma::mat eps = prob->mv_sigma(1);
-  if(n > int(eps.n_cols)) {
-    throw Rcpp::exception("simeps index out of bounds", false);
-  }
-  if(n > 0) {
-    prob->eps(n-1,eps(0,n-1));
-    return;
-  }
-  for(unsigned int i=0; i < eps.n_cols; ++i) {
-    prob->eps(i,eps(0,i)); 
+  for(unsigned int i = 0; i < eps.n_cols; ++i) {
+    prob->eps(i, eps(0,i)); 
   }
 }
 


### PR DESCRIPTION
- `simeta(n)` and `simeps(n)` are now fully deprecated
- The  (regex-based) check for this construct has been removed
- If the user tries to call `simeta(n)`, the model will not compile

``` r
library(mrgsolve)
#> 
#> Attaching package: 'mrgsolve'
#> The following object is masked from 'package:stats':
#> 
#>     filter

code <- ' 
$OMEGA 1

$PK
simeta(1);
'

mod <- mcode("simeta", code)
#> Building simeta ...
#> error.
#> 
#> ---:: stderr ::---------------------------------------------
#> using C++ compiler: ‘Homebrew clang version 22.1.2’
#> using SDK: ‘MacOSX15.5.sdk’
#> 52:1: error: no matching function for call to object of type 'mrgsolve::resim'
#>    52 | simeta(1);
#>       | ^~~~~~
#> /Users/kyleb/renv/renv/library/R-4.5/aarch64-apple-darwin24.6.0/mrgsolve/base/mrgsolv.h:42:8: note: candidate function not viable: requires 0 arguments, but 1 was provided
#>    42 |   void operator()() {
#>       |        ^
#> 1 error generated.
#> make: *** [simeta-mread-source.o] Error 1
#> 
#> ------------------------------------------------------------
#> Error:
#> ! the model build step failed.
```

<sup>Created on 2026-04-17 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>