### PR TITLE
Clear an individual's records when moving to i+1

### DIFF
--- a/src/devtran.cpp
+++ b/src/devtran.cpp
@@ -830,6 +830,7 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
       }
       tfrom = tto;
     }
+    a[i].clear();
   }
   if(digits > 0) {
     for(int i=req_start; i < ans.ncol(); ++i) {


### PR DESCRIPTION
Continuing on the responsible memory theme: 

This PR clears records in the deque from the ith subject once we go on to i+1. 