### PR TITLE
Adjust parameter update for doses under locf

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -59,3 +59,4 @@ vignettes/extra/mrgsolve-builds/
 ^build$
 ^\.claude$
 ^CLAUDE\.md$
+^\.positai$

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,8 +19,16 @@ jobs:
         config:
           - os: ubuntu-22.04
             r: 4.1.3
+            # distributional 0.8.0 requires R 4.3 through its use of
+            # chooseOpsMethod.
+            distributional_pkg: 'url::https://mpn.metworx.com/snapshots/stable/2026-05-27/src/contrib/distributional_0.7.0.tar.gz'
+            pinned: true
           - os: ubuntu-22.04
             r: 4.2.3
+            # distributional 0.8.0 requires R 4.3 through its use of
+            # chooseOpsMethod.
+            distributional_pkg: 'url::https://mpn.metworx.com/snapshots/stable/2026-05-27/src/contrib/distributional_0.7.0.tar.gz'
+            pinned: true
           - os: ubuntu-22.04
             r: 4.3.1
           - os: ubuntu-latest
@@ -35,8 +43,10 @@ jobs:
           use-public-rspm: true
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck
-          upgrade: 'TRUE'
+          extra-packages: |
+            any::rcmdcheck
+            ${{ matrix.config.distributional_pkg }}
+          upgrade: ${{ matrix.config.pinned && 'FALSE' || 'TRUE' }}
       - name: Install pdflatex
         shell: bash
         run: sudo apt-get install texlive-latex-base texlive-fonts-extra tidy

--- a/inst/include/dataobject.h
+++ b/inst/include/dataobject.h
@@ -59,7 +59,7 @@ public:
   double get_uid(int i) const {return Uid.at(i);}
   uidtype return_uid()  {return Uid;}
   void copy_parameters(int this_row,odeproblem *prob);
-  void copy_parameters_nocb(int id_n, bool from_data, int this_row, odeproblem *prob);
+  void copy_parameters_nocb(int id_n, const rec_ptr& this_rec, odeproblem *prob);
   void next_id(int id_n);
   void copy_inits(int this_row,odeproblem *prob);
   void reload_parameters(const Rcpp::NumericVector& param, odeproblem *prob);

--- a/inst/include/dataobject.h
+++ b/inst/include/dataobject.h
@@ -59,7 +59,7 @@ public:
   double get_uid(int i) const {return Uid.at(i);}
   uidtype return_uid()  {return Uid;}
   void copy_parameters(int this_row,odeproblem *prob);
-  void copy_next_parameters(int id_n, bool from_data, int this_row, odeproblem *prob);
+  void copy_parameters_nocb(int id_n, bool from_data, int this_row, odeproblem *prob);
   void next_id(int id_n);
   void copy_inits(int this_row,odeproblem *prob);
   void reload_parameters(const Rcpp::NumericVector& param, odeproblem *prob);

--- a/inst/maintenance/unit/test-nocb.R
+++ b/inst/maintenance/unit/test-nocb.R
@@ -151,3 +151,65 @@ $CAPTURE DV, CL, COV2 = COV
 })
 
 
