### PR TITLE
don't check dot anymore

### DIFF
--- a/R/class_mrgmod.R
+++ b/R/class_mrgmod.R
@@ -100,49 +100,6 @@ check_globals <- function(x,cmt) {
   return(invisible(NULL))
 }
 
-check_cpp_dot <- function(env, x) {
-  # Vast majority of models will just return
-  if(is.null(env[["cpp_dot"]])) return(NULL)
-  cpp_dot <- env[["cpp_dot"]]
-  dont_check <- x@envir[["MRGSOLVE_CPP_DOT_SKIP"]]
-  if(is.character(dont_check)) {
-    dont_check <- cvec_cs(dont_check)
-    cpp_dot <- setdiff(cpp_dot, dont_check)
-  } 
-  if(!length(cpp_dot)) return(NULL)
-  mod_names <- names(x)
-  mod_names <- mod_names[c("param", "init", "omega_labels", "sigma_labels")]
-  mod_labels <- unlist(mod_names, use.names = FALSE)
-  bad <- cpp_dot[cpp_dot %in% mod_labels]
-  bad <- setdiff(bad, Reserved)  
-  if(!length(bad)) return(NULL)
-  mod_names$sigma_labels <- unlist(mod_names$sigma_labels, use.names = FALSE)
-  mod_names$omega_labels <- unlist(mod_names$omega_labels, use.names = FALSE)
-  for(i in seq_along(bad)) {
-    if(bad[i] %in% mod_names$param) {
-      bad[i] <- paste(bad[i], "(parameter)")
-    }
-    if(bad[i] %in% mod_names$init) {
-      bad[i] <- paste(bad[i], "(compartment)")
-    }
-    if(bad[i] %in% mod_names$omega_labels) {
-      bad[i] <- paste(bad[i], "(eta label)")
-    }
-    if(bad[i] %in% mod_names$sigma_labels) {
-      bad[i] <- paste(bad[i], "(eps label)")
-    }
-  }
-  if(length(bad) > 1) {
-    msg <- "Reserved symbols cannot be used as model names:"
-    foot <- "These symbols became reserved because they were detected in C++ model code."
-  } else {
-    msg <- "Reserved symbol cannot be used as model name:"
-    foot <- "This symbol became reserved because it was detected in C++ model code."
-  }
-  names(bad) <- rep("x", length(bad))
-  abort(c(msg, bad), footer = foot)
-}
-
 protomod <- list(model=character(0),
                  modfile = character(0),
                  package=character(0),

--- a/R/modspec.R
+++ b/R/modspec.R
@@ -569,24 +569,6 @@ move_global2 <- function(spec, env, build) {
   spec
 }
 
-find_cpp_dot <- function(spec, env) {
-  to_check <- c("PREAMBLE", "MAIN", "PRED", "ODE", "EVENT", "TABLE", "GLOBAL")
-  x <- spec[names(spec) %in% to_check]
-  x <- unlist(x, use.names = FALSE)
-  # Narrow the search first; 10x speed up when searching for `pattern`
-  x <- x[grepl(".", x, fixed = TRUE)]
-  if(!length(x)) return(NULL)
-  pattern <- "\\b[a-zA-Z][a-zA-Z0-9_]*\\.[a-zA-Z][a-zA-Z0-9_]*\\b"
-  m <- gregexpr(pattern, x, perl = TRUE)
-  mm <- regmatches(x, m)
-  mm <- unlist(mm, use.names = FALSE)
-  if(!length(mm)) return(NULL)
-  cpp_dot <- strsplit(mm, ".", fixed = TRUE)
-  cpp_dot <- unlist(cpp_dot, use.names = FALSE)
-  env[["cpp_dot"]] <- unique(cpp_dot)
-  return(NULL)
-}
-
 # nocov start
 get_rcpp_vars <- function(y) {
   m <- gregexpr(move_global_rcpp_re_find,y,perl=TRUE)
@@ -786,7 +768,6 @@ parse_env <- function(spec, incoming_names = names(spec),build,ENV=new.env()) {
   mread.env$blocks <- names(spec)
   mread.env$incoming_names <- incoming_names
   mread.env$capture_etas <- NULL
-  mread.env$cpp_dot <- NULL
   mread.env$check_modeled_infusions <- TRUE
   mread.env$convert_pow <-
     !isFALSE(ENV[["MRGSOLVE_CONVERT_POW"]])

--- a/R/mread.R
+++ b/R/mread.R
@@ -413,9 +413,6 @@ mread <- function(model, project = getOption("mrgsolve.project", getwd()),
   # Check mod ----
   check_pkmodel(x, subr, spec)
   check_globals(mread.env[["move_global"]], Cmt(x))
-  # Find cpp objects with dot syntax; saved to mread.env$cpp_dot ----
-  find_cpp_dot(spec, mread.env)
-  check_cpp_dot(mread.env, x)
   
   # This must come after nm-vars is processed; nmv is NULL if 
   # not using nm-vars

--- a/tests/testthat/test-modspec.R
+++ b/tests/testthat/test-modspec.R
@@ -650,66 +650,7 @@ test_that("INPUT block", {
   expect_equal(tagdf$tag, rep("input", 2))
 })
 
-test_that("Reserve names in cpp dot gh-1159", {
-  # clash with parameter
-  code <- '
-  $param cl = 2, v = 2, d = 5
-  $cmt a b c
-  $main 
-  foo.d = 2;
-  '  
-  expect_error(
-    mcode("cpp-dot-1", code, compile = FALSE), 
-    regexp = "d (parameter)", 
-    fixed = TRUE
-  )
-  
-  # clash with compartment
-  code <- '
-  $param cl = 2, v = 2
-  $cmt a b c
-  $ode 
-  foo.a = 2;
-  '
-  
-  expect_error(
-    mcode("cpp-dot-2", code, compile = FALSE), 
-    regexp = "a (compartment)", 
-    fixed = TRUE
-  )
-  
-  # clash with omega
-  code <- '
-  $param cl = 2, v = 2
-  $cmt a b c
-  $omega @labels foo
-  1
-  $table 
-  foo.e = 2;
-  '
-  
-  expect_error(
-    mcode("cpp-dot-3", code, compile = FALSE), 
-    regexp = "foo (eta label)", 
-    fixed = TRUE
-  )
-  
-  # clash with sigma
-  code <- '
-  $param cl = 2, v = 2
-  $cmt a b c
-  $sigma @labels bar
-  1
-  $preamble
-  foo.bar = 2;
-  '
-  
-  expect_error(
-    mcode("cpp-dot-4", code, compile = FALSE), 
-    regexp = "bar (eps label)", 
-    fixed = TRUE
-  )
-  
+test_that("Reserve names in cpp dot gh-1159", {  
   # some names are checked in the object
   code <- '
   $param rate = 2
@@ -722,42 +663,6 @@ test_that("Reserve names in cpp dot gh-1159", {
     regexp = "Reserved words in model names: rate", 
     fixed = TRUE
   )
-})
-
-test_that("Skip cpp dot check gh-1159", {
-  temp <- '$param {param}\n$main\n{main};\n$env MRGSOLVE_CPP_DOT_SKIP="foo"'
-  
-  param <- "cl = 1, foo = 3, vc = 5"
-  main <- "double b = 5;\nfoo.bar = true;"
-  table <- "true;"
-  code <- glue::glue(temp)
-  
-  expect_s4_class(mcode("cpp-dot-skip-1", code, compile = FALSE), "mrgmod")
-  
-  temp <- '$param {param}\n$main\n{main};\n$env MRGSOLVE_CPP_DOT_SKIP="foo"'
-  param <- "cl = 1, foo = 3, bar = 2, vc = 5"
-  main <- "double b = 5;\nfoo.bar = true;"
-  table <- "true;"
-  code <- glue::glue(temp)
-  
-  expect_error(
-    mcode("cpp-dot-skip-2", code, compile = FALSE), 
-    regexp = "bar (parameter)", 
-    fixed = TRUE
-  )
-  
-  check <- try(mcode("cpp-dot-skip-3", code, compile = FALSE), silent = TRUE)
-  
-  expect_match(check, "bar (parameter)", fixed = TRUE)
-  expect_no_match(check, "foo (parameter)", fixed = TRUE)
-  
-  temp <- '$param {param}\n$main\n{main};\n$env MRGSOLVE_CPP_DOT_SKIP="foo,bar"'
-  param <- "cl = 1, foo = 3, bar = 2, vc = 5"
-  main <- "double b = 5;\nfoo.bar = true;"
-  table <- "true;"
-  code <- glue::glue(temp)
-  
-  expect_s4_class(mcode("cpp-dot-skip-4", code, compile = FALSE), "mrgmod")
 })
 
 test_that("Invalid item in $SET generates error", {


### PR DESCRIPTION
In #1159 we started scanning the code for `object.member` syntax and generated an error if the `member` part matched up with a parameter, compartment or matrix label. 

With #1332, those model definitions have been refactored so this syntax should no longer be a problem. These checks have been removed in this PR. 

The first example now builds fine; the second should still error. 

``` r
library(mrgsolve)
#> 
#> Attaching package: 'mrgsolve'
#> The following object is masked from 'package:stats':
#> 
#>     filter


code <- '
$PARAM check_unique = 2
$MAIN 
mrg::evdata ev(0, 2);
ev.check_unique = true;
'

mod <- mcode("verify1", code)
#> Building verify1 ...
#> done.


code <- '
$PARAM check_unique = 2, amt = 2
$MAIN 
mrg::evdata ev(0, 2);
ev.amt = 100;
'

mod <- mcode("verify2", code)
#> Error in `validObject()`:
#> ! invalid class "mrgmod" object: Reserved words in model names: amt
```

<sup>Created on 2026-04-18 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>