### PR TITLE
defer mat2df until return from DEVTRAN

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -95,12 +95,8 @@ EXPAND_OBSERVATIONS <- function(data, times, to_copy, next_pos) {
     .Call(`_mrgsolve_EXPAND_OBSERVATIONS`, data, times, to_copy, next_pos)
 }
 
-set_names_inplace <- function(x, nm) {
-    invisible(.Call(`_mrgsolve_set_names_inplace`, x, nm))
-}
-
-mat2df <- function(x) {
-    .Call(`_mrgsolve_mat2df`, x)
+mat2df <- function(x, nm) {
+    .Call(`_mrgsolve_mat2df`, x, nm)
 }
 
 TOUCH_FUNS <- function(funs, mod) {

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -99,6 +99,10 @@ set_names_inplace <- function(x, nm) {
     invisible(.Call(`_mrgsolve_set_names_inplace`, x, nm))
 }
 
+mat2df <- function(x) {
+    .Call(`_mrgsolve_mat2df`, x)
+}
+
 TOUCH_FUNS <- function(funs, mod) {
     .Call(`_mrgsolve_TOUCH_FUNS`, funs, mod)
 }

--- a/R/mrgsim_q.R
+++ b/R/mrgsim_q.R
@@ -163,8 +163,7 @@ mrgsim_q <- function(x,
     PACKAGE = "mrgsolve"
   )[["data"]]
   
-  out <- mat2df(out)
-  set_names_inplace(out, c("ID", tcol, x@cmtL, x@capL))
+  out <- mat2df(out, c("ID", tcol, x@cmtL, x@capL))
   
   if(output=="df") {
     return(out)  

--- a/R/mrgsim_q.R
+++ b/R/mrgsim_q.R
@@ -163,6 +163,7 @@ mrgsim_q <- function(x,
     PACKAGE = "mrgsolve"
   )[["data"]]
   
+  out <- mat2df(out)
   set_names_inplace(out, c("ID", tcol, x@cmtL, x@capL))
   
   if(output=="df") {

--- a/R/mrgsolve.R
+++ b/R/mrgsolve.R
@@ -734,6 +734,7 @@ do_mrgsim <- function(x,
     cnames <- new_names
   }
   
+  out[["data"]] <- mat2df(out[["data"]])
   set_names_inplace(out[["data"]], cnames)
 
   if(do_recover_data || do_recover_idata) {
@@ -891,8 +892,9 @@ qsim <- function(x,
   
   if(tad) tcol <- c(tcol,"tad")
   
+  out[["data"]] <- mat2df(out[["data"]])
   set_names_inplace(out[["data"]], c("ID", tcol, x@cmtL, x@capL))
-  
+
   if(output=="df") {
     return(out[["data"]])
   }

--- a/R/mrgsolve.R
+++ b/R/mrgsolve.R
@@ -734,8 +734,7 @@ do_mrgsim <- function(x,
     cnames <- new_names
   }
   
-  out[["data"]] <- mat2df(out[["data"]])
-  set_names_inplace(out[["data"]], cnames)
+  out[["data"]] <- mat2df(out[["data"]], cnames)
 
   if(do_recover_data || do_recover_idata) {
     if(do_recover_data) {
@@ -892,8 +891,7 @@ qsim <- function(x,
   
   if(tad) tcol <- c(tcol,"tad")
   
-  out[["data"]] <- mat2df(out[["data"]])
-  set_names_inplace(out[["data"]], c("ID", tcol, x@cmtL, x@capL))
+  out[["data"]] <- mat2df(out[["data"]], c("ID", tcol, x@cmtL, x@capL))
 
   if(output=="df") {
     return(out[["data"]])

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -156,25 +156,15 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// set_names_inplace
-void set_names_inplace(Rcpp::RObject x, Rcpp::CharacterVector nm);
-RcppExport SEXP _mrgsolve_set_names_inplace(SEXP xSEXP, SEXP nmSEXP) {
-BEGIN_RCPP
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< Rcpp::RObject >::type x(xSEXP);
-    Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type nm(nmSEXP);
-    set_names_inplace(x, nm);
-    return R_NilValue;
-END_RCPP
-}
 // mat2df
-Rcpp::List mat2df(Rcpp::NumericMatrix const& x);
-RcppExport SEXP _mrgsolve_mat2df(SEXP xSEXP) {
+Rcpp::List mat2df(Rcpp::NumericMatrix const& x, Rcpp::CharacterVector nm);
+RcppExport SEXP _mrgsolve_mat2df(SEXP xSEXP, SEXP nmSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::NumericMatrix const& >::type x(xSEXP);
-    rcpp_result_gen = Rcpp::wrap(mat2df(x));
+    Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type nm(nmSEXP);
+    rcpp_result_gen = Rcpp::wrap(mat2df(x, nm));
     return rcpp_result_gen;
 END_RCPP
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -167,6 +167,17 @@ BEGIN_RCPP
     return R_NilValue;
 END_RCPP
 }
+// mat2df
+Rcpp::List mat2df(Rcpp::NumericMatrix const& x);
+RcppExport SEXP _mrgsolve_mat2df(SEXP xSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Rcpp::NumericMatrix const& >::type x(xSEXP);
+    rcpp_result_gen = Rcpp::wrap(mat2df(x));
+    return rcpp_result_gen;
+END_RCPP
+}
 // TOUCH_FUNS
 Rcpp::List TOUCH_FUNS(const Rcpp::List& funs, const Rcpp::S4 mod);
 RcppExport SEXP _mrgsolve_TOUCH_FUNS(SEXP funsSEXP, SEXP modSEXP) {

--- a/src/devtran.cpp
+++ b/src/devtran.cpp
@@ -839,6 +839,6 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
   if((tscale != 1) && (tscale >= 0)) {
     ans(Rcpp::_,1) = ans(Rcpp::_,1) * tscale;
   }
-  return Rcpp::List::create(Rcpp::Named("data") = mat2df(ans),
+  return Rcpp::List::create(Rcpp::Named("data") = ans,
                             Rcpp::Named("trannames") = tran_names);
 }

--- a/src/mrgsolve.cpp
+++ b/src/mrgsolve.cpp
@@ -447,6 +447,7 @@ void set_names_inplace(Rcpp::RObject x, Rcpp::CharacterVector nm) {
   x.attr("names") = nm;
 }
 
+// [[Rcpp::export]]
 Rcpp::List mat2df(Rcpp::NumericMatrix const& x) {
   int n_rows = x.nrow();
   int n_cols = x.ncol();

--- a/src/mrgsolve.cpp
+++ b/src/mrgsolve.cpp
@@ -443,27 +443,23 @@ Rcpp::List EXPAND_OBSERVATIONS(
 }
 
 // [[Rcpp::export]]
-void set_names_inplace(Rcpp::RObject x, Rcpp::CharacterVector nm) {
-  x.attr("names") = nm;
-}
-
-// [[Rcpp::export]]
-Rcpp::List mat2df(Rcpp::NumericMatrix const& x) {
+Rcpp::List mat2df(Rcpp::NumericMatrix const& x, Rcpp::CharacterVector nm) {
   int n_rows = x.nrow();
   int n_cols = x.ncol();
-  
+
   Rcpp::List ret(n_cols);
-  
+
   for(int i = 0; i < n_cols; ++i) {
     ret[i] = Rcpp::NumericVector(
-      x.begin() + (size_t)i * n_rows, 
+      x.begin() + (size_t)i * n_rows,
       x.begin() + (size_t)(i + 1) * n_rows
     );
   }
-  
+
+  ret.attr("names") = nm;
   ret.attr("row.names") = Rcpp::IntegerVector::create(NA_INTEGER, -n_rows);
   ret.attr("class") = "data.frame";
-  
+
   return ret;
 }
 

--- a/src/mrgsolve_init.cpp
+++ b/src/mrgsolve_init.cpp
@@ -61,6 +61,7 @@ RcppExport SEXP _mrgsolve_warn_int_div_impl(SEXP,SEXP);
 RcppExport SEXP _mrgsolve_convert_fort_if_impl(SEXP);
 RcppExport SEXP _mrgsolve_convert_semicolons_impl(SEXP);
 RcppExport SEXP _mrgsolve_set_names_inplace(SEXP,SEXP);
+RcppExport SEXP _mrgsolve_mat2df(SEXP);
 
 RcppExport void _model_housemodel_main__(MRGSOLVE_INIT_SIGNATURE);
 RcppExport void _model_housemodel_ode__(MRGSOLVE_ODE_SIGNATURE);
@@ -83,6 +84,7 @@ static R_CallMethodDef callEntryPoints[]  = {
   CALLDEF(_mrgsolve_convert_fort_if_impl,1),
   CALLDEF(_mrgsolve_convert_semicolons_impl,1),
   CALLDEF(_mrgsolve_set_names_inplace,2),
+  CALLDEF(_mrgsolve_mat2df,1),
   CALLDEF(_model_housemodel_main__,MRGSOLVE_INIT_SIGNATURE_N),
   CALLDEF(_model_housemodel_ode__,MRGSOLVE_ODE_SIGNATURE_N),
   CALLDEF(_model_housemodel_table__,MRGSOLVE_TABLE_SIGNATURE_N),

--- a/src/mrgsolve_init.cpp
+++ b/src/mrgsolve_init.cpp
@@ -60,8 +60,7 @@ RcppExport SEXP _mrgsolve_convert_pow_impl(SEXP,SEXP);
 RcppExport SEXP _mrgsolve_warn_int_div_impl(SEXP,SEXP);
 RcppExport SEXP _mrgsolve_convert_fort_if_impl(SEXP);
 RcppExport SEXP _mrgsolve_convert_semicolons_impl(SEXP);
-RcppExport SEXP _mrgsolve_set_names_inplace(SEXP,SEXP);
-RcppExport SEXP _mrgsolve_mat2df(SEXP);
+RcppExport SEXP _mrgsolve_mat2df(SEXP,SEXP);
 
 RcppExport void _model_housemodel_main__(MRGSOLVE_INIT_SIGNATURE);
 RcppExport void _model_housemodel_ode__(MRGSOLVE_ODE_SIGNATURE);
@@ -83,8 +82,7 @@ static R_CallMethodDef callEntryPoints[]  = {
   CALLDEF(_mrgsolve_warn_int_div_impl,2),
   CALLDEF(_mrgsolve_convert_fort_if_impl,1),
   CALLDEF(_mrgsolve_convert_semicolons_impl,1),
-  CALLDEF(_mrgsolve_set_names_inplace,2),
-  CALLDEF(_mrgsolve_mat2df,1),
+  CALLDEF(_mrgsolve_mat2df,2),
   CALLDEF(_model_housemodel_main__,MRGSOLVE_INIT_SIGNATURE_N),
   CALLDEF(_model_housemodel_ode__,MRGSOLVE_ODE_SIGNATURE_N),
   CALLDEF(_model_housemodel_table__,MRGSOLVE_TABLE_SIGNATURE_N),


### PR DESCRIPTION
I've been thinking a lot about memory management and anything simple we could do to be less careless about copies and the like. 

This PR moves the `mat2df()` call to outside of `DEVTRAN()`. It is functionally no change in behavior. When we do `mat2df()`, there will be a 2x spike in memory utilization because we have both the matrix and the data frame going at the same time. I think this is unavoidable; and I'm convinced saving to matrix won't be beat and we will have to get to data frame to do anything useful with the data. But doing this in `DEVTRAN()`, all of the data records that were created for the simulation are still in scope so that 2x spike is on top of all of that. By moving the `mat2df()` call outside of `DEVTRAN()`, this will let all the data record objects get torn down prior to the 2x spike. 

QUESTION: should I update `mat2df()` to pass in data frame names so we can set them in the same call? or just leave it as is for now (with calls to both `mat2df()` and `set_names_inplace()`? 