+nocb_doses <- '
+$PARAM CL = 1, V = 20, KA = 1.2, FLAG = 0
+$PKMODEL advan = 2
+$PK
+F_A1 = 1; 
+if(FLAG==1) F_A1 = 0.5;
+capture FF = F_A1;
+$CAPTURE FLAG
+'
+mod <- mcode("nocb-doses", nocb_doses)
+ 
+test_that("Covariate effects on bioavailability come on the dose record", {
+ 
+  data <- data.frame(
+    ID = 1,
+    TIME = c(0,24,48,72), 
+    EVID = 1, 
+    AMT = 1000, 
+    FLAG = c(0, 1, 1, 0), 
+    CMT = 1
+  )
+  
+  mod <- update(mod, end = 168)
+  
+  out1 <- mrgsim(mod, data, carry_out = "evid")
+  out2 <- mrgsim(mod, data, carry_out = "evid", nocb = FALSE)  
+  out1 <- filter_sims(out1, evid==1)
+  out2 <- filter_sims(out2, evid==1)
+  expect_identical(as.data.frame(out1), as.data.frame(out2))
+
+  out3 <- mrgsim(mod, data, carry_out = "evid", recsort = 3)
+  out4 <- mrgsim(mod, data, carry_out = "evid", recsort = 3, nocb = FALSE)  
+  out3f <- filter_sims(out3, evid==1)
+  out4f <- filter_sims(out4, evid==1)
+  expect_identical(as.data.frame(out3f), as.data.frame(out4f))
+  expect_identical(out3$A2, out4$A2)
+  
+})
+
+test_that("Verify nocb / locf covariate advance", {
+ 
+  data <- data.frame(
+    ID = 1,
+    TIME = c(0,24,48,72), 
+    EVID = 1, 
+    AMT = 1000, 
+    FLAG = c(0, 1, 1, 0), 
+    CMT = 1
+  )
+  
+  mod <- update(mod, end = 168)
+  out1 <- mrgsim(mod, data, carry_out = "evid,DFLAG = FLAG")
+  out2 <- mrgsim(mod, data, carry_out = "evid,DFLAG = FLAG", nocb = FALSE) 
+  
+  ## Covariate nocb
+  expect_equal(out1$FF[c(1,2,3,4)], c(1, 1, 0.5, 0.5))
+  expect_identical(out1$FLAG, out1$FLAG)
+  
+  ## Covariate locf
+  expect_equal(out2$FF[c(1,2,3,4)], c(1, 1, 1,1))
+  expect_identical(out2$FLAG, out2$DFLAG)
+})

--- a/inst/maintenance/unit/test-nocb.R
+++ b/inst/maintenance/unit/test-nocb.R
@@ -152,8 +152,8 @@ $CAPTURE DV, CL, COV2 = COV
 
 
 nocb_doses <- '
-$PARAM CL = 1, V = 20, KA = 1.2, FLAG = 0
-$PKMODEL advan = 2
+$PARAM CL = 5, V = 20, FLAG = 0
+$PKMODEL advan = 1
 $PK
 F_A1 = 1; 
 if(FLAG==1) F_A1 = 0.5;
@@ -166,27 +166,39 @@ test_that("Covariate effects on bioavailability come on the dose record", {
  
   data <- data.frame(
     ID = 1,
-    TIME = c(0,24,48,72), 
+    TIME = c(0,100,200,300), 
     EVID = 1, 
     AMT = 1000, 
-    FLAG = c(0, 1, 1, 0), 
+    FLAG = c(1, 0, 0, 1), 
     CMT = 1
   )
   
-  mod <- update(mod, end = 168)
+  mod <- update(mod, end = 500, delta = 0.1)
   
   out1 <- mrgsim(mod, data, carry_out = "evid")
   out2 <- mrgsim(mod, data, carry_out = "evid", nocb = FALSE)  
   out1 <- filter_sims(out1, evid==1)
   out2 <- filter_sims(out2, evid==1)
   expect_identical(as.data.frame(out1), as.data.frame(out2))
-
+  
+  # Bioavailability obeys dose record parameter value - nocb
+  expect_equal(out1$A1[1],  500, tolerance = 2)
+  expect_equal(out1$A1[2], 1000, tolerance = 2)
+  expect_equal(out1$A1[3], 1000, tolerance = 2)
+  expect_equal(out1$A1[4],  500, tolerance = 2)
+  
+  # Bioavailability obeys dose record parameter value - locf
+  expect_equal(out2$A1[1],  500, tolerance = 2)
+  expect_equal(out2$A1[2], 1000, tolerance = 2)
+  expect_equal(out2$A1[3], 1000, tolerance = 2)
+  expect_equal(out2$A1[4],  500, tolerance = 2)
+  
   out3 <- mrgsim(mod, data, carry_out = "evid", recsort = 3)
   out4 <- mrgsim(mod, data, carry_out = "evid", recsort = 3, nocb = FALSE)  
   out3f <- filter_sims(out3, evid==1)
   out4f <- filter_sims(out4, evid==1)
   expect_identical(as.data.frame(out3f), as.data.frame(out4f))
-  expect_identical(out3$A2, out4$A2)
+  expect_identical(out3$A1, out4$A1)
   
 })
 

--- a/inst/maintenance/unit/test-nocb.R
+++ b/inst/maintenance/unit/test-nocb.R
@@ -256,13 +256,18 @@ test_that("Verify nocb / locf covariate advance", {
   out130b <- dplyr::filter(out130, TIME != 1)
   expect_identical(out110b, out130b)
   
-  out210 <- dplyr::slice(out21, 1, .by = TIME)
-  out230 <- dplyr::slice(out23, 1, .by = TIME)
+  # The actual simulation results are identical; we are only looking at 
+  # the bookkeeping in the output here
+  out210 <- dplyr::slice(out21, dplyr::n(), .by = TIME)
+  out230 <- dplyr::slice(out23, dplyr::n(), .by = TIME)
   expect_identical(out210$CL, out230$CL)
   
   out210b <- dplyr::filter(out210, TIME != 1)
   out230b <- dplyr::filter(out230, TIME != 1)
   expect_identical(out210b, out230b)
-
+  
+  # Recsort 1 and 3 should be different here  
+  expect_equal(out11$A1[16], out13$A1[16], tolerance = 1e-4)
+  expect_equal(out21$A1[16], out23$A1[16], tolerance = 1e-4)
 })
 

--- a/inst/maintenance/unit/test-nocb.R
+++ b/inst/maintenance/unit/test-nocb.R
@@ -219,7 +219,7 @@ test_that("Verify nocb / locf covariate advance", {
   
   ## Covariate nocb
   expect_equal(out1$FF[c(1,2,3,4)], c(1, 1, 0.5, 0.5))
-  expect_identical(out1$FLAG, out1$FLAG)
+  expect_identical(out1$FLAG, out1$DFLAG)
   
   ## Covariate locf
   expect_equal(out2$FF[c(1,2,3,4)], c(1, 1, 1,1))

--- a/inst/maintenance/unit/test-nocb.R
+++ b/inst/maintenance/unit/test-nocb.R
@@ -152,13 +152,15 @@ $CAPTURE DV, CL, COV2 = COV
 
 
 nocb_doses <- '
-$PARAM CL = 5, V = 20, FLAG = 0
+$PARAM TVCL = 5, V = 20, FLAG = 0, COV = 0
 $PKMODEL advan = 1
 $PK
 F_A1 = 1; 
 if(FLAG==1) F_A1 = 0.5;
+double CL = TVCL;
+if(COV==1) CL = TVCL / 10;
 capture FF = F_A1;
-$CAPTURE FLAG
+$CAPTURE FLAG CL
 '
 mod <- mcode("nocb-doses", nocb_doses)
  
@@ -203,7 +205,7 @@ test_that("Covariate effects on bioavailability come on the dose record", {
 })
 
 test_that("Verify nocb / locf covariate advance", {
- 
+
   data <- data.frame(
     ID = 1,
     TIME = c(0,24,48,72), 
@@ -224,4 +226,43 @@ test_that("Verify nocb / locf covariate advance", {
   ## Covariate locf
   expect_equal(out2$FF[c(1,2,3,4)], c(1, 1, 1,1))
   expect_identical(out2$FLAG, out2$DFLAG)
+  
+  ## Recsort 1 or 3 changes the full output; this is expected
+  # But identical result (save the dose record amount) if you grab the 
+  # equivalent rows
+  data <- data.frame(
+    ID = 1, 
+    TIME = c(0, 1, 5, 10), 
+    EVID = c(2, 1, 2, 2), 
+    AMT = c(0, 1000, 0, 0), 
+    COV = c(0, 0, 1, 0),
+    CMT = 1
+  )
+
+  out11 <- mrgsim(mod, data, end = 11, delta = 1, recsort = 1)
+  out21 <- mrgsim(mod, data, end = 11, delta = 1, nocb = FALSE, recsort = 1)  
+  
+  out13 <- mrgsim(mod, data, end = 11, delta = 1, recsort = 3)
+  out23 <- mrgsim(mod, data, end = 11, delta = 1, nocb = FALSE, recsort = 3)
+  
+  expect_false(identical(out11$CL, out13$CL))
+  expect_false(identical(out21$CL, out23$CL))
+  
+  out110 <- dplyr::slice(out11, 1, .by = TIME)
+  out130 <- dplyr::slice(out13, 1, .by = TIME)
+  expect_identical(out110$CL, out130$CL)
+  
+  out110b <- dplyr::filter(out110, TIME != 1)
+  out130b <- dplyr::filter(out130, TIME != 1)
+  expect_identical(out110b, out130b)
+  
+  out210 <- dplyr::slice(out21, 1, .by = TIME)
+  out230 <- dplyr::slice(out23, 1, .by = TIME)
+  expect_identical(out210$CL, out230$CL)
+  
+  out210b <- dplyr::filter(out210, TIME != 1)
+  out230b <- dplyr::filter(out230, TIME != 1)
+  expect_identical(out210b, out230b)
+
 })
+

--- a/src/dataobject.cpp
+++ b/src/dataobject.cpp
@@ -213,6 +213,7 @@ void dataobject::next_id(int id_n) {
 void dataobject::copy_next_parameters(int id_n, bool from_data, int this_row, 
                                       odeproblem* prob) {
   if(done_copying) return;
+  if(!from_data) return;
   if(from_data) {
     copy_parameters(this_row, prob);
     if(this_row >= Endrow.at(id_n)) {

--- a/src/dataobject.cpp
+++ b/src/dataobject.cpp
@@ -210,20 +210,29 @@ void dataobject::next_id(int id_n) {
   next_copy_row = Startrow.at(id_n);
 }
 
-void dataobject::copy_next_parameters(int id_n, bool from_data, int this_row, 
+void dataobject::copy_next_parameters(int id_n, bool from_data, 
+                                      int this_row, 
                                       odeproblem* prob) {
-  if(done_copying) return;
-  if(!from_data) return;
+  if(done_copying) {
+    return;
+  }
+  
+  // Copy from the data record we are advancing too
   if(from_data) {
     copy_parameters(this_row, prob);
-    if(this_row >= Endrow.at(id_n)) {
+    if(this_row == Endrow[id_n]) {
       done_copying = true;  
       return;
     }
+    // In case of sparse input data, mark the row to pull parameters from 
+    // when we advance to the next data record, potentially hitting inserted
+    // records in between
     next_copy_row = ++this_row;
     return;
   }
-  if((next_copy_row != last_copy_row) && (next_copy_row <= Endrow.at(id_n))) {
+  // Moving off of a data record; copy from the next available row
+  // For nocb only
+  if((next_copy_row != last_copy_row) && (next_copy_row <= Endrow[id_n])) {
     copy_parameters(next_copy_row, prob); 
     last_copy_row = next_copy_row;
   }

--- a/src/dataobject.cpp
+++ b/src/dataobject.cpp
@@ -210,7 +210,7 @@ void dataobject::next_id(int id_n) {
   next_copy_row = Startrow.at(id_n);
 }
 
-void dataobject::copy_next_parameters(int id_n, bool from_data, 
+void dataobject::copy_parameters_nocb(int id_n, bool from_data, 
                                       int this_row, 
                                       odeproblem* prob) {
   if(done_copying) {

--- a/src/dataobject.cpp
+++ b/src/dataobject.cpp
@@ -207,24 +207,41 @@ void dataobject::copy_parameters(int this_row, odeproblem* prob) {
 void dataobject::next_id(int id_n) {
   done_copying = false;
   last_copy_row = -1;
-  next_copy_row = Startrow.at(id_n);
+  next_copy_row = Startrow[id_n];
 }
 
-void dataobject::copy_parameters_nocb(int id_n, bool from_data, 
-                                      int this_row, 
+/** 
+  Copies parameters from the data set under nocb
+  
+  @param id_n The current ID number (zero to nid-1)
+  @param from_data Is the record actually in the data or not
+  @param this_row The data set record position (rec->pos())
+  @param odeproblem The problem object
+
+  @details
+  - done_copying, next_copy_row, and last_copy_row are initialized for each id
+  - If the record is from the data set, we copy the parameters from that row, 
+    then do some bookkeeping to figure out if we are done copying or to get the 
+    number of the next row to copy when we're advancing away from a data set
+    record and toward a non-dataset record
+  - The `next_copy_row` comparison against `last_copy_row` make sure that when
+    we're processing the first inserted record after a data set record, we copy 
+    the next data set row just once; this is nocb behavior    
+**/
+void dataobject::copy_parameters_nocb(int id_n, const rec_ptr& this_rec,
                                       odeproblem* prob) {
   if(done_copying) {
     return;
   }
-  
   // Copy from the data record we are advancing too
-  if(from_data) {
+  if(this_rec->from_data()) {
+    int this_row = this_rec->pos();
     copy_parameters(this_row, prob);
     if(this_row == Endrow[id_n]) {
-      done_copying = true;  
+      done_copying = true;
       return;
     }
-    // In case of sparse input data, mark the row to pull parameters from 
+    // In case of sparse input data, mark the row to pull parameters from
     // when we advance to the next data record, potentially hitting inserted
     // records in between
     next_copy_row = ++this_row;
@@ -233,7 +250,7 @@ void dataobject::copy_parameters_nocb(int id_n, bool from_data,
   // Moving off of a data record; copy from the next available row
   // For nocb only
   if((next_copy_row != last_copy_row) && (next_copy_row <= Endrow[id_n])) {
-    copy_parameters(next_copy_row, prob); 
+    copy_parameters(next_copy_row, prob);
     last_copy_row = next_copy_row;
   }
 }

--- a/src/devtran.cpp
+++ b/src/devtran.cpp
@@ -508,12 +508,7 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
       // nocb we copy tto parameters just prior to $PK
       if(dat.any_copy && (nocb)) {
         // will call lsoda_init if parameters are copied
-        dat.copy_parameters_nocb(
-          i, 
-          this_rec->from_data(), 
-          this_rec->pos(), 
-          &prob
-        );
+        dat.copy_parameters_nocb(i, this_rec, &prob);
       }
       
       if(j != 0) {

--- a/src/devtran.cpp
+++ b/src/devtran.cpp
@@ -509,7 +509,7 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
       }
       
       // nocb we copy tto parameters just prior to $PK
-      if(dat.any_copy && (nocb)) {
+      if(dat.any_copy && nocb) {
         // will call lsoda_init if parameters are copied
         dat.copy_parameters_nocb(i, this_rec, &prob);
       }

--- a/src/devtran.cpp
+++ b/src/devtran.cpp
@@ -275,7 +275,7 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
       std::inplace_merge(it->begin(), it->begin() + merge_idx, it->end(), CompRec());
     }
   }
-
+  
   // Create results matrix:
   //  rows: ntime*nset
   //  cols: rep, time, eq[0], eq[1], ..., yout[0], yout[1],...
@@ -435,14 +435,8 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
       idat.copy_inits(this_idata_row,&prob);
     }
     
-    if(dat.any_copy) {
-      if(a[i][0]->from_data()) {
-        dat.copy_parameters(a[i][0]->pos(),&prob);
-      } else {
-        if(filbak) {
-          dat.copy_parameters(dat.start(i),&prob);
-        }
-      }
+    if(dat.any_copy && filbak) {
+      dat.copy_parameters(dat.start(i), &prob);  
     }
     
     prob.set_d(a[i][0]);
@@ -454,7 +448,7 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
         Rcpp::checkUserInterrupt();
         ic = prob.interrupt;
       }
-    
+      
       rec_ptr this_rec = a[i][j];
       
       this_rec->id(id);
@@ -467,8 +461,8 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
       
       // Only update row counters on output records
       if(this_rec->output()) {
-         prob.irown(icrow);
-         prob.rown(crow);
+        prob.irown(icrow);
+        prob.rown(crow);
       }
       
       if(prob.systemoff()) {
@@ -501,16 +495,6 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
         continue;
       }
       
-      if(dat.any_copy && nocb) {
-        // will call lsoda_init if parameters are copied
-        dat.copy_next_parameters(
-          i, 
-          this_rec->from_data(), 
-          this_rec->pos(), 
-          &prob
-        );
-      }
-
       double dt  = (tto-tfrom)/(tfrom == 0.0 ? 1.0 : tfrom);
       
       if((dt > 0.0) && (dt < mindt)) {
@@ -519,6 +503,17 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
       
       for(int k = 0; k < neps; ++k) {
         prob.eps(k,eps(crow,k));
+      }
+      
+      // nocb we copy tto parameters just prior to $PK
+      if(dat.any_copy && (nocb)) {
+        // will call lsoda_init if parameters are copied
+        dat.copy_next_parameters(
+          i, 
+          this_rec->from_data(), 
+          this_rec->pos(), 
+          &prob
+        );
       }
       
       if(j != 0) {
@@ -535,7 +530,7 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
       // but rate is fixed to the parent rate and we only verify infusions 
       // on actual dose records in the data set. 
       if(this_rec->is_event()) {
-
+        
         this_cmtn = this_rec->cmtn();
         
         if(!this_rec->is_lagged()) {
@@ -559,7 +554,7 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
         if(this_rec->rate() < 0) {
           prob.check_data_rate(this_rec, this_cmtn);  
         }
-
+        
         // Only check data set records
         if(this_rec->from_data()) {
           // Validate modeled rates
@@ -575,12 +570,12 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
         if(this_rec->rate() < 0) {
           prob.rate_main(this_rec, this_cmtn);
         }
-
+        
         bool sort_recs = false;
-
+        
         // Checking
         if(!this_rec->is_lagged()) {
-
+          
           // there is a valid lag time
           if(prob.alag(this_cmtn) > mindt && this_rec->is_dose()) {
             if(this_rec->ss() > 0) {
@@ -629,7 +624,7 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
             }
           }
         } // from data
-
+        
         // This block gets hit for any and all infusions; sometimes the
         // infusion just got started and we need to add the lag time
         // sometimes it is an infusion via addl and lag time is already there
@@ -641,7 +636,7 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
                                  this_rec->rate(),
                                  -299,
                                  id);
-
+          
           if(this_rec->from_data()) {
             evoff->time(evoff->time() + prob.alag(this_cmtn));
           }
@@ -658,16 +653,20 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
       
       prob.advance(tfrom,tto,solver);
       
-      if(this_rec->evid() != 2) {
-        this_rec->steady(&prob,a[i],solver);
-        this_rec->implement(&prob);
-      }
-      
       if(!nocb && dat.any_copy) {
         if(this_rec->from_data()) {
           // will call lsoda_init
-          dat.copy_parameters(this_rec->pos(),&prob);
+          dat.copy_parameters(this_rec->pos(), &prob);
+          if(this_rec->is_dose() && !this_rec->is_lagged()) {
+            prob.init_call_record(tto);
+            this_rec->fn(prob.fbio(this_rec->cmtn()));
+          }
         }
+      }
+      
+      if(this_rec->evid() != 2) {
+        this_rec->steady(&prob,a[i],solver);
+        this_rec->implement(&prob);
       }
       
       if(!this_rec->is_lagged()) {

--- a/src/devtran.cpp
+++ b/src/devtran.cpp
@@ -655,7 +655,7 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
         if(this_rec->from_data()) {
           // will call lsoda_init
           dat.copy_parameters(this_rec->pos(), &prob);
-          if(this_rec->is_dose() && !this_rec->is_lagged()) {
+          if(!this_rec->is_lagged()) {
             prob.init_call_record(tto);
             this_rec->fn(prob.fbio(this_rec->cmtn()));
           }

--- a/src/devtran.cpp
+++ b/src/devtran.cpp
@@ -508,7 +508,7 @@ Rcpp::List DEVTRAN(const Rcpp::List parin,
       // nocb we copy tto parameters just prior to $PK
       if(dat.any_copy && (nocb)) {
         // will call lsoda_init if parameters are copied
-        dat.copy_next_parameters(
+        dat.copy_parameters_nocb(
           i, 
           this_rec->from_data(), 
           this_rec->pos(), 


### PR DESCRIPTION
There was a user report where bioavailability was derived from a data set item wasn't behaving as expected. Because bioav comes from the data, it means that the results will be sensitive to `nocb` / `locf` behavior. 

https://github.com/metrumresearchgroup/mrgsolve/issues/1395

I did a simulation against nonmem and found that the `nocb` case was correctly handled. The principle was that the value of the parameter on the data set row for the dose record is what determines F in this case. 

There is a demonstration here: https://github.com/mrgsolve/nmtests/blob/master/nocb/1001.md


It's not obvious if it should be different or the same when you simulate with `locf`.  As a simple solution, I implemented a change where we follow the same behavior for `locf` (it's the value of the parameter on the dosing record that determines F). To do this, we have to call `$MAIN` again, after the `locf`-targeted parameter update. 

This PR also changes the name of `copy_next_parameters()` to `copy_parameters_nocb()` to better reflect the fact that this handles the `nocb` case only.

