### PR TITLE
dsl-preprocess.cpp: fix compilation error under C++20

### DIFF
--- a/src/dsl-preprocess.cpp
+++ b/src/dsl-preprocess.cpp
@@ -170,7 +170,7 @@ struct Emitter : boost::static_visitor<std::string> {
 };
 
 inline std::string emit(const ast::Expr& e) {
-  return boost::apply_visitor(Emitter{}, e);
+  return boost::apply_visitor(Emitter(), e);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Building mrgsolve under R 4.6.0, which updated its default C++ standard from C++17 to C++20, fails with

    dsl-preprocess.cpp:173:39: error: ‘constexpr boost::static_visitor<R>::static_visitor()
    [with R = std::__cxx11::basic_string<char>]’ is protected within this context
      173 |   return boost::apply_visitor(Emitter{}, e);

Switch from list initialization to value initialization, which resolves the error and matches the style used for the apply_visitor calls in the Boost tutorial [*].

Fixes #1384

[*] https://www.boost.org/doc/libs/latest/doc/html/variant/tutorial.html