### PR TITLE
Fix/mread pow convert

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: mrgsolve
 Title: Simulate from ODE-Based Models
-Version: 2.0.0
+Version: 2.0.0.9000
 Authors@R: 
     c(person(given = "Kyle T", family = "Baron",
              role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# mrgsolve (development version)
+
 # mrgsolve 2.0.0
 
 ## Breaking Changes

--- a/R/modspec.R
+++ b/R/modspec.R
@@ -505,11 +505,12 @@ convert_fort_if_spec <- function(x) {
 }
 
 # Apply ** to pow conversion to the right blocks; used in addin
+# Also used in mread, where block_names is the original incoming 
+# block name vector; we don't need to convert any spec position beyond
+# what was in the original spec list
 convert_pow_spec <- function(x, block_names = names(x)) {
-  if(length(x) != length(block_names)) {
-    block_names <- names(x)
-  }
   to_convert <- which(names(x) %in% GLOBALS$PRE_PROC_BLOCKS)
+  to_convert <- to_convert[to_convert <= length(block_names)]
   for(i in to_convert) {
     if(!length(x[[i]])) next
     x[[i]] <- convert_pow(x[[i]], block_names[i])

--- a/R/modspec.R
+++ b/R/modspec.R
@@ -504,10 +504,13 @@ convert_fort_if_spec <- function(x) {
 
 # Apply ** to pow conversion to the right blocks; used in addin
 convert_pow_spec <- function(x, block_names = names(x)) {
+  if(length(x) != length(block_names)) {
+    block_names <- names(x)
+  }
   to_convert <- which(names(x) %in% GLOBALS$PRE_PROC_BLOCKS)
-  to_convert_names <- block_names[to_convert]
   for(i in to_convert) {
-    x[[i]] <- convert_pow(x[[i]], to_convert_names[i])
+    if(!length(x[[i]])) next
+    x[[i]] <- convert_pow(x[[i]], block_names[i])
   }
   x
 }

--- a/R/modspec.R
+++ b/R/modspec.R
@@ -486,9 +486,11 @@ modelunsplit <- function(x) {
 
 # Apply convert_semicolons to the right blocks; used in addin
 convert_semicolons_spec <- function(x) {
-  to_convert <- which(names(x) %in% GLOBALS$PRE_PROC_BLOCKS)
+  to_convert <- which(
+    names(x) %in% GLOBALS$PRE_PROC_BLOCKS &
+    lengths(x) > 0
+  )
   for(i in to_convert) {
-    if(!length(x[[i]])) next
     x[[i]] <- convert_semicolons(x[[i]])
   }
   x
@@ -496,9 +498,11 @@ convert_semicolons_spec <- function(x) {
 
 # Apply fortran if/else conversion to the right blocks; used in addin
 convert_fort_if_spec <- function(x) {
-  to_convert <- which(names(x) %in% GLOBALS$PRE_PROC_BLOCKS)
+  to_convert <- which(
+    names(x) %in% GLOBALS$PRE_PROC_BLOCKS &
+    lengths(x) > 0
+  )
   for(i in to_convert) {
-    if(!length(x[[i]])) next
     x[[i]] <- convert_fort_if(x[[i]])
   }
   x
@@ -509,10 +513,12 @@ convert_fort_if_spec <- function(x) {
 # block name vector; we don't need to convert any spec position beyond
 # what was in the original spec list
 convert_pow_spec <- function(x, block_names = names(x)) {
-  to_convert <- which(names(x) %in% GLOBALS$PRE_PROC_BLOCKS)
+  to_convert <- which(
+    names(x) %in% GLOBALS$PRE_PROC_BLOCKS &
+    lengths(x) > 0
+  )
   to_convert <- to_convert[to_convert <= length(block_names)]
   for(i in to_convert) {
-    if(!length(x[[i]])) next
     x[[i]] <- convert_pow(x[[i]], block_names[i])
   }
   x

--- a/R/modspec.R
+++ b/R/modspec.R
@@ -488,6 +488,7 @@ modelunsplit <- function(x) {
 convert_semicolons_spec <- function(x) {
   to_convert <- which(names(x) %in% GLOBALS$PRE_PROC_BLOCKS)
   for(i in to_convert) {
+    if(!length(x[[i]])) next
     x[[i]] <- convert_semicolons(x[[i]])
   }
   x
@@ -497,6 +498,7 @@ convert_semicolons_spec <- function(x) {
 convert_fort_if_spec <- function(x) {
   to_convert <- which(names(x) %in% GLOBALS$PRE_PROC_BLOCKS)
   for(i in to_convert) {
+    if(!length(x[[i]])) next
     x[[i]] <- convert_fort_if(x[[i]])
   }
   x

--- a/R/mread.R
+++ b/R/mread.R
@@ -182,7 +182,7 @@ mread <- function(model, project = getOption("mrgsolve.project", getwd()),
   } else {
     spec  <- modelparse(readLines(build[["modfile"]], warn = FALSE))
   }
-  
+
   ## Block name aliases
   incoming_block_names <- names(spec)
   names(spec) <- toupper(names(spec))
@@ -419,6 +419,8 @@ mread <- function(model, project = getOption("mrgsolve.project", getwd()),
   # TODO: harmonize with other audit process
   if(!has_name("ODE", spec)) {
     spec[["ODE"]] <- "DXDTZERO();"
+    incoming_block_names <- c(incoming_block_names, "ODE")
+    mread.env$incoming_names <- c(mread.env$incoming_names, "ODE")
   } else {
     spec[["ODE"]] <- c(spec[["ODE"]], ode)
     audit_spec(x, spec, nmv, mread.env, warn = warn)

--- a/R/mread.R
+++ b/R/mread.R
@@ -419,8 +419,6 @@ mread <- function(model, project = getOption("mrgsolve.project", getwd()),
   # TODO: harmonize with other audit process
   if(!has_name("ODE", spec)) {
     spec[["ODE"]] <- "DXDTZERO();"
-    incoming_block_names <- c(incoming_block_names, "ODE")
-    mread.env$incoming_names <- c(mread.env$incoming_names, "ODE")
   } else {
     spec[["ODE"]] <- c(spec[["ODE"]], ode)
     audit_spec(x, spec, nmv, mread.env, warn = warn)
@@ -459,7 +457,7 @@ mread <- function(model, project = getOption("mrgsolve.project", getwd()),
 
   # Convert pow just before writing the file
   if(mread.env$convert_pow) {
-    spec <- convert_pow_spec(spec, mread.env$incoming_names)
+    spec <- convert_pow_spec(spec, incoming_block_names)
   }
 
   ## Collect all code to be written to the different blocks

--- a/tests/testthat/test-modspec.R
+++ b/tests/testthat/test-modspec.R
@@ -1026,6 +1026,30 @@ test_that("convert_pow handles ** in if() condition", {
   )
 })
 
+test_that("convert_pow reports the right block name on warning", {
+  convert_pow_warn_ <- '
+  $PARAM CL = 1
+  
+  $error double foo = CL ** b[2];
+  
+  $MAIN 
+  '
+  expect_warning(
+    mcode("convert_pow_warn_", convert_pow_warn_, compile = FALSE), 
+    "Could not convert ** in $error block", 
+    fixed = TRUE
+  )
+})
+
+test_that("convert_pow mapbayr test with missing main", {
+  mod0bis <- mcode("mod0bis",
+                "$CMT GUT CENT
+                $MAIN
+                ", compile = FALSE)
+
+  expect_is(mod0bis, "mrgmod")
+})
+
 test_that("environment variable suppresses convert pow", {
   code <- '
   $ENV MRGSOLVE_CONVERT_POW <- TRUE


### PR DESCRIPTION
@kyleam Found the regression below in mapbayr after 2.0.0 release. 

The problem comes with the call to `convert_pow_spec()` which had late move to the main `mread()` flow, right before writing out the cpp file. 

1. We wanted to pass in the "original" block names to use in warning messages when certain code can't be converted; this came from `incoming_block_names`, which could longer than the length of `spec` when the names were captured
2. We have to convert `$MAIN` in the mapbayr example, that could be `NULL` (no code); while `convert_pow()` can handle `NULL`, assigning `x[[i]] <- NULL` blows that position away causing problems when processing subsequent blocks. 

- `convert_pow_spec()` only checks when length > 0
- I added this as defensive move in the other `convert_*_spec()` functions (however, these aren't called in the same context and I don't expect this same issue)
- `convert_pow_spec()` doesn't check blocks beyond the length of `block_names` with the idea that these blocks were added by `mread()` as shim and don't need to be converted.


```r
> 
> ── Error ('test-read_mrgsolve_model.R:71:3'): adm_0_cmt works ──────────────────
> <subscriptOutOfBoundsError/error/condition>
> Error in `x[[i]]`: subscript out of bounds
> Backtrace:
>     ▆
>  1. └─mrgsolve::mcode(...) at test-read_mrgsolve_model.R:71:3
>  2.   └─mrgsolve::mread(...) at mrgsolve/R/mcode.R:57:3
>  3.     └─mrgsolve:::convert_pow_spec(spec, mread.env$incoming_names) at mrgsolve/R/mread.R:460:5
>  4.       └─mrgsolve::convert_pow(x[[i]], to_convert_names[i]) at mrgsolve/R/modspec.R:510:5
> ```
> 
> check output
> ```
> ── R CMD check results ───────────────────────────────────── mapbayr 0.10.2 ────
> Duration: 1m 19.3s
> 
> ❯ checking tests ...
>   See below...
> 
> ── Test failures ───────────────────────────────────────────────── testthat ────
> 
> > library(testthat)
> > library(mapbayr)
> 
> Attaching package: 'mapbayr'
> 
> The following object is masked from 'package:stats':
> 
>     filter
> 
> > 
> > test_check("mapbayr")
> 
> 
> [ FAIL 1 | WARN 0 | SKIP 4 | PASS 717 ]
> 
> ══ Skipped tests (4) ═══════════════════════════════════════════════════════════
> • On CRAN (4): 'test-progress.R:5:3', 'test-reset-conditions.R:3:3',
>   'test-reset-conditions.R:93:3', 'test-reset-conditions.R:175:3'
> 
> ══ Failed tests ════════════════════════════════════════════════════════════════
> ── Error ('test-read_mrgsolve_model.R:71:3'): adm_0_cmt works ──────────────────
> <subscriptOutOfBoundsError/error/condition>
> Error in `x[[i]]`: subscript out of bounds
> Backtrace:
>     ▆
>  1. └─mrgsolve::mcode(...) at test-read_mrgsolve_model.R:71:3
>  2.   └─mrgsolve::mread(...) at mrgsolve/R/mcode.R:57:3
>  3.     └─mrgsolve:::convert_pow_spec(spec, mread.env$incoming_names) at mrgsolve/R/mread.R:460:5
>  4.       └─mrgsolve::convert_pow(x[[i]], to_convert_names[i]) at mrgsolve/R/modspec.R:510:5
> 
> [ FAIL 1 | WARN 0 | SKIP 4 | PASS 717 ]
> Error: Test failures
> Execution halted
> 
> 1 error ✖ | 0 warnings ✔ | 0 notes ✔
> ```
> 
> https://github.com/FelicienLL/mapbayr/blob/3df5f6afeed675bc751038b2071e730109cbdf64/tests/testthat/test-read_mrgsolve_model.R#L71-L74
> 
> ```
>   #$MAIN but empty
>   mod0bis <- mcode("mod0bis",
>                 "$CMT GUT CENT
>                 $MAIN
>                 ", compile = FALSE)
> ```
> 
> I'm hoping we can let this through as "not a functional issue".
> 
> The other option is to pin mrgsolve and wait for an update on either the mrgsolve or mapbayr side.
> 
> cc: @kyleb
```