### PR TITLE
Consolidate pow conversion to after all the other conversions

### DIFF
--- a/R/dsl-preprocess-addin.R
+++ b/R/dsl-preprocess-addin.R
@@ -1,3 +1,9 @@
+addin_warning <- function(w) {
+  msg <- c(x = w$message)
+  inform(msg)
+  invokeRestart("muffleWarning")
+}
+
 addin_run <- function(ctx, apply_fn) {
   sel <- ctx$selection[[1]]
   text <- sel$text
@@ -55,10 +61,14 @@ addin_add_semicolons <- function() {
 addin_apply_convert_pow <- function(lines) {
   if(has_block_markers(lines)) {
     result <- modelsplit(lines)
-    result <- convert_pow_spec(result)
+    withCallingHandlers({
+      result <- convert_pow_spec(result)
+    }, warning = addin_warning)
     result <- modelunsplit(result)
   } else {
-    result <- convert_pow(lines)
+    withCallingHandlers({
+      result <- convert_pow(lines)
+    }, warning = addin_warning)
   }
   paste(result, collapse = "\n")
 }

--- a/R/handle_spec_block.R
+++ b/R/handle_spec_block.R
@@ -21,12 +21,6 @@
 
 # UTILS ------------------------------------------------------------------------
 get_length <- function(what) sum(sapply(what,length))
-handle_convert_pow <- function(x, env, pos) {
-  if(env$convert_pow) {
-    x <- convert_pow(x, env$incoming_names[pos])  
-  }
-  x
-}
 handle_warn_int_div <- function(x, env, pos) {
   if(env$warn_int_div) {
     warn_int_div(x, env$incoming_names[pos])
@@ -573,7 +567,7 @@ handle_spec_block.specTABLE <- function(x, env, ...) {
          "   $TABLE double name = value;\n   $CAPTURE name")
   }
   handle_warn_int_div(x, env, pos)
-  handle_convert_pow(x, env, pos)
+
 }
 
 #' @export
@@ -584,7 +578,7 @@ handle_spec_block.specEVENT <- function(x, env, ...) {
   check_block_data(x, env, pos)
   
   handle_warn_int_div(x, env, pos)
-  handle_convert_pow(x, env, pos)
+
 }
 
 # NMXML --------------------------------
@@ -649,7 +643,7 @@ PRED <- function(x, env, pos, ...) {
     stop("$ODE not allowed when $PRED is used",call.=FALSE)  
   }
   handle_warn_int_div(x, env, pos)
-  handle_convert_pow(x, env, pos)
+
 }
 
 # INCLUDE ----------------------------------------------------------------------
@@ -1046,7 +1040,7 @@ handle_spec_block.specODE <- function(x, env, ...) {
   env[["audit_dadt"]] <- isTRUE(con[["audit"]])
   
   handle_warn_int_div(x, env, pos)
-  handle_convert_pow(x, env, pos)
+
 }
 
 # PREAMBLE --------------------------------------------------------------------
@@ -1057,7 +1051,7 @@ handle_spec_block.specPREAMBLE <- function(x, env, ...) {
   x <- dump_opts(x)
   
   handle_warn_int_div(x, env, pos)
-  handle_convert_pow(x, env, pos)
+
 }
 
 # MAIN -------------------------------------------------------------------------
@@ -1069,7 +1063,7 @@ handle_spec_block.specMAIN <- function(x,env,...) {
   env$check_modeled_infusions <- isTRUE(x$check_modeled_infusions)
   
   handle_warn_int_div(x$x, env, pos)
-  handle_convert_pow(x$x, env, pos)
+
 }
 
 # BLOCK ------------------------------------------------------------------------

--- a/R/modspec.R
+++ b/R/modspec.R
@@ -530,10 +530,11 @@ convert_fort_if_spec <- function(x) {
 }
 
 # Apply ** to pow conversion to the right blocks; used in addin
-convert_pow_spec <- function(x) {
+convert_pow_spec <- function(x, block_names = names(x)) {
   to_convert <- which(names(x) %in% GLOBALS$PRE_PROC_BLOCKS)
+  to_convert_names <- block_names[to_convert]
   for(i in to_convert) {
-    x[[i]] <- convert_pow(x[[i]], names(x)[i])
+    x[[i]] <- convert_pow(x[[i]], to_convert_names[i])
   }
   x
 }

--- a/R/mread.R
+++ b/R/mread.R
@@ -457,8 +457,10 @@ mread <- function(model, project = getOption("mrgsolve.project", getwd()),
   })
 
   # Group rdefs for output; see compile.R
-  rd <- arrange_rdefs(rd) 
-  
+  rd <- arrange_rdefs(rd)
+
+  if(mread.env$convert_pow) spec <- convert_pow_spec(spec)
+
   ## Collect all code to be written to the different blocks
   global_code <- c(
     spec[["GLOBAL"]]  

--- a/R/mread.R
+++ b/R/mread.R
@@ -459,7 +459,10 @@ mread <- function(model, project = getOption("mrgsolve.project", getwd()),
   # Group rdefs for output; see compile.R
   rd <- arrange_rdefs(rd)
 
-  if(mread.env$convert_pow) spec <- convert_pow_spec(spec)
+  # Convert pow just before writing the file
+  if(mread.env$convert_pow) {
+    spec <- convert_pow_spec(spec, mread.env$incoming_names)
+  }
 
   ## Collect all code to be written to the different blocks
   global_code <- c(

--- a/inst/maintenance/unit/test-addin.R
+++ b/inst/maintenance/unit/test-addin.R
@@ -74,10 +74,3 @@ test_that("Addin: convert nonmem converts IF/ELSE", {
   expect_match(out, "Z = 5;", fixed = TRUE)
   expect_match(out, "else if(WT == 80) {", fixed = TRUE)
 })
-
-test_that("convert_pow handles Fortran /= (not-equal) in condition", {
-  # /= is the Fortran not-equal operator; find_assign_eq must not treat it as
-  # an assignment so the RHS pow conversion can proceed
-  out <- mrgsolve:::convert_pow("IF(X/=3) Y=1.3**5")
-  expect_equal(out, "IF(X/=3) Y = pow(1.3, 5)")
-})


### PR DESCRIPTION
@kyleam What do you think about this refactor?

In testing the addin stuff, I realized that `convert_pow()` gets called early on; so it could have to deal with more complicated code (like NONMEM code that will eventually get converted). 

This PR, I pull `convert_pow()` from the handler functions and do this conversion last, making sure it has the simplest, most uniform code to deal with. 

In terms of the plugin, that would have to be a potential limitation - that it's possible that `convert_pow()` could choke on some NONMEM constructs if Convert NM isn't called first. 

NB `convert_pow()` currently won't parse your example `IF(X/=3) Y=1.3**5`; I played with an update to `convert_pow()` to handle this but I started thinking it's just doing more than we need. With this refactor, it would let `convert_pow()` work when called under the hood because we're controlling the order, calling it last. If it crumps with the addin because the order wasn't right, I'd just say run NM addin first. And the long term goal with this is to write a (partial) converter, that would look to (1) generate a starter model file from an existing nonmem control stream with option to (2) take an existing mrgsolve model and update with the relevant model blocks from nonmem (e.g., $PK, $ODE, etc ... the stuff that actually changes as model development proceeds); so long term, we're going to control the conversion order. 