### PR TITLE
Release/2.0.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: mrgsolve
 Title: Simulate from ODE-Based Models
-Version: 1.8.0.9002
+Version: 2.0.0
 Authors@R: 
     c(person(given = "Kyle T", family = "Baron",
              role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# mrgsolve (development version)
+# mrgsolve 2.0.0
 
 - Closed-form three-compartment linear models with or without depot compartments
   can now be implemented via `$PKMODEL` (#1345). 

--- a/NEWS.md
+++ b/NEWS.md
@@ -56,7 +56,7 @@
   - `convert_semicolons()` inserts missing trailing semicolons on assignment
     statements.
   - RStudio addins are provided to allow conversion of certain NONMEM source 
-    blocks code to mrgsolve format in the RStudio editor window.
+    code blocks to mrgsolve format in the RStudio editor window.
 
 - Closed-form three-compartment linear models with or without depot compartments
   can now be implemented via `$PKMODEL` (#1345).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,16 +1,93 @@
 # mrgsolve 2.0.0
 
+## Breaking Changes
+
+- `data_set()` and `idata_set()` no longer accept `.subset`, `.select`,
+  `object`, or `need` arguments. These arguments allowed filtering and
+  column selection inside the call; that processing should now be done on the
+  data frame before passing it to `data_set()` or `idata_set()`.  (#1374)
+
+- The `n` argument to `simeta()` and `simeps()` has been discouraged for a
+  while and is now removed. Calling `simeta(n)` or `simeps(n)` to resimulate 
+  a single ETA or EPS value is no longer supported. Use `simeta()` or `simeps()` 
+  (no argument) to resimulate all values. (#1373)
+
+- `knobs()`, `wf_sweep()`, and `render()` have been removed. These
+  functions were previously deprecated. (#1369)
+
+- The default value of `root` in `$NMXML` and `$NMEXT` has changed from
+  `"working"` to `"cppfile"`. The root directory for locating NONMEM
+  output files now defaults to the directory containing the model `.cpp` file
+  rather than the R working directory. Pass `root = "working"` to restore the
+  previous behavior; but users are _highly_ encouraged to use the new default.
+  (#1368)
+
+- `summarise.each()` is removed; it has not been practically reachable by the 
+  user for several years (#1352).
+
+- Several `modlib` model library models have had parameter and compartment
+  names standardized (#1361):
+  - The first extravascular compartment is now named `EV` (was `EV1`) in
+    `pk1cmt`, `pk2cmt`, `irm1`-`irm4`, and `emax`.
+  - The first absorption rate constant is now named `KA` (was `KA1`) in
+    models that previously used numbered names.
+  - Code that references these compartments or parameters by name (e.g.,
+    `init(mod, EV1 = 0)` or `param(mod, KA1 = 1)`) will need to be updated.
+  - We continue to discourage users from using these models in production 
+    code. 
+
+## New Features
+
 - Closed-form three-compartment linear models with or without depot compartments
-  can now be implemented via `$PKMODEL` (#1345). 
+  can now be implemented via `$PKMODEL` (#1345).
 
-- `$PKMODEL` gains an `advan` input for selecting 1, 2, or 3 compartment 
-  models with analytical solutions. When `advan` is specified, compartments 
-  with standard names are automatically registered if neither `$INIT` nor
-  `$CMT` are found in the model file and no compartments are registered 
-  at the time that `$PKMODEL` is processed (#1345).
+- `$PKMODEL` gains an `advan` input for selecting 1, 2, or 3 compartment
+  models with analytical solutions; for example, setting `advan` to 2, 4,
+  or 12 will give you 1, 2, or 3 compartment model in closed form with an 
+  depot compartment. When `advan` is specified, compartments with standard 
+  names are automatically registered if neither `$INIT` nor `$CMT` are 
+  found in the model file and no compartments are registered at the time 
+  that `$PKMODEL` is processed (#1345).
 
-- Two new `modlib` models, `pk3` and `pk3iv`, provide the corresponding 
+- Two new `modlib` models, `pk3` and `pk3iv`, provide the corresponding
   pre-coded model files (#1345).
+
+- Models can now use `a ** b` syntax to represent `pow(a, b)`; this syntax is
+  always available, without need to invoke a plugin (#1360).
+
+- With the `nm-vars` plugin, mrgsolve now recognizes NONMEM / Fortran 
+  `IF / ELSE / THEN` statements; this code can be left in your model and 
+  mrgsolve will convert to appropriate C++ under the hood (#1360).
+
+- `ERR(n)` is now recognized as an alias for `EPS(n)` when using the `nm-vars`
+  plugin (#1367).
+
+- New DSL preprocessing functions convert NONMEM/Fortran model code to C++
+  syntax (#1360, #1362, #1366):
+  - `convert_pow()` converts Fortran `**` exponentiation to `pow()`.
+  - `convert_fort_if()` converts Fortran `IF/THEN/ELSE/END IF` blocks to C++
+    `if/else` syntax.
+  - `convert_semicolons()` inserts missing trailing semicolons on assignment
+    statements.
+  - RStudio addins are provided for each conversion, as well as a combined
+    "Convert NM" addin that applies all three in the correct order.
+
+- `mrgx::assign()` is now available in the `mrgx` plugin; this is a convenience 
+  function to help you get R objects from your model code back to R when the 
+  simulation finishes (#1353).
+
+- The `plot()` method for `mrgsims` objects gains a `fixy` argument to fix the
+  y-axis limits across panels in the plot (#1349).
+
+- Users can now find `plot()` method documentation through `?plot` (#1349). 
+
+- `env_get()` refactored to allow access of R objects inside the model 
+  environment similar to `base::get()`; `env_get_obj()` is an alias to `env_get()`, 
+  analagous to `env_get_env()`(#1355).
+
+## Bugs Fixed
+- Fixed a bug where the model row counter was not correct when a simulation 
+  was preformed with only an idata set (#1351).
 
 # mrgsolve 1.8.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@
 - `data_set()` and `idata_set()` no longer accept `.subset`, `.select`,
   `object`, or `need` arguments. These arguments allowed filtering and
   column selection inside the call; that processing should now be done on the
-  data frame before passing it to `data_set()` or `idata_set()`.  (#1374)
+  data frame before passing it to `data_set()` or `idata_set()`. (#1374)
 
 - The `n` argument to `simeta()` and `simeps()` has been discouraged for a
   while and is now removed. Calling `simeta(n)` or `simeps(n)` to resimulate 
@@ -38,20 +38,6 @@
 
 ## New Features
 
-- Closed-form three-compartment linear models with or without depot compartments
-  can now be implemented via `$PKMODEL` (#1345).
-
-- `$PKMODEL` gains an `advan` input for selecting 1, 2, or 3 compartment
-  models with analytical solutions; for example, setting `advan` to 2, 4,
-  or 12 will give you 1, 2, or 3 compartment model in closed form with an 
-  depot compartment. When `advan` is specified, compartments with standard 
-  names are automatically registered if neither `$INIT` nor `$CMT` are 
-  found in the model file and no compartments are registered at the time 
-  that `$PKMODEL` is processed (#1345).
-
-- Two new `modlib` models, `pk3` and `pk3iv`, provide the corresponding
-  pre-coded model files (#1345).
-
 - Models can now use `a ** b` syntax to represent `pow(a, b)`; this syntax is
   always available, without need to invoke a plugin (#1360).
 
@@ -62,15 +48,29 @@
 - `ERR(n)` is now recognized as an alias for `EPS(n)` when using the `nm-vars`
   plugin (#1367).
 
-- New DSL preprocessing functions convert NONMEM/Fortran model code to C++
-  syntax (#1360, #1362, #1366):
+- New DSL preprocessing functions convert NONMEM/Fortran model code to 
+  mrgsolve / C++ syntax (#1360, #1362, #1366):
   - `convert_pow()` converts Fortran `**` exponentiation to `pow()`.
   - `convert_fort_if()` converts Fortran `IF/THEN/ELSE/END IF` blocks to C++
     `if/else` syntax.
   - `convert_semicolons()` inserts missing trailing semicolons on assignment
     statements.
-  - RStudio addins are provided for each conversion, as well as a combined
-    "Convert NM" addin that applies all three in the correct order.
+  - RStudio addins are provided to allow conversion of certain NONMEM source 
+    blocks code to mrgsolve format in the RStudio editor window.
+
+- Closed-form three-compartment linear models with or without depot compartments
+  can now be implemented via `$PKMODEL` (#1345).
+
+- `$PKMODEL` gains an `advan` input for selecting 1, 2, or 3 compartment
+  models with analytical solutions; for example, setting `advan` to 2, 4,
+  or 12 will give you 1, 2, or 3 compartment model in closed form with a
+  depot compartment. When `advan` is specified, compartments with standard 
+  names are automatically registered if neither `$INIT` nor `$CMT` are 
+  found in the model file and no compartments are registered at the time 
+  that `$PKMODEL` is processed (#1345).
+
+- Two new `modlib` models, `pk3` and `pk3iv`, provide the corresponding
+  pre-coded model files (#1345).
 
 - `mrgx::assign()` is now available in the `mrgx` plugin; this is a convenience 
   function to help you get R objects from your model code back to R when the 
@@ -83,11 +83,12 @@
 
 - `env_get()` refactored to allow access of R objects inside the model 
   environment similar to `base::get()`; `env_get_obj()` is an alias to `env_get()`, 
-  analagous to `env_get_env()`(#1355).
+  analogous to `env_get_env()` (#1355).
 
 ## Bugs Fixed
-- Fixed a bug where the model row counter was not correct when a simulation 
-  was preformed with only an idata set (#1351).
+
+- Fixed a bug where the model row counter was not correct when a simulation
+  was performed with only an idata set (#1351).
 
 # mrgsolve 1.8.0
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -57,7 +57,7 @@ convert_fort_if_impl <- function(code) {
 #' blank lines, lines already ending with \code{;}, lines ending with
 #' \code{\{} or \code{\}}, C/C++ comments (\code{//} or \code{/*}),
 #' preprocessor directives (\code{#}), lines containing block 
-#'  options (line starts wtih \code{@}), and lines ending with Fortran
+#'  options (line starts with \code{@}), and lines ending with Fortran
 #'  block-structure keywords.
 #'
 #' @param code Character vector of source lines.

--- a/man/convert_semicolons_impl.Rd
+++ b/man/convert_semicolons_impl.Rd
@@ -18,7 +18,7 @@ statement but does not already have one.  Lines that are left unchanged:
 blank lines, lines already ending with \code{;}, lines ending with
 \code{\{} or \code{\}}, C/C++ comments (\code{//} or \code{/*}),
 preprocessor directives (\code{#}), lines containing block 
- options (line starts wtih \code{@}), and lines ending with Fortran
+ options (line starts with \code{@}), and lines ending with Fortran
  block-structure keywords.
 }
 \keyword{internal}

--- a/src/dsl-preprocess.cpp
+++ b/src/dsl-preprocess.cpp
@@ -922,7 +922,7 @@ Rcpp::CharacterVector convert_fort_if_impl(Rcpp::CharacterVector code) {
 //' blank lines, lines already ending with \code{;}, lines ending with
 //' \code{\{} or \code{\}}, C/C++ comments (\code{//} or \code{/*}),
 //' preprocessor directives (\code{#}), lines containing block 
-//'  options (line starts wtih \code{@}), and lines ending with Fortran
+//'  options (line starts with \code{@}), and lines ending with Fortran
 //'  block-structure keywords.
 //'
 //' @param code Character vector of source lines.


### PR DESCRIPTION
# mrgsolve 2.0.0

## Breaking Changes

- `data_set()` and `idata_set()` no longer accept `.subset`, `.select`,
  `object`, or `need` arguments. These arguments allowed filtering and
  column selection inside the call; that processing should now be done on the
  data frame before passing it to `data_set()` or `idata_set()`. (#1374)

- The `n` argument to `simeta()` and `simeps()` has been discouraged for a
  while and is now removed. Calling `simeta(n)` or `simeps(n)` to resimulate 
  a single ETA or EPS value is no longer supported. Use `simeta()` or `simeps()` 
  (no argument) to resimulate all values. (#1373)

- `knobs()`, `wf_sweep()`, and `render()` have been removed. These
  functions were previously deprecated. (#1369)

- The default value of `root` in `$NMXML` and `$NMEXT` has changed from
  `"working"` to `"cppfile"`. The root directory for locating NONMEM
  output files now defaults to the directory containing the model `.cpp` file
  rather than the R working directory. Pass `root = "working"` to restore the
  previous behavior; but users are _highly_ encouraged to use the new default.
  (#1368)

- `summarise.each()` is removed; it has not been practically reachable by the 
  user for several years (#1352).

- Several `modlib` model library models have had parameter and compartment
  names standardized (#1361):
  - The first extravascular compartment is now named `EV` (was `EV1`) in
    `pk1cmt`, `pk2cmt`, `irm1`-`irm4`, and `emax`.
  - The first absorption rate constant is now named `KA` (was `KA1`) in
    models that previously used numbered names.
  - Code that references these compartments or parameters by name (e.g.,
    `init(mod, EV1 = 0)` or `param(mod, KA1 = 1)`) will need to be updated.
  - We continue to discourage users from using these models in production 
    code. 

## New Features

- Models can now use `a ** b` syntax to represent `pow(a, b)`; this syntax is
  always available, without need to invoke a plugin (#1360).

- With the `nm-vars` plugin, mrgsolve now recognizes NONMEM / Fortran 
  `IF / ELSE / THEN` statements; this code can be left in your model and 
  mrgsolve will convert to appropriate C++ under the hood (#1360).

- `ERR(n)` is now recognized as an alias for `EPS(n)` when using the `nm-vars`
  plugin (#1367).

- New DSL preprocessing functions convert NONMEM/Fortran model code to 
  mrgsolve / C++ syntax (#1360, #1362, #1366):
  - `convert_pow()` converts Fortran `**` exponentiation to `pow()`.
  - `convert_fort_if()` converts Fortran `IF/THEN/ELSE/END IF` blocks to C++
    `if/else` syntax.
  - `convert_semicolons()` inserts missing trailing semicolons on assignment
    statements.
  - RStudio addins are provided to allow conversion of certain NONMEM source 
    code blocks to mrgsolve format in the RStudio editor window.

- Closed-form three-compartment linear models with or without depot compartments
  can now be implemented via `$PKMODEL` (#1345).

- `$PKMODEL` gains an `advan` input for selecting 1, 2, or 3 compartment
  models with analytical solutions; for example, setting `advan` to 2, 4,
  or 12 will give you 1, 2, or 3 compartment model in closed form with a
  depot compartment. When `advan` is specified, compartments with standard 
  names are automatically registered if neither `$INIT` nor `$CMT` are 
  found in the model file and no compartments are registered at the time 
  that `$PKMODEL` is processed (#1345).

- Two new `modlib` models, `pk3` and `pk3iv`, provide the corresponding
  pre-coded model files (#1345).

- `mrgx::assign()` is now available in the `mrgx` plugin; this is a convenience 
  function to help you get R objects from your model code back to R when the 
  simulation finishes (#1353).

- The `plot()` method for `mrgsims` objects gains a `fixy` argument to fix the
  y-axis limits across panels in the plot (#1349).

- Users can now find `plot()` method documentation through `?plot` (#1349). 

- `env_get()` refactored to allow access of R objects inside the model 
  environment similar to `base::get()`; `env_get_obj()` is an alias to `env_get()`, 
  analogous to `env_get_env()` (#1355).

## Bugs Fixed

- Fixed a bug where the model row counter was not correct when a simulation
  was performed with only an idata set (#1351).