### PR TITLE
Fix bug where system didn't reset on EVID 4 with a lag time

### DIFF
--- a/inst/include/odeproblem.h
+++ b/inst/include/odeproblem.h
@@ -237,6 +237,7 @@ public:
   bool ss_fixed; ///< If true, then no warning is issued if SS not reached in ss_n doses
   int ss_n; ///< Max number of doses during SS advance before warning is issued
   bool ss_flag; ///< flag indicating when the system is advancing to SS
+  bool system_at_ss; ///< flag indicating the system was advanced to SS 
   std::vector<int> Ss_cmt; ///< vector of compartments to consider for SS
 
   bool check_modeled_infusions;

--- a/inst/maintenance/unit/test-z-alag-f.R
+++ b/inst/maintenance/unit/test-z-alag-f.R
@@ -48,11 +48,29 @@ mod <-
   carry_out(evid) %>% 
   update(end=2)
 
-test_that("ss=1 and F_CMT =0 issue-497", {
+test_that("ss=1 and F_CMT=0 issue-497", {
   mod <- param(mod, F1 = 0)
   out <- mrgsim(mod, ev(amt = 100, ii = 24, ss=1), delta=1,end=6)
   expect_is(out, "mrgsims")
   expect_true(all(out$CENT==0))
+})
+
+test_that("EVID=4 with lag time still resets", {
+  mod <- param(mod, ALAG1 = 0.25)
+  e <- ev_seq(
+    ev(amt = 100, ii = 12, addl = 3), 
+    wait = 24, 
+    ev(amt = 50, evid = 4), 
+    wait = 24,
+    ev(amt = 100, ii = 12, addl = 3)
+  )
+  e <- realize_addl(e)
+  out <- mrgsim(mod, e, end = 2*168)
+  out <- filter(out, time %in% c(72, 73))
+  expect_equal(nrow(out), 3)
+  # Accumulated 100 mg doses x4, then reset, then the 50 mg dose on EVID4
+  expect_equal(out$CENT, c(400, 0, 50))
+  expect_equal(out$evid, c(0, 4, 0)) 
 })
 
 

--- a/inst/maintenance/unit/test-z-alag-f.R
+++ b/inst/maintenance/unit/test-z-alag-f.R
@@ -1,4 +1,4 @@
-# Copyright (C) 2013 - 2023  Metrum Research Group
+# Copyright (C) 2013 - 2026  Metrum Research Group
 #
 # This file is part of mrgsolve.
 #
@@ -55,7 +55,7 @@ test_that("ss=1 and F_CMT=0 issue-497", {
   expect_true(all(out$CENT==0))
 })
 
-test_that("EVID=4 with lag time still resets", {
+test_that("EVID=4 with lag time still resets gh-1396", {
   mod <- param(mod, ALAG1 = 0.25)
   e <- ev_seq(
     ev(amt = 100, ii = 12, addl = 3), 
@@ -65,11 +65,12 @@ test_that("EVID=4 with lag time still resets", {
     ev(amt = 100, ii = 12, addl = 3)
   )
   e <- realize_addl(e)
-  out <- mrgsim(mod, e, end = 2*168)
+  out <- mrgsim(mod, e, end = 2*168, carry_out = "evid")
   out <- filter(out, time %in% c(72, 73))
   expect_equal(nrow(out), 3)
   # Accumulated 100 mg doses x4, then reset, then the 50 mg dose on EVID4
   expect_equal(out$CENT, c(400, 0, 50))
+  # EVID=4 record still carries out ok
   expect_equal(out$evid, c(0, 4, 0)) 
 })
 

--- a/src/datarecord.cpp
+++ b/src/datarecord.cpp
@@ -192,7 +192,7 @@ void datarecord::implement(odeproblem* prob) {
     prob->y(eq_n, Amt);
     break;
   case 4: // dose and reset; reset only if non-ss
-    if(this->ss()==0) {
+    if(this->ss()==0 && !prob->system_at_ss) {
       for(int i=0; i < prob->neq(); ++i) {
         prob->y(i,0.0);
         prob->on(i);
@@ -309,6 +309,7 @@ void datarecord::steady_bolus(odeproblem* prob, LSODA& solver) {
   } 
   prob->lsoda_init();
   prob->ss_flag = false;
+  prob->system_at_ss = true;
 } 
 
 
@@ -464,6 +465,7 @@ void datarecord::steady_infusion(odeproblem* prob, reclist& thisi, LSODA& solver
   std::inplace_merge(thisi.begin(),thisi.begin()+merge_idx,thisi.end(),CompRec());
   prob->lsoda_init();
   prob->ss_flag = false;
+  prob->system_at_ss = true;
 }
 
 void datarecord::steady_zero(odeproblem* prob, LSODA& solver) {
@@ -533,6 +535,7 @@ void datarecord::steady_zero(odeproblem* prob, LSODA& solver) {
   prob->lsoda_init();
   this->unarm();
   prob->ss_flag = false;
+  prob->system_at_ss = true;
 }
 
 void datarecord::schedule(reclist& thisi, double maxtime, 

--- a/src/datarecord.cpp
+++ b/src/datarecord.cpp
@@ -191,7 +191,8 @@ void datarecord::implement(odeproblem* prob) {
   case 8: // replace
     prob->y(eq_n, Amt);
     break;
-  case 4: // dose and reset; reset only if non-ss
+  case 4: 
+    // When EVID=4 and SS=1 we're already at SS and don't reset
     if(this->ss()==0 && !prob->system_at_ss) {
       for(int i=0; i < prob->neq(); ++i) {
         prob->y(i,0.0);
@@ -200,6 +201,7 @@ void datarecord::implement(odeproblem* prob) {
       }
       prob->init_call(Time);
     }
+    // For example, doses at lag times
     if(!Armed) break;
     if(Rate > 0) {
       this->evid(5);

--- a/src/datarecord.cpp
+++ b/src/datarecord.cpp
@@ -192,7 +192,6 @@ void datarecord::implement(odeproblem* prob) {
     prob->y(eq_n, Amt);
     break;
   case 4: // dose and reset; reset only if non-ss
-    if(!Armed) break;
     if(this->ss()==0) {
       for(int i=0; i < prob->neq(); ++i) {
         prob->y(i,0.0);
@@ -201,6 +200,7 @@ void datarecord::implement(odeproblem* prob) {
       }
       prob->init_call(Time);
     }
+    if(!Armed) break;
     if(Rate > 0) {
       this->evid(5);
     } else {

--- a/src/devtran.cpp
+++ b/src/devtran.cpp
@@ -532,8 +532,8 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
       
       // Some non-observation event happening
       // Note that F needs to get updated at every dose including addl
-      // but rate is fixed to the parent rate and we only verify infusions 
-      // on actual dose records in the data set. 
+      // but rate is fixed to the parent rate and we only verify infusions
+      // on actual dose records in the data set.
       if(this_rec->is_event()) {
 
         this_cmtn = this_rec->cmtn();
@@ -586,6 +586,8 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
             if(this_rec->ss() > 0) {
               this_rec->steady(&prob, a[i], solver);
               tfrom = tto;
+              // EVID=4 and SS > 1 acts like EVID=1
+              if(this_rec->evid() == 4) this_rec->evid(1);
             }
             // We already advanced to ss
             // Lagged dose and all subsequent should be vanilla EVID=1 doses

--- a/src/devtran.cpp
+++ b/src/devtran.cpp
@@ -454,7 +454,7 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
         Rcpp::checkUserInterrupt();
         ic = prob.interrupt;
       }
-    
+
       rec_ptr this_rec = a[i][j];
       
       this_rec->id(id);
@@ -464,6 +464,9 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
       if(icrow==NNI || crow==NN || tto > maxtime) {
         continue;
       }
+
+      // steady() has not been called yet on this record
+      prob.system_at_ss = false;
       
       // Only update row counters on output records
       if(this_rec->output()) {
@@ -586,10 +589,8 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
             if(this_rec->ss() > 0) {
               this_rec->steady(&prob, a[i], solver);
               tfrom = tto;
-              // EVID=4 and SS > 1 acts like EVID=1
-              if(this_rec->evid() == 4) this_rec->evid(1);
             }
-            // We already advanced to ss
+            // We already advanced to ss; prob has the system_at_ss flag set
             // Lagged dose and all subsequent should be vanilla EVID=1 doses
             this_rec->ss(0);
             rec_ptr newev = NEWREC(*this_rec);

--- a/src/devtran.cpp
+++ b/src/devtran.cpp
@@ -532,8 +532,8 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
       
       // Some non-observation event happening
       // Note that F needs to get updated at every dose including addl
-      // but rate is fixed to the parent rate and we only verify infusions
-      // on actual dose records in the data set.
+      // but rate is fixed to the parent rate and we only verify infusions 
+      // on actual dose records in the data set. 
       if(this_rec->is_event()) {
 
         this_cmtn = this_rec->cmtn();

--- a/src/odeproblem.cpp
+++ b/src/odeproblem.cpp
@@ -88,6 +88,7 @@ odeproblem::odeproblem(Rcpp::List param,
   ss_fixed = false;
   ss_n = 500;
   ss_flag = false;
+  system_at_ss = false;
   ssRtol = 0;
   ssAtol = 0;
   interrupt = -1;


### PR DESCRIPTION
There was a logic issue when processing EVID==4 records when the record was already "unarmed".  The flawed logic was introduced when trying to match what NONMEM does on EVID=4 with a lag time.  #1262

I saw a bug in production code where the system was not correctly reset prior to reset/dose when there was a lag time. The logic in #1262 did not properly deal with the situation where the dose had a lag time.

This PR adds a flag to `odeproblem` called `system_at_ss`; whenever we advance the system to steady state, we set this flag to `true`. Then, when processing an `EVID=4` record, we decline to reset the system of we find we're already at ss.  With this check in place, the EVID=4 logic works. 




See #1396 for before / after fix. 