### PR TITLE
Rcpp helper to set names in place

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: mrgsolve
 Title: Simulate from ODE-Based Models
-Version: 2.0.0.9000
+Version: 2.0.0.9001
 Authors@R: 
     c(person(given = "Kyle T", family = "Baron",
              role = c("aut", "cre"),

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -95,6 +95,10 @@ EXPAND_OBSERVATIONS <- function(data, times, to_copy, next_pos) {
     .Call(`_mrgsolve_EXPAND_OBSERVATIONS`, data, times, to_copy, next_pos)
 }
 
+set_names_inplace <- function(x, nm) {
+    invisible(.Call(`_mrgsolve_set_names_inplace`, x, nm))
+}
+
 TOUCH_FUNS <- function(funs, mod) {
     .Call(`_mrgsolve_TOUCH_FUNS`, funs, mod)
 }

--- a/R/mrgsim_q.R
+++ b/R/mrgsim_q.R
@@ -163,7 +163,7 @@ mrgsim_q <- function(x,
     PACKAGE = "mrgsolve"
   )[["data"]]
   
-  names(out) <- c("ID", tcol, x@cmtL, x@capL)
+  set_names_inplace(out, c("ID", tcol, x@cmtL, x@capL))
   
   if(output=="df") {
     return(out)  

--- a/R/mrgsolve.R
+++ b/R/mrgsolve.R
@@ -734,8 +734,8 @@ do_mrgsim <- function(x,
     cnames <- new_names
   }
   
-  names(out[["data"]]) <- cnames
-  
+  set_names_inplace(out[["data"]], cnames)
+
   if(do_recover_data || do_recover_idata) {
     if(do_recover_data) {
       if(!rename.recov$identical) {

--- a/R/mrgsolve.R
+++ b/R/mrgsolve.R
@@ -891,7 +891,7 @@ qsim <- function(x,
   
   if(tad) tcol <- c(tcol,"tad")
   
-  names(out[["data"]]) <- c("ID", tcol,  x@cmtL, x@capL)
+  set_names_inplace(out[["data"]], c("ID", tcol, x@cmtL, x@capL))
   
   if(output=="df") {
     return(out[["data"]])

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -156,6 +156,17 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// set_names_inplace
+void set_names_inplace(Rcpp::RObject x, Rcpp::CharacterVector nm);
+RcppExport SEXP _mrgsolve_set_names_inplace(SEXP xSEXP, SEXP nmSEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Rcpp::RObject >::type x(xSEXP);
+    Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type nm(nmSEXP);
+    set_names_inplace(x, nm);
+    return R_NilValue;
+END_RCPP
+}
 // TOUCH_FUNS
 Rcpp::List TOUCH_FUNS(const Rcpp::List& funs, const Rcpp::S4 mod);
 RcppExport SEXP _mrgsolve_TOUCH_FUNS(SEXP funsSEXP, SEXP modSEXP) {

--- a/src/mrgsolve.cpp
+++ b/src/mrgsolve.cpp
@@ -442,6 +442,11 @@ Rcpp::List EXPAND_OBSERVATIONS(
                             Rcpp::Named("index") = index);
 }
 
+// [[Rcpp::export]]
+void set_names_inplace(Rcpp::RObject x, Rcpp::CharacterVector nm) {
+  x.attr("names") = nm;
+}
+
 Rcpp::List mat2df(Rcpp::NumericMatrix const& x) {
   int n_rows = x.nrow();
   int n_cols = x.ncol();

--- a/src/mrgsolve_init.cpp
+++ b/src/mrgsolve_init.cpp
@@ -60,6 +60,7 @@ RcppExport SEXP _mrgsolve_convert_pow_impl(SEXP,SEXP);
 RcppExport SEXP _mrgsolve_warn_int_div_impl(SEXP,SEXP);
 RcppExport SEXP _mrgsolve_convert_fort_if_impl(SEXP);
 RcppExport SEXP _mrgsolve_convert_semicolons_impl(SEXP);
+RcppExport SEXP _mrgsolve_set_names_inplace(SEXP,SEXP);
 
 RcppExport void _model_housemodel_main__(MRGSOLVE_INIT_SIGNATURE);
 RcppExport void _model_housemodel_ode__(MRGSOLVE_ODE_SIGNATURE);
@@ -81,6 +82,7 @@ static R_CallMethodDef callEntryPoints[]  = {
   CALLDEF(_mrgsolve_warn_int_div_impl,2),
   CALLDEF(_mrgsolve_convert_fort_if_impl,1),
   CALLDEF(_mrgsolve_convert_semicolons_impl,1),
+  CALLDEF(_mrgsolve_set_names_inplace,2),
   CALLDEF(_model_housemodel_main__,MRGSOLVE_INIT_SIGNATURE_N),
   CALLDEF(_model_housemodel_ode__,MRGSOLVE_ODE_SIGNATURE_N),
   CALLDEF(_model_housemodel_table__,MRGSOLVE_TABLE_SIGNATURE_N),


### PR DESCRIPTION
Some profiling showed that simulated data have been getting copied when I've been setting output data frame names. This is a well known problem but we've been doing it for years now. 

This addition is a simple way to set attributes in place. 